### PR TITLE
Fix the multi-GDB mode bugs

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1143,6 +1143,9 @@ static int examine(struct target *target)
 	/* Find the address of the program buffer, which must be done without
 	 * knowing anything about the target. */
 	for (int i = 0; i < riscv_count_harts(target); ++i) {
+		if (!riscv_hart_enabled(target, i))
+			continue;
+
 		riscv_set_current_hartid(target, i);
 
 		/* Without knowing anything else we can at least mess with the
@@ -1213,6 +1216,9 @@ static int examine(struct target *target)
 
 	/* Then we check the number of triggers availiable to each hart. */
 	for (int i = 0; i < riscv_count_harts(target); ++i) {
+		if (!riscv_hart_enabled(target, i))
+			continue;
+
 		for (uint32_t t = 0; t < RISCV_MAX_TRIGGERS; ++t) {
 			riscv_set_current_hartid(target, i);
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1334,9 +1334,6 @@ static int read_memory(struct target *target, target_addr_t address,
 			size, address);
 
 	select_dmi(target);
-	/* There was a bug in the memory system and only accesses from hart 0 actually
-	 * worked correctly.  This should be obselete now. -palmer */
-	riscv_set_current_hartid(target, 0);
 
 	/* This program uses two temporary registers.  A word of data and the
 	 * associated address are stored at some location in memory.  The
@@ -1532,9 +1529,6 @@ static int write_memory(struct target *target, target_addr_t address,
 	LOG_DEBUG("writing %d words of %d bytes to 0x%08lx", count, size, (long)address);
 
 	select_dmi(target);
-	/* There was a bug in the memory system and only accesses from hart 0 actually
-	 * worked correctly.  This should be obselete now. -palmer */
-	riscv_set_current_hartid(target, 0);
 
 	/* This program uses two temporary registers.  A word of data and the
 	 * associated address are stored at some location in memory.  The

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -832,7 +832,7 @@ static int add_trigger(struct target *target, struct trigger *trigger)
 
 		uint64_t tdata1_rb;
 		for (int hartid = 0; hartid < riscv_count_harts(target); ++hartid) {
-			if (!riscv_hart_enabled(target, i))
+			if (!riscv_hart_enabled(target, hartid))
 				continue;
 
 			riscv_set_current_hartid(target, hartid);
@@ -921,7 +921,7 @@ static int remove_trigger(struct target *target, struct trigger *trigger)
 	}
 	LOG_DEBUG("Stop using resource %d for bp %d", i, trigger->unique_id);
 	for (int hartid = 0; hartid < riscv_count_harts(target); ++hartid) {
-		if (!riscv_hart_enabled(target, i))
+		if (!riscv_hart_enabled(target, hartid))
 			continue;
 
 		riscv_set_current_hartid(target, hartid);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -832,6 +832,9 @@ static int add_trigger(struct target *target, struct trigger *trigger)
 
 		uint64_t tdata1_rb;
 		for (int hartid = 0; hartid < riscv_count_harts(target); ++hartid) {
+			if (!riscv_hart_enabled(target, i))
+				continue;
+
 			riscv_set_current_hartid(target, hartid);
 
 			if (hartid > 0) {
@@ -918,6 +921,9 @@ static int remove_trigger(struct target *target, struct trigger *trigger)
 	}
 	LOG_DEBUG("Stop using resource %d for bp %d", i, trigger->unique_id);
 	for (int hartid = 0; hartid < riscv_count_harts(target); ++hartid) {
+		if (!riscv_hart_enabled(target, i))
+			continue;
+
 		riscv_set_current_hartid(target, hartid);
 		register_write_direct(target, GDB_REGNO_TSELECT, i);
 		register_write_direct(target, GDB_REGNO_TDATA1, 0);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -706,7 +706,7 @@ static int init_target(struct command_context *cmd_ctx,
 	LOG_DEBUG("init");
 	riscv_info_t *generic_info = (riscv_info_t *) target->arch_info;
 
-	riscv_info_init(generic_info);
+	riscv_info_init(target, generic_info);
 	generic_info->get_register = &riscv013_get_register;
 	generic_info->set_register = &riscv013_set_register;
 	generic_info->select_current_hart = &riscv013_select_current_hart;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -448,11 +448,12 @@ static int riscv_get_gdb_reg_list(struct target *target,
 {
 	RISCV_INFO(r);
 	LOG_DEBUG("reg_class=%d", reg_class);
-	LOG_DEBUG("riscv_get_gdb_reg_list: rtos_hartid=%d current_hartid=%d", r->rtos_hartid, r->current_hartid);
-	if (r->rtos_hartid != -1)
+	LOG_DEBUG("rtos_hartid=%d current_hartid=%d", r->rtos_hartid, r->current_hartid);
+
+	if (r->rtos_hartid != -1 && riscv_rtos_enabled(target))
 		riscv_set_current_hartid(target, r->rtos_hartid);
 	else
-		riscv_set_current_hartid(target, 0);
+		riscv_set_current_hartid(target, target->coreid);
 
 	switch (reg_class) {
 		case REG_CLASS_GENERAL:

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -872,11 +872,12 @@ struct target_type riscv_target =
 
 /*** RISC-V Interface ***/
 
-void riscv_info_init(riscv_info_t *r)
+void riscv_info_init(struct target *target, riscv_info_t *r)
 {
 	memset(r, 0, sizeof(*r));
 	r->dtm_version = 1;
 	r->registers_initialized = false;
+	r->current_hartid = target->coreid;
 
 	for (size_t h = 0; h < RISCV_MAX_HARTS; ++h) {
 		r->xlen[h] = -1;
@@ -1068,10 +1069,7 @@ void riscv_invalidate_register_cache(struct target *target)
 int riscv_current_hartid(const struct target *target)
 {
 	RISCV_INFO(r);
-	if (riscv_rtos_enabled(target))
-		return r->current_hartid;
-	else
-		return target->coreid;
+	return r->current_hartid;
 }
 
 void riscv_set_all_rtos_harts(struct target *target)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -134,7 +134,7 @@ int riscv_openocd_deassert_reset(struct target *target);
 /*** RISC-V Interface ***/
 
 /* Initializes the shared RISC-V structure. */
-void riscv_info_init(riscv_info_t *r);
+void riscv_info_init(struct target *target, riscv_info_t *r);
 
 /* Run control, possibly for multiple harts.  The _all_harts versions resume
  * all the enabled harts, which when running in RTOS mode is all the harts on

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -215,4 +215,7 @@ int riscv_dmi_write_u64_bits(struct target *target);
 /* Invalidates the register cache. */
 void riscv_invalidate_register_cache(struct target *target);
 
+/* Returns TRUE when a hart is enabled in this target. */
+bool riscv_hart_enabled(struct target *target, int hartid);
+
 #endif


### PR DESCRIPTION
I just smoke tested this: I can run and halt both harts on my system, but that's all I tested.  I suspect we need to sprinkle riscv_hart_enabled() all over the place (at least in the hardware breakpoint code), but I think we're pretty close.

I haven't tested this at all in RTOS mode.