### PR TITLE
server.c: fix clang warning

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -302,7 +302,7 @@ int add_service(char *name,
 
 		struct sockaddr_in addr_in;
 		socklen_t addr_in_size = sizeof(addr_in);
-		getsockname(c->fd, &addr_in, &addr_in_size);
+		getsockname(c->fd, (struct sockaddr *)&addr_in, &addr_in_size);
 		LOG_INFO("Listening on port %d for %s connections",
 				ntohs(addr_in.sin_port), name);
 	} else if (c->type == CONNECTION_STDINOUT) {


### PR DESCRIPTION
```
/Users/ilg/Work/openocd/openocd.git/src/server/server.c:305:22: error:
incompatible pointer types passing 'struct sockaddr_in *' to
parameter of type 'struct sockaddr *'
[-Werror,-Wincompatible-pointer-types]
getsockname(c->fd, &addr_in, &addr_in_size);
^~~~~~~~
/usr/include/sys/socket.h:687:50: note: passing argument to parameter
here
int     getsockname(int, struct sockaddr * __restrict, socklen_t *
__restrict)
```
