### PR TITLE
riscv-v11: Don't perform unexpected operation in cache_write

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -872,7 +872,7 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 
 	if (last == info->dramsize) {
 		// Nothing needs to be written to RAM.
-		dbus_write(target, DMCONTROL, DMCONTROL_HALTNOT | DMCONTROL_INTERRUPT);
+	        dbus_write(target, DMCONTROL, DMCONTROL_HALTNOT | (run ? DMCONTROL_INTERRUPT : 0));
 
 	} else {
 		for (unsigned int i = 0; i < info->dramsize; i++) {


### PR DESCRIPTION
This is meant to address #51. Only actually set interrupt if 'run' was intended.

I have tested on a HiFive1 and the fix works as expected (I was able to duplicate the double-interrupt behavior before and now it doesn't do it, but I haven't tested that it still works to e.g. program the board).