### PR TITLE
Fix compile warning with gcc 6.3.0

### DIFF
--- a/src/flash/nor/stm32f2x.c
+++ b/src/flash/nor/stm32f2x.c
@@ -1321,7 +1321,7 @@ COMMAND_HANDLER(stm32x_handle_unlock_command)
 	 * this will also force a device unlock if set */
 	stm32x_info->option_bytes.RDP = 0xAA;
 	if (stm32x_info->has_optcr2_pcrop) {
-		stm32x_info->option_bytes.optcr2_pcrop = OPTCR2_PCROP_RDP | (~1 << bank->num_sectors);
+		stm32x_info->option_bytes.optcr2_pcrop = OPTCR2_PCROP_RDP | (~1U << bank->num_sectors);
 	}
 
 	if (stm32x_write_options(bank) != ERROR_OK) {


### PR DESCRIPTION
Change-Id: I14ebf597f41429c0fc3ebac8da9c9f62c78fb1ae