### PR TITLE
Add some keep_alive()s for use with slow targets.

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -44,6 +44,8 @@ bool riscv_batch_full(struct riscv_batch *batch)
 
 void riscv_batch_run(struct riscv_batch *batch)
 {
+	keep_alive();
+
 	LOG_DEBUG("running a batch of %ld scans", (long)batch->used_scans);
 	riscv_batch_add_nop(batch);
 

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -41,6 +41,8 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 
 int riscv_program_exec(struct riscv_program *p, struct target *t)
 {
+	keep_alive();
+
 	if (riscv_debug_buffer_leave(t, p) != ERROR_OK) {
 		LOG_ERROR("unable to write program buffer exit code");
 		return ERROR_FAIL;


### PR DESCRIPTION
The only real improvement is that now OpenOCD doesn't warn that keep_alive isn't called often enough anymore. Presumably there's some user improvement if you're using gdb interactively.