### PR TITLE
Fix cut and paste bug.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -873,7 +873,7 @@ static int scratch_find(struct target *target,
 	}
 
 	if (riscv_use_scratch_ram) {
-		scratch->hart_address = (riscv_use_scratch_ram + alignment - 1) &
+		scratch->hart_address = (riscv_scratch_ram_address + alignment - 1) &
 			~(alignment - 1);
 		scratch->memory_space = SPACE_DMI_RAM;
 		scratch->debug_address = scratch->hart_address;


### PR DESCRIPTION
Now reading 64-bit FPRs on 32-bit harts using scratch memory might work.

Change-Id: Ie8c0fc689386c6e724ecab5e8c855e725fa8dd97