### PR TITLE
Use %ll instead of %L in scanf.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1168,7 +1168,7 @@ COMMAND_HANDLER(riscv_set_scratch_ram)
 	}
 
 	long long unsigned int address;
-	int result = sscanf(CMD_ARGV[0], "%Lx", &address);
+	int result = sscanf(CMD_ARGV[0], "%llx", &address);
 	if (result != (int) strlen(CMD_ARGV[0])) {
 		LOG_ERROR("%s is not a valid address for command.", CMD_ARGV[0]);
 		riscv_use_scratch_ram = false;


### PR DESCRIPTION
Mac build barfs on L, and the manpage says they're equivalent.

Hopefully fixes #147

Change-Id: I3aa57775731f3f5ceb03097cae2a9dc6fd426dcd