### PR TITLE
Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # stuff "git status" should ignore
 
 # build output
+build/
 .libs
 .deps
 .dirstamp


### PR DESCRIPTION
the riscv-tools build script make a subdirectory to build in, other submodules ignore this file