### PR TITLE
riscv_program_gah takes program as first arg

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1171,7 +1171,7 @@ static int examine(struct target *target)
 		LOG_DEBUG("hart %d has XLEN=%d", i, r->xlen[i]);
 		LOG_DEBUG("found program buffer at 0x%08lx", (long)(r->debug_buffer_addr[i]));
 
-		if (riscv_program_gah(r->debug_buffer_addr[i])) {
+		if (riscv_program_gah(0, r->debug_buffer_addr[i])) {
                 	LOG_ERROR("This implementation will not work with hart %d with debug_buffer_addr of 0x%x\n", i, 
                             r->debug_buffer_addr[i]);
 			abort();


### PR DESCRIPTION
Not sure why this even compiled..?

`riscv_program_gah` needs two arguments. It doesn't use the first one, so this just passes Null.