### PR TITLE
Dummy travis config, so development isn't blocked.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+
+#addons:
+#    apt:
+#        sources:
+#            - ubuntu-toolchain-r-test
+#        packages:
+#            - automake-1.14
+
+script:
+    - automake --version
+#    - ./bootstrap && ./configure && make


### PR DESCRIPTION
Getting an actual build going isn't as trivial as it should be. This
should allow development to keep going until I've got that figured out.