### PR TITLE
memory read is now completely stable even on intermittently slow targets

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -527,14 +527,6 @@ static void increase_ac_busy_delay(struct target *target)
 	LOG_INFO("dtmcontrol_idle=%d, dmi_busy_delay=%d, ac_busy_delay=%d",
 			info->dtmcontrol_idle, info->dmi_busy_delay,
 			info->ac_busy_delay);
-
-	// Wait for busy to go away.
-	uint32_t abstractcs = dmi_read(target, DMI_ABSTRACTCS);
-	while (get_field(abstractcs, DMI_ABSTRACTCS_BUSY)) {
-		abstractcs = dmi_read(target, DMI_ABSTRACTCS);
-	}
-	// Clear the error status.
-	dmi_write(target, DMI_ABSTRACTCS, abstractcs & DMI_ABSTRACTCS_CMDERR);
 }
 
 uint32_t abstract_register_size(unsigned width)
@@ -2087,6 +2079,11 @@ int riscv013_debug_buffer_register(struct target *target, riscv_addr_t addr)
 
 void riscv013_clear_abstract_error(struct target *target)
 {
-	uint32_t acs = dmi_read(target, DMI_ABSTRACTCS);
-	dmi_write(target, DMI_ABSTRACTCS, acs);
+	// Wait for busy to go away.
+	uint32_t abstractcs = dmi_read(target, DMI_ABSTRACTCS);
+	while (get_field(abstractcs, DMI_ABSTRACTCS_BUSY)) {
+		abstractcs = dmi_read(target, DMI_ABSTRACTCS);
+	}
+	// Clear the error status.
+	dmi_write(target, DMI_ABSTRACTCS, abstractcs & DMI_ABSTRACTCS_CMDERR);
 }

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -471,7 +471,7 @@ static uint64_t dmi_read(struct target *target, uint16_t address)
 		} else if (status == DMI_STATUS_SUCCESS) {
 			break;
 		} else {
-			LOG_ERROR("failed read (NOP) at 0x%x, status=%d\n", address, status);
+			LOG_ERROR("failed read (NOP) at 0x%x, status=%d", address, status);
 			break;
 		}
 	}
@@ -500,13 +500,13 @@ static void dmi_write(struct target *target, uint16_t address, uint64_t value)
 		} else if (status == DMI_STATUS_SUCCESS) {
 			break;
 		} else {
-			LOG_ERROR("failed write to 0x%x, status=%d\n", address, status);
+			LOG_ERROR("failed write to 0x%x, status=%d", address, status);
 			break;
 		}
 	}
 
 	if (status != DMI_STATUS_SUCCESS) {
-		LOG_ERROR("Failed write to 0x%x;, status=%d\n",
+		LOG_ERROR("Failed write to 0x%x;, status=%d",
 				address, status);
 		abort();
 	}
@@ -521,12 +521,12 @@ static void dmi_write(struct target *target, uint16_t address, uint64_t value)
 		} else if (status == DMI_STATUS_SUCCESS) {
 			break;
 		} else {
-			LOG_ERROR("failed write (NOP) at 0x%x, status=%d\n", address, status);
+			LOG_ERROR("failed write (NOP) at 0x%x, status=%d", address, status);
 			break;
 		}
 	}
 	if (status != DMI_STATUS_SUCCESS) {
-		LOG_ERROR("failed to write (NOP) 0x%" PRIx64 " to 0x%x; status=%d\n", value, address, status);
+		LOG_ERROR("failed to write (NOP) 0x%" PRIx64 " to 0x%x; status=%d", value, address, status);
 		abort();
 	}
 }
@@ -1146,7 +1146,7 @@ static int examine(struct target *target)
 				r->xlen[i], r->debug_buffer_addr[i]);
 
 		if (riscv_program_gah(&program64, r->debug_buffer_addr[i])) {
-			LOG_ERROR("This implementation will not work with hart %d with debug_buffer_addr of 0x%lx\n", i,
+			LOG_ERROR("This implementation will not work with hart %d with debug_buffer_addr of 0x%lx", i,
 					(long)r->debug_buffer_addr[i]);
 			abort();
 		}

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1430,9 +1430,9 @@ static int read_memory(struct target *target, target_addr_t address,
 
 			switch (riscv_xlen(target)) {
 				case 64:
-					riscv013_write_debug_buffer(target, d_addr + 1, (cur_addr - size) >> 32);
+					riscv013_write_debug_buffer(target, d_addr + 1, cur_addr >> 32);
 				case 32:
-					riscv013_write_debug_buffer(target, d_addr, (cur_addr - size));
+					riscv013_write_debug_buffer(target, d_addr, cur_addr);
 					break;
 				default:
 					LOG_ERROR("unknown XLEN %d", riscv_xlen(target));

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1438,7 +1438,7 @@ static int read_memory(struct target *target, target_addr_t address,
 
 			switch (riscv_xlen(target)) {
 				case 64:
-					riscv013_write_debug_buffer(target, d_addr + 4, (cur_addr - size) >> 32);
+					riscv013_write_debug_buffer(target, d_addr + 1, (cur_addr - size) >> 32);
 				case 32:
 					riscv013_write_debug_buffer(target, d_addr, (cur_addr - size));
 					break;


### PR DESCRIPTION
The downloaded program now post-increments, and there's no longer an attempt to read the current address from the target. This made it easier to fix the problem where at the start of the loop the current address was already read (in regular entry) or has not yet been read (when the first round through the loop encountered busy more than once, or busy was encountered at least once later on).

Fixed a few math errors regarding addresses/indexes.

Also:
* Removed unnecessary reset in increase_ac_busy_delay().
* Removed various unnecessary newlines in log messages.

This version passes a stress test (simultaneously run 4 spikes with random delays added in, covering 32- and 64-bit, as well as single and dual core), and it also passes against the hardware I have access to.