### PR TITLE
riscv: Add commands for setting timeouts

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1137,6 +1137,71 @@ int riscv_openocd_deassert_reset(struct target *target)
 	return ERROR_OK;
 }
 
+
+/* Command Handlers */
+COMMAND_HANDLER(riscv_set_command_timeout_sec) {
+
+	if (CMD_ARGC != 1) {
+		LOG_ERROR("Command takes exactly 1 parameter");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	int timeout = atoi(CMD_ARGV[0]);
+	if (timeout <= 0){
+		LOG_ERROR("%s is not a valid integer argument for command.", CMD_ARGV[0]);
+		return ERROR_FAIL;
+	}
+
+	riscv_command_timeout_sec = timeout;
+
+	return ERROR_OK;
+}
+
+COMMAND_HANDLER(riscv_set_reset_timeout_sec) {
+
+	if (CMD_ARGC != 1) {
+			LOG_ERROR("Command takes exactly 1 parameter");
+			return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	int timeout = atoi(CMD_ARGV[0]);
+	if (timeout <= 0){
+		LOG_ERROR("%s is not a valid integer argument for command.", CMD_ARGV[0]);
+		return ERROR_FAIL;
+	}
+
+	riscv_reset_timeout_sec = timeout;
+	return ERROR_OK;
+}
+
+
+static const struct command_registration riscv_exec_command_handlers[] = {
+	{
+		.name = "set_command_timeout_sec",
+		.handler = riscv_set_command_timeout_sec,
+		.mode = COMMAND_ANY,
+		.usage = "riscv set_command_timeout_sec [sec]",
+		.help = "Set the wall-clock timeout (in seconds) for individual commands"
+	 },
+	 {
+		.name = "set_reset_timeout_sec",
+		.handler = riscv_set_reset_timeout_sec,
+		.mode = COMMAND_ANY,
+		.usage = "riscv set_reset_timeout_sec [sec]",
+		.help = "Set the wall-clock timeout (in seconds) after reset is deasserted"
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
+const struct command_registration riscv_command_handlers[] = {
+	{
+		.name = "riscv",
+		.mode = COMMAND_ANY,
+		.help = "RISC-V Command Group",
+		.usage = "",
+		.chain = riscv_exec_command_handlers
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
 struct target_type riscv_target =
 {
 	.name = "riscv",
@@ -1173,7 +1238,7 @@ struct target_type riscv_target =
 
 	.run_algorithm = riscv_run_algorithm,
 
-        .commands = riscv_command_handlers
+	.commands = riscv_command_handlers
 };
 
 /*** RISC-V Interface ***/
@@ -1583,7 +1648,6 @@ int riscv_enumerate_triggers(struct target *target)
 			tselect_rb &= ~(1ULL << (riscv_xlen(target)-1));
 			if (tselect_rb != t)
 				break;
-
 			uint64_t tdata1 = riscv_get_register_on_hart(target, hartid,
 					GDB_REGNO_TDATA1);
 			int type = get_field(tdata1, MCONTROL_TYPE(riscv_xlen(target)));
@@ -1608,70 +1672,6 @@ int riscv_enumerate_triggers(struct target *target)
 
 	return ERROR_OK;
 }
-
-/* Command Handlers */
-COMMAND_HANDLER(riscv_set_command_timeout_sec) {
-
-  if (CMD_ARGC != 1) {
-      LOG_ERROR("Command takes exactly 1 parameter");
-      return ERROR_COMMAND_SYNTAX_ERROR;
-  }
-  int timeout = atoi(CMD_ARGV[0]);
-  if (timeout <= 0){
-    LOG_ERROR("%s is not a valid integer argument for command.", CMD_ARGV[0]);
-    return ERROR_FAIL;
-  }
-
-  riscv_command_timeout_sec = timeout;
-
-  return ERROR_OK;
-}
-
-COMMAND_HANDLER(riscv_set_reset_timeout_sec) {
-
-  if (CMD_ARGC != 1) {
-      LOG_ERROR("Command takes exactly 1 parameter");
-      return ERROR_COMMAND_SYNTAX_ERROR;
-  }
-  int timeout = atoi(CMD_ARGV[0]);
-  if (timeout <= 0){
-    LOG_ERROR("%s is not a valid integer argument for command.", CMD_ARGV[0]);
-    return ERROR_FAIL;
-  }
-
-  riscv_reset_timeout_sec = timeout;
-  return ERROR_OK;
-}
-
-
-static const struct command_registration riscv_exec_command_handlers[] = {
- {
-    .name = "set_command_timeout_sec",
-    .handler = riscv_set_command_timeout_sec,
-    .mode = COMMAND_ANY,
-    .usage = "riscv set_command_timeout_sec [sec]",
-    .help = "Set the wall-clock timeout (in seconds) for individual commands"
- },
- {
-    .name = "set_reset_timeout_sec",
-    .handler = riscv_set_reset_timeout_sec,
-    .mode = COMMAND_ANY,
-    .usage = "riscv set_reset_timeout_sec [sec]",
-    .help = "Set the wall-clock timeout (in seconds) after reset is deasserted"
-  },
-  COMMAND_REGISTRATION_DONE
-};
-
-const struct command_registration riscv_command_handlers[] = {
-  {
-    .name = "riscv",
-    .mode = COMMAND_ANY,
-    .help = "RISC-V Command Group",
-    .usage = "",
-    .chain = riscv_exec_command_handlers
-  },
-  COMMAND_REGISTRATION_DONE
-};
 
 const char *gdb_regno_name(enum gdb_regno regno)
 {

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -13,6 +13,9 @@ struct riscv_program;
 #define RISCV_MAX_TRIGGERS 32
 #define RISCV_MAX_HWBPS 16
 
+#define DEFAULT_COMMAND_TIMEOUT_SEC		2
+#define DEFAULT_RESET_TIMEOUT_SEC		30
+
 extern struct target_type riscv011_target;
 extern struct target_type riscv013_target;
 
@@ -102,6 +105,12 @@ typedef struct {
 	void (*fill_dmi_nop_u64)(struct target *target, char *buf);
 	void (*reset_current_hart)(struct target *target);
 } riscv_info_t;
+
+/* Wall-clock timeout for a command/access. Settable via RISC-V Target commands.*/
+extern int riscv_command_timeout_sec;
+
+/* Wall-clock timeout after reset. Settable via RISC-V Target commands.*/
+extern int riscv_reset_timeout_sec;
 
 /* Everything needs the RISC-V specific info structure, so here's a nice macro
  * that provides that. */


### PR DESCRIPTION
Addresses #96.

Rather than using a #define for the timeouts, allow the user to specify them using OpenOCD's "Command Handler" interface. The defaults remain the same as they were with the #defines.

I tried making these target-specific variables, but then they can only be run with mode of COMMAND_EXEC, which can only be run after 'init'. These need to be set before attempting to interact with the target, so I changed it to COMMAND_ANY and moved them out of the target info structure. 

(There are some other whitespace changes because I used emacs 'tabify' to fight with the tab-based indentation, which tabified a few other things)