### PR TITLE
Fix block memory reads on slow targets.

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -44,6 +44,11 @@ bool riscv_batch_full(struct riscv_batch *batch)
 
 void riscv_batch_run(struct riscv_batch *batch)
 {
+	if (batch->used_scans == 0) {
+		LOG_DEBUG("Ignoring empty batch.");
+		return;
+	}
+
 	LOG_DEBUG("running a batch of %ld scans", (long)batch->used_scans);
 	riscv_batch_add_nop(batch);
 


### PR DESCRIPTION
The interesting new code concerns ignore_prev_addr and
this_is_last_read.

Additionally, I tweaked some debug output, and optimized
riscv_batch_run() when the batch is empty.