### PR TITLE
Print out which port OpenOCD is listening on.

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -298,6 +298,12 @@ int add_service(char *name,
 			free_service(c);
 			return ERROR_FAIL;
 		}
+
+		struct sockaddr_in addr_in;
+		socklen_t addr_in_size = sizeof(addr_in);
+		getsockname(c->fd, &addr_in, &addr_in_size);
+		LOG_INFO("Listening on port %d for %s connections",
+				ntohs(addr_in.sin_port), name);
 	} else if (c->type == CONNECTION_STDINOUT) {
 		c->fd = fileno(stdin);
 


### PR DESCRIPTION
This is essential when a test environment asks OpenOCD to listen on port
0, so that the environment can easily discover which port is actually
being used.

I added this so the test environment can work even when OpenOCD is run under strace/valgrind.