### PR TITLE
When gdb_port is 0, don't increment it.

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -3113,7 +3113,13 @@ static int gdb_target_add_one(struct target *target)
 		if (!*end) {
 			if (parse_long(gdb_port_next, &portnumber) == ERROR_OK) {
 				free(gdb_port_next);
-				gdb_port_next = alloc_printf("%d", portnumber+1);
+				if (portnumber) {
+					gdb_port_next = alloc_printf("%d", portnumber+1);
+				} else {
+					/* Don't increment if gdb_port is 0, since we're just
+					 * trying to allocate an unused port. */
+					gdb_port_next = alloc_printf("0");
+				}
 			}
 		}
 	}

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -273,7 +273,8 @@ int add_service(char *name,
 		c->sin.sin_port = htons(c->portnumber);
 
 		if (bind(c->fd, (struct sockaddr *)&c->sin, sizeof(c->sin)) == -1) {
-			LOG_ERROR("couldn't bind %s to socket: %s", name, strerror(errno));
+			LOG_ERROR("couldn't bind %s to socket on port %d: %s", name,
+					c->portnumber, strerror(errno));
 			close_socket(c->fd);
 			free_service(c);
 			return ERROR_FAIL;


### PR DESCRIPTION
Usually incrementing to get the next port is a good idea, but when set
to 0 the idea is to find an arbitrary unallocated port. 1 is almost
certainly not helpful.