### PR TITLE
Silence some clang warnings

### DIFF
--- a/src/target/riscv/asm.h
+++ b/src/target/riscv/asm.h
@@ -17,7 +17,7 @@ static uint32_t load(const struct target *target, unsigned int rd,
 			return ld(rd, base, offset);
 	}
 	assert(0);
-    return 0; // Silence -Werror=return-type
+	return 0; // Silence -Werror=return-type
 }
 
 static uint32_t store(const struct target *target, unsigned int src,
@@ -32,7 +32,7 @@ static uint32_t store(const struct target *target, unsigned int src,
 			return sd(src, base, offset);
 	}
 	assert(0);
-    return 0; // Silence -Werror=return-type
+	return 0; // Silence -Werror=return-type
 }
 
 #endif

--- a/src/target/riscv/asm.h
+++ b/src/target/riscv/asm.h
@@ -17,6 +17,7 @@ static uint32_t load(const struct target *target, unsigned int rd,
 			return ld(rd, base, offset);
 	}
 	assert(0);
+    return 0; // Silence -Werror=return-type
 }
 
 static uint32_t store(const struct target *target, unsigned int src,
@@ -31,6 +32,7 @@ static uint32_t store(const struct target *target, unsigned int src,
 			return sd(src, base, offset);
 	}
 	assert(0);
+    return 0; // Silence -Werror=return-type
 }
 
 #endif

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -478,7 +478,11 @@ riscv_addr_t riscv_program_gah(struct riscv_program *p, riscv_addr_t addr)
 
 riscv_addr_t riscv_program_gal(struct riscv_program *p, riscv_addr_t addr)
 {
-	return ((addr > 0) ? 1 : 0) * (addr & 0x7FF);
+	if (addr > 0) {
+	    return (addr & 0x7FF);
+	} else {
+	    return 0;
+	}
 }
 
 int riscv_program_lah(struct riscv_program *p, enum gdb_regno d, riscv_addr_t addr)

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -269,6 +269,7 @@ static unsigned int slot_offset(const struct target *target, slot_t slot)
 	LOG_ERROR("slot_offset called with xlen=%d, slot=%d",
 			riscv_xlen(target), slot);
 	assert(0);
+	return 0; // Silence -Werror=return-type
 }
 
 static uint32_t load_slot(const struct target *target, unsigned int dest,


### PR DESCRIPTION
The changes are minor, and generally cosmetic; the impact on the tests should be null. 