### PR TITLE
Disable debugger-set triggers on connect

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1239,21 +1239,7 @@ static int examine(struct target *target)
 	}
 
 	/* Then we check the number of triggers availiable to each hart. */
-	for (int i = 0; i < riscv_count_harts(target); ++i) {
-		if (!riscv_hart_enabled(target, i))
-			continue;
-
-		for (uint32_t t = 0; t < RISCV_MAX_TRIGGERS; ++t) {
-			riscv_set_current_hartid(target, i);
-
-			r->trigger_count[i] = t;
-			register_write_direct(target, GDB_REGNO_TSELECT, t);
-			uint64_t tselect = t+1;
-			register_read_direct(target, &tselect, GDB_REGNO_TSELECT);
-			if (tselect != t)
-				break;
-		}
-	}
+	riscv_enumerate_triggers(target);
 
 	/* Resumes all the harts, so the debugger can later pause them. */
 	riscv_resume_all_harts(target);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -57,7 +57,7 @@ typedef struct {
 	int xlen[RISCV_MAX_HARTS];
 
 	/* The number of triggers per hart. */
-	int trigger_count[RISCV_MAX_HARTS];
+	unsigned trigger_count[RISCV_MAX_HARTS];
 
 	/* The address of the debug RAM buffer. */
 	riscv_addr_t debug_buffer_addr[RISCV_MAX_HARTS];
@@ -70,8 +70,9 @@ typedef struct {
 
 	/* Helper functions that target the various RISC-V debug spec
 	 * implementations. */
-	riscv_reg_t (*get_register)(struct target *, int, int);
-	void (*set_register)(struct target *, int, int, uint64_t);
+	riscv_reg_t (*get_register)(struct target *, int hartid, int regid);
+	void (*set_register)(struct target *, int hartid, int regid,
+			uint64_t value);
 	void (*select_current_hart)(struct target *);
 	bool (*is_halted)(struct target *target);
 	void (*halt_current_hart)(struct target *);
@@ -217,5 +218,7 @@ void riscv_invalidate_register_cache(struct target *target);
 
 /* Returns TRUE when a hart is enabled in this target. */
 bool riscv_hart_enabled(struct target *target, int hartid);
+
+int riscv_enumerate_triggers(struct target *target);
 
 #endif


### PR DESCRIPTION
When first connecting to a target, have the debugger disable any
hardware triggers that are set by a previously connected debugger.
The 0.11 code already did this, but 0.13 did not.

To achieve this I decided to share the code to enumerate triggers
between 0.11 and 0.13, which required me to implement get_register() and
set_register() for 0.11, which made the whole change a lot larger than
you might have guessed.

Hopefully this sets us up to in the future share the code to set/remove
triggers as well.