### PR TITLE
flash/nor/Makefile.am: keep files in lexicographical order

### DIFF
--- a/src/flash/nor/Makefile.am
+++ b/src/flash/nor/Makefile.am
@@ -22,8 +22,8 @@ NOR_DRIVERS = \
 	%D%/dsp5680xx_flash.c \
 	%D%/efm32.c \
 	%D%/em357.c \
-	%D%/fespi.c \
 	%D%/faux.c \
+	%D%/fespi.c \
 	%D%/fm3.c \
 	%D%/fm4.c \
 	%D%/jtagspi.c \


### PR DESCRIPTION
This is definitelly cosmetic, but since I stumbled upon it, I decided to fix it. So I pass it back to keep the differences between our versions at a minimum.