### PR TITLE
Conform to OpenOCD style guide.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 
         - os: linux
           env:
-              - BUILD=i686-linux-gnu 
+              - BUILD=i686-linux-gnu
               - CFLAGS=-m32
               - EXECUTABLE=openocd
           compiler: clang
@@ -38,7 +38,7 @@ matrix:
                       - gcc-multilib
 
         - os: linux
-          env: 
+          env:
               - BUILD=i686-w64-mingw
               - CONFIGURE_ARGS="--build=i686-unknown-linux-gnu --host=i686-w64-mingw32"
               - EXECUTABLE=openocd.exe

--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2010 by Antonio Borneo <borneo.antonio@gmail.com>       *
  *   Modified by Megan Wachs <megan@sifive.com> from the original stmsmi.c *
- *                                                                         * 
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -18,7 +18,7 @@
 
 /* The Freedom E SPI controller is a SPI bus controller
  * specifically designed for SPI Flash Memories on Freedom E platforms.
- * 
+ *
  * Two working modes are available:
  * - SW mode: the SPI is controlled by SW. Any custom commands can be sent
  *   on the bus. Writes are only possible in this mode.
@@ -127,7 +127,7 @@
 	int __a;						\
 	uint32_t __v;						\
 								\
-	__a = target_read_u32(target, ctrl_base + (a), &__v); 	\
+	__a = target_read_u32(target, ctrl_base + (a), &__v);	\
 	if (__a != ERROR_OK) {					\
 		LOG_ERROR("FESPI_READ_REG error");		\
 		return __a;					\
@@ -139,7 +139,7 @@
 {								\
 	int __r;						\
 								\
-	__r = target_write_u32(target, ctrl_base + (a), (v)); 	\
+	__r = target_write_u32(target, ctrl_base + (a), (v));	\
 	if (__r != ERROR_OK) {					\
 		LOG_ERROR("FESPI_WRITE_REG error");		\
 		return __r;					\
@@ -163,7 +163,7 @@ struct fespi_target {
 	uint32_t ctrl_base;
 };
 
-//TODO !!! What is the right naming convention here?
+/* TODO !!! What is the right naming convention here? */
 static const struct fespi_target target_devices[] = {
 	/* name,   tap_idcode, ctrl_base */
 	{ "Freedom E300 SPI Flash",  0x10e31913 , 0x10014000 },
@@ -189,16 +189,17 @@ FLASH_BANK_COMMAND_HANDLER(fespi_flash_bank_command)
 	fespi_info->probed = 0;
 	fespi_info->ctrl_base = 0;
 	if (CMD_ARGC >= 7) {
-          int temp;
-	  COMMAND_PARSE_NUMBER(int, CMD_ARGV[6], temp);
-          fespi_info->ctrl_base = (uint32_t) temp;
-	  LOG_DEBUG("ASSUMING FESPI device at ctrl_base = 0x%x", fespi_info->ctrl_base);
+		int temp;
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[6], temp);
+		fespi_info->ctrl_base = (uint32_t) temp;
+		LOG_DEBUG("ASSUMING FESPI device at ctrl_base = 0x%x", fespi_info->ctrl_base);
 	}
 
 	return ERROR_OK;
 }
 
-static int fespi_set_dir (struct flash_bank * bank, bool dir) {
+static int fespi_set_dir(struct flash_bank *bank, bool dir)
+{
 	struct target *target = bank->target;
 	struct fespi_flash_bank *fespi_info = bank->driver_priv;
 	uint32_t ctrl_base = fespi_info->ctrl_base;
@@ -211,7 +212,8 @@ static int fespi_set_dir (struct flash_bank * bank, bool dir) {
 
 }
 
-static int fespi_txwm_wait(struct flash_bank *bank) {
+static int fespi_txwm_wait(struct flash_bank *bank)
+{
 	struct target *target = bank->target;
 	struct fespi_flash_bank *fespi_info = bank->driver_priv;
 	uint32_t ctrl_base = fespi_info->ctrl_base;
@@ -219,9 +221,8 @@ static int fespi_txwm_wait(struct flash_bank *bank) {
 	int64_t start = timeval_ms();
 
 	while (1) {
-		if (FESPI_READ_REG(FESPI_REG_IP) & FESPI_IP_TXWM) {
+		if (FESPI_READ_REG(FESPI_REG_IP) & FESPI_IP_TXWM)
 			break;
-		}
 		int64_t now = timeval_ms();
 		if (now - start > 1000) {
 			LOG_ERROR("ip.txwm didn't get set.");
@@ -233,7 +234,8 @@ static int fespi_txwm_wait(struct flash_bank *bank) {
 
 }
 
-static int fespi_tx(struct flash_bank *bank, uint8_t in){
+static int fespi_tx(struct flash_bank *bank, uint8_t in)
+{
 	struct target *target = bank->target;
 	struct fespi_flash_bank *fespi_info = bank->driver_priv;
 	uint32_t ctrl_base = fespi_info->ctrl_base;
@@ -241,9 +243,8 @@ static int fespi_tx(struct flash_bank *bank, uint8_t in){
 	int64_t start = timeval_ms();
 
 	while (1) {
-		if ((int32_t) FESPI_READ_REG(FESPI_REG_TXFIFO) >= 0) {
+		if ((int32_t) FESPI_READ_REG(FESPI_REG_TXFIFO) >= 0)
 			break;
-		}
 		int64_t now = timeval_ms();
 		if (now - start > 1000) {
 			LOG_ERROR("txfifo stayed negative.");
@@ -276,14 +277,14 @@ static int fespi_rx(struct flash_bank *bank, uint8_t *out)
 		}
 	}
 
-	if (out) {
+	if (out)
 		*out = value & 0xff;
-	}
+
 	return ERROR_OK;
 }
 
-//TODO!!! Why don't we need to call this after writing?
-static int fespi_wip (struct flash_bank * bank, int timeout)
+/* TODO!!! Why don't we need to call this after writing? */
+static int fespi_wip(struct flash_bank *bank, int timeout)
 {
 	struct target *target = bank->target;
 	struct fespi_flash_bank *fespi_info = bank->driver_priv;
@@ -326,26 +327,34 @@ static int fespi_erase_sector(struct flash_bank *bank, int sector)
 	int retval;
 
 	retval = fespi_tx(bank, SPIFLASH_WRITE_ENABLE);
-	if (retval != ERROR_OK) {return retval;}
+	if (retval != ERROR_OK)
+		return retval;
 	retval = fespi_txwm_wait(bank);
-	if (retval != ERROR_OK) {return retval;}
-	  
+	if (retval != ERROR_OK)
+		return retval;
+
 	FESPI_WRITE_REG(FESPI_REG_CSMODE, FESPI_CSMODE_HOLD);
 	retval = fespi_tx(bank, fespi_info->dev->erase_cmd);
-	if (retval != ERROR_OK) {return retval;}	
+	if (retval != ERROR_OK)
+		return retval;
 	sector = bank->sectors[sector].offset;
 	retval = fespi_tx(bank, sector >> 16);
-	if (retval != ERROR_OK) {return retval;}	
+	if (retval != ERROR_OK)
+		return retval;
 	retval = fespi_tx(bank, sector >> 8);
-	if (retval != ERROR_OK) {return retval;}	
+	if (retval != ERROR_OK)
+		return retval;
 	retval = fespi_tx(bank, sector);
-	if (retval != ERROR_OK) {return retval;}	
+	if (retval != ERROR_OK)
+		return retval;
 	retval = fespi_txwm_wait(bank);
-	if (retval != ERROR_OK) {return retval;}	
+	if (retval != ERROR_OK)
+		return retval;
 	FESPI_WRITE_REG(FESPI_REG_CSMODE, FESPI_CSMODE_AUTO);
 
 	retval = fespi_wip(bank, FESPI_MAX_TIMEOUT);
-	if (retval != ERROR_OK){return retval;}
+	if (retval != ERROR_OK)
+		return retval;
 
 	return ERROR_OK;
 }
@@ -384,9 +393,9 @@ static int fespi_erase(struct flash_bank *bank, int first, int last)
 
 	FESPI_WRITE_REG(FESPI_REG_TXCTRL, FESPI_TXWM(1));
 	retval = fespi_txwm_wait(bank);
-	if (retval != ERROR_OK){
-	  LOG_ERROR("WM Didn't go high before attempting.");
-	  return retval;
+	if (retval != ERROR_OK) {
+		LOG_ERROR("WM Didn't go high before attempting.");
+		return retval;
 	}
 
 	/* Disable Hardware accesses*/
@@ -394,7 +403,7 @@ static int fespi_erase(struct flash_bank *bank, int first, int last)
 
 	/* poll WIP */
 	retval = fespi_wip(bank, FESPI_PROBE_TIMEOUT);
-	if (retval != ERROR_OK) 
+	if (retval != ERROR_OK)
 		return retval;
 
 	for (sector = first; sector <= last; sector++) {
@@ -427,7 +436,7 @@ static int slow_fespi_write_buffer(struct flash_bank *bank,
 	uint32_t ctrl_base = fespi_info->ctrl_base;
 	uint32_t ii;
 
-	//TODO!!! assert that len < page size
+	/* TODO!!! assert that len < page size */
 
 	fespi_tx(bank, SPIFLASH_WRITE_ENABLE);
 	fespi_txwm_wait(bank);
@@ -440,9 +449,8 @@ static int slow_fespi_write_buffer(struct flash_bank *bank,
 	fespi_tx(bank, offset >> 8);
 	fespi_tx(bank, offset);
 
-	for (ii = 0; ii < len; ii++) {
+	for (ii = 0; ii < len; ii++)
 		fespi_tx(bank, buffer[ii]);
-	}
 
 	fespi_txwm_wait(bank);
 
@@ -487,67 +495,67 @@ static int slow_fespi_write_buffer(struct flash_bank *bank,
 		.global _start
 _start:
 command_table:
-        j       main            // 0
-        ebreak                  // 4
-        j       tx              // 8
-        j       txwm_wait       // 12
-        j       write_reg       // 16
+		j       main            // 0
+		ebreak                  // 4
+		j       tx              // 8
+		j       txwm_wait       // 12
+		j       write_reg       // 16
 		j		wip_wait		// 20
-		j		set_dir 		// 24
+		j		set_dir			// 24
 
 // Execute the program.
 main:
-        lbu     t0, 0(a1)
-        addi    a1, a1, 1
-        la      t1, command_table
-        add     t0, t0, t1
-        jr      t0
+		lbu     t0, 0(a1)
+		addi    a1, a1, 1
+		la      t1, command_table
+		add     t0, t0, t1
+		jr      t0
 
 // Read 1 byte the contains the number of bytes to transmit. Then read those
 // bytes from the program and transmit them one by one.
 tx:
-        lbu     t1, 0(a1)       // read number of bytes to transmit
-        addi    a1, a1, 1
+		lbu     t1, 0(a1)       // read number of bytes to transmit
+		addi    a1, a1, 1
 1:      lw      t0, FESPI_REG_TXFIFO(a0)        // wait for FIFO clear
-        bltz    t0, 1b
-        lbu     t0, 0(a1)       // Load byte to write
-        sw      t0, FESPI_REG_TXFIFO(a0)
-        addi    a1, a1, 1
-        addi    t1, t1, -1
-        bgtz    t1, 1b
-        j       main
+		bltz    t0, 1b
+		lbu     t0, 0(a1)       // Load byte to write
+		sw      t0, FESPI_REG_TXFIFO(a0)
+		addi    a1, a1, 1
+		addi    t1, t1, -1
+		bgtz    t1, 1b
+		j       main
 
 // Wait until TXWM is set.
 txwm_wait:
 1:      lw      t0, FESPI_REG_IP(a0)
-        andi    t0, t0, FESPI_IP_TXWM
-        beqz    t0, 1b
-        j       main
+		andi    t0, t0, FESPI_IP_TXWM
+		beqz    t0, 1b
+		j       main
 
 // Read 1 byte that contains the offset of the register to write, and 1 byte
 // that contains the data to write.
 write_reg:
-        lbu     t0, 0(a1)       // read register to write
-        add     t0, t0, a0
-        lbu     t1, 1(a1)       // read value to write
-        addi    a1, a1, 2
-        sw      t1, 0(t0)
-        j       main
+		lbu     t0, 0(a1)       // read register to write
+		add     t0, t0, a0
+		lbu     t1, 1(a1)       // read value to write
+		addi    a1, a1, 2
+		sw      t1, 0(t0)
+		j       main
 
 wip_wait:
 		li		a2, SPIFLASH_READ_STATUS
-        jal		txrx_byte
+		jal		txrx_byte
 		// discard first result
 1:		li		a2, 0
-        jal		txrx_byte
+		jal		txrx_byte
 		andi	t0, a2, SPIFLASH_BSY_BIT
 		bnez	t0, 1b
 		j		main
 
 txrx_byte:	// transmit the byte in a2, receive a bit into a2
 		lw      t0, FESPI_REG_TXFIFO(a0)        // wait for FIFO clear
-        bltz    t0, txrx_byte
-        sw      a2, FESPI_REG_TXFIFO(a0)
+		bltz    t0, txrx_byte
+		sw      a2, FESPI_REG_TXFIFO(a0)
 1:		lw		a2, FESPI_REG_RXFIFO(a0)
 		bltz	a2, 1b
 		ret
@@ -556,8 +564,8 @@ set_dir:
 		lw		t0, FESPI_REG_FMT(a0)
 		li		t1, ~(FESPI_FMT_DIR(0xFFFFFFFF))
 		and		t0, t0, t1
-        lbu     t1, 0(a1)       // read value to OR in
-        addi    a1, a1, 1
+		lbu     t1, 0(a1)       // read value to OR in
+		addi    a1, a1, 1
 		or		t0, t0, t1
 		sw		t0, FESPI_REG_FMT(a0)
 		j		main
@@ -565,24 +573,24 @@ set_dir:
 // ALGO_END
  */
 static const uint8_t algorithm_bin[] = {
-  0x6f, 0x00, 0xc0, 0x01, 0x73, 0x00, 0x10, 0x00, 0x6f, 0x00, 0xc0, 0x02,
-  0x6f, 0x00, 0x00, 0x05, 0x6f, 0x00, 0xc0, 0x05, 0x6f, 0x00, 0x00, 0x07,
-  0x6f, 0x00, 0x00, 0x0a, 0x83, 0xc2, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
-  0x17, 0x03, 0x00, 0x00, 0x13, 0x03, 0xc3, 0xfd, 0xb3, 0x82, 0x62, 0x00,
-  0x67, 0x80, 0x02, 0x00, 0x03, 0xc3, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
-  0x83, 0x22, 0x85, 0x04, 0xe3, 0xce, 0x02, 0xfe, 0x83, 0xc2, 0x05, 0x00,
-  0x23, 0x24, 0x55, 0x04, 0x93, 0x85, 0x15, 0x00, 0x13, 0x03, 0xf3, 0xff,
-  0xe3, 0x44, 0x60, 0xfe, 0x6f, 0xf0, 0x5f, 0xfc, 0x83, 0x22, 0x45, 0x07,
-  0x93, 0xf2, 0x12, 0x00, 0xe3, 0x8c, 0x02, 0xfe, 0x6f, 0xf0, 0x5f, 0xfb,
-  0x83, 0xc2, 0x05, 0x00, 0xb3, 0x82, 0xa2, 0x00, 0x03, 0xc3, 0x15, 0x00,
-  0x93, 0x85, 0x25, 0x00, 0x23, 0xa0, 0x62, 0x00, 0x6f, 0xf0, 0xdf, 0xf9,
-  0x13, 0x06, 0x50, 0x00, 0xef, 0x00, 0x80, 0x01, 0x13, 0x06, 0x00, 0x00,
-  0xef, 0x00, 0x00, 0x01, 0x93, 0x72, 0x16, 0x00, 0xe3, 0x9a, 0x02, 0xfe,
-  0x6f, 0xf0, 0x1f, 0xf8, 0x83, 0x22, 0x85, 0x04, 0xe3, 0xce, 0x02, 0xfe,
-  0x23, 0x24, 0xc5, 0x04, 0x03, 0x26, 0xc5, 0x04, 0xe3, 0x4e, 0x06, 0xfe,
-  0x67, 0x80, 0x00, 0x00, 0x83, 0x22, 0x05, 0x04, 0x13, 0x03, 0x70, 0xff,
-  0xb3, 0xf2, 0x62, 0x00, 0x03, 0xc3, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
-  0xb3, 0xe2, 0x62, 0x00, 0x23, 0x20, 0x55, 0x04, 0x6f, 0xf0, 0x9f, 0xf4
+	 0x6f, 0x00, 0xc0, 0x01, 0x73, 0x00, 0x10, 0x00, 0x6f, 0x00, 0xc0, 0x02,
+	 0x6f, 0x00, 0x00, 0x05, 0x6f, 0x00, 0xc0, 0x05, 0x6f, 0x00, 0x00, 0x07,
+	 0x6f, 0x00, 0x00, 0x0a, 0x83, 0xc2, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
+	 0x17, 0x03, 0x00, 0x00, 0x13, 0x03, 0xc3, 0xfd, 0xb3, 0x82, 0x62, 0x00,
+	 0x67, 0x80, 0x02, 0x00, 0x03, 0xc3, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
+	 0x83, 0x22, 0x85, 0x04, 0xe3, 0xce, 0x02, 0xfe, 0x83, 0xc2, 0x05, 0x00,
+	 0x23, 0x24, 0x55, 0x04, 0x93, 0x85, 0x15, 0x00, 0x13, 0x03, 0xf3, 0xff,
+	 0xe3, 0x44, 0x60, 0xfe, 0x6f, 0xf0, 0x5f, 0xfc, 0x83, 0x22, 0x45, 0x07,
+	 0x93, 0xf2, 0x12, 0x00, 0xe3, 0x8c, 0x02, 0xfe, 0x6f, 0xf0, 0x5f, 0xfb,
+	 0x83, 0xc2, 0x05, 0x00, 0xb3, 0x82, 0xa2, 0x00, 0x03, 0xc3, 0x15, 0x00,
+	 0x93, 0x85, 0x25, 0x00, 0x23, 0xa0, 0x62, 0x00, 0x6f, 0xf0, 0xdf, 0xf9,
+	 0x13, 0x06, 0x50, 0x00, 0xef, 0x00, 0x80, 0x01, 0x13, 0x06, 0x00, 0x00,
+	 0xef, 0x00, 0x00, 0x01, 0x93, 0x72, 0x16, 0x00, 0xe3, 0x9a, 0x02, 0xfe,
+	 0x6f, 0xf0, 0x1f, 0xf8, 0x83, 0x22, 0x85, 0x04, 0xe3, 0xce, 0x02, 0xfe,
+	 0x23, 0x24, 0xc5, 0x04, 0x03, 0x26, 0xc5, 0x04, 0xe3, 0x4e, 0x06, 0xfe,
+	 0x67, 0x80, 0x00, 0x00, 0x83, 0x22, 0x05, 0x04, 0x13, 0x03, 0x70, 0xff,
+	 0xb3, 0xf2, 0x62, 0x00, 0x03, 0xc3, 0x05, 0x00, 0x93, 0x85, 0x15, 0x00,
+	 0xb3, 0xe2, 0x62, 0x00, 0x23, 0x20, 0x55, 0x04, 0x6f, 0xf0, 0x9f, 0xf4
 };
 #define STEP_EXIT			4
 #define STEP_TX				8
@@ -625,7 +633,7 @@ static int as_empty(struct algorithm_steps *as)
 	return 1;
 }
 
-// Return size of compiled program.
+/* Return size of compiled program. */
 static unsigned as_compile(struct algorithm_steps *as, uint8_t *target,
 		unsigned target_size)
 {
@@ -684,9 +692,8 @@ static unsigned as_compile(struct algorithm_steps *as, uint8_t *target,
 	LOG_DEBUG("%d-byte program:", offset);
 	for (unsigned i = 0; i < offset;) {
 		char buf[80];
-		for (unsigned x = 0; i < offset && x < 16; x++, i++) {
+		for (unsigned x = 0; i < offset && x < 16; x++, i++)
 			sprintf(buf + x*3, "%02x ", target[i]);
-		}
 		LOG_DEBUG("%s", buf);
 	}
 
@@ -771,7 +778,7 @@ static int steps_add_buffer_write(struct algorithm_steps *as,
 	as_add_txwm_wait(as);
 	as_add_write_reg(as, FESPI_REG_CSMODE, FESPI_CSMODE_AUTO);
 
-	// fespi_wip()
+	/* fespi_wip() */
 	as_add_set_dir(as, FESPI_DIR_RX);
 	as_add_write_reg(as, FESPI_REG_CSMODE, FESPI_CSMODE_HOLD);
 	as_add_wip_wait(as);
@@ -908,11 +915,10 @@ static int fespi_write(struct flash_bank *bank, const uint8_t *buffer,
 		cur_count = 4 - (offset & 3);
 		if (cur_count > count)
 			cur_count = count;
-		if (algorithm_wa) {
+		if (algorithm_wa)
 			retval = steps_add_buffer_write(as, buffer, offset, cur_count);
-		} else {
+		else
 			retval = slow_fespi_write_buffer(bank, buffer, offset, cur_count);
-		}
 		if (retval != ERROR_OK)
 			goto err;
 		offset += cur_count;
@@ -929,11 +935,10 @@ static int fespi_write(struct flash_bank *bank, const uint8_t *buffer,
 		else
 			cur_count = count & ~3;
 
-		if (algorithm_wa) {
+		if (algorithm_wa)
 			retval = steps_add_buffer_write(as, buffer, offset, cur_count);
-		} else {
+		else
 			retval = slow_fespi_write_buffer(bank, buffer, offset, cur_count);
-		}
 		if (retval != ERROR_OK)
 			goto err;
 
@@ -945,18 +950,16 @@ static int fespi_write(struct flash_bank *bank, const uint8_t *buffer,
 
 	/* buffer tail */
 	if (count > 0) {
-		if (algorithm_wa) {
+		if (algorithm_wa)
 			retval = steps_add_buffer_write(as, buffer, offset, count);
-		} else {
+		else
 			retval = slow_fespi_write_buffer(bank, buffer, offset, count);
-		}
 		if (retval != ERROR_OK)
 			goto err;
 	}
 
-	if (algorithm_wa) {
+	if (algorithm_wa)
 		retval = steps_execute(as, bank, algorithm_wa, data_wa);
-	}
 
 err:
 	if (algorithm_wa) {
@@ -1043,27 +1046,27 @@ static int fespi_probe(struct flash_bank *bank)
 	fespi_info->probed = 0;
 
 	if (fespi_info->ctrl_base == 0) {
-	  for (target_device = target_devices ; target_device->name ; ++target_device)
-	    if (target_device->tap_idcode == target->tap->idcode)
-	      break;
+		for (target_device = target_devices ; target_device->name ; ++target_device)
+			if (target_device->tap_idcode == target->tap->idcode)
+				break;
 
-	  if (!target_device->name) {
-	    LOG_ERROR("Device ID 0x%" PRIx32 " is not known as FESPI capable",
-		      target->tap->idcode);
-	    return ERROR_FAIL;
-	  }
+		if (!target_device->name) {
+			LOG_ERROR("Device ID 0x%" PRIx32 " is not known as FESPI capable",
+					target->tap->idcode);
+			return ERROR_FAIL;
+		}
 
-	  fespi_info->ctrl_base = target_device->ctrl_base;
+		fespi_info->ctrl_base = target_device->ctrl_base;
 
-	  LOG_DEBUG("Valid FESPI on device %s at address 0x%" PRIx32,
-		    target_device->name, bank->base);
+		LOG_DEBUG("Valid FESPI on device %s at address 0x%" PRIx32,
+				target_device->name, bank->base);
 
 	} else {
 	  LOG_DEBUG("Assuming FESPI as specified at address 0x%x with ctrl at 0x%x",
 		    fespi_info->ctrl_base,
 		    bank->base);
 	}
-        ctrl_base = fespi_info->ctrl_base;
+	ctrl_base = fespi_info->ctrl_base;
 
 	/* read and decode flash ID; returns in SW mode */
 	FESPI_WRITE_REG(FESPI_REG_TXCTRL, FESPI_TXWM(1));

--- a/src/jtag/drivers/remote_bitbang.c
+++ b/src/jtag/drivers/remote_bitbang.c
@@ -76,10 +76,8 @@ static void remote_bitbang_fill_buf(void)
 				contiguous_available_space);
 		if (count > 0) {
 			remote_bitbang_end += count;
-			// TODO: check for overflow.
-			if (remote_bitbang_end == sizeof(remote_bitbang_buf)) {
+			if (remote_bitbang_end == sizeof(remote_bitbang_buf))
 				remote_bitbang_end = 0;
-			}
 		} else if (count == 0) {
 			return;
 		} else if (count < 0) {
@@ -171,7 +169,7 @@ static int remote_bitbang_read_sample(void)
 {
 	if (remote_bitbang_start != remote_bitbang_end) {
 		int c = remote_bitbang_buf[remote_bitbang_start];
-		remote_bitbang_start = 
+		remote_bitbang_start =
 			(remote_bitbang_start + 1) % sizeof(remote_bitbang_buf);
 		return char_to_int(c);
 	}

--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -79,7 +79,7 @@ static int riscv_gdb_thread_packet(struct connection *connection, const char *pa
 		if (strncmp(packet, "qfThreadInfo", 12) == 0) {
 			riscv_update_threads(target->rtos);
 			r->qs_thread_info_offset = 1;
-			
+
 			char m[16];
 			snprintf(m, 16, "m%08x", (int)rtos->thread_details[0].threadid);
 			gdb_put_packet(connection, m, strlen(m));
@@ -305,8 +305,7 @@ static int riscv_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[])
 	return JIM_OK;
 }
 
-const struct rtos_type riscv_rtos =
-{
+const struct rtos_type riscv_rtos = {
 	.name = "riscv",
 	.detect_rtos = riscv_detect_rtos,
 	.create = riscv_create_rtos,

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -1286,10 +1286,10 @@ static int gdb_get_register_packet(struct connection *connection,
 	}
 
 	if (!reg_list[reg_num]->valid) {
-	        retval = reg_list[reg_num]->type->get(reg_list[reg_num]);
+		retval = reg_list[reg_num]->type->get(reg_list[reg_num]);
 		if (retval != ERROR_OK) {
 			LOG_DEBUG("Couldn't get register %s.", reg_list[reg_num]->name);
-			free (reg_list);
+			free(reg_list);
 			return gdb_error(connection, retval);
 		}
 	}
@@ -1347,7 +1347,7 @@ static int gdb_set_register_packet(struct connection *connection,
 	gdb_target_to_reg(target, separator + 1, chars, bin_buf);
 
 	retval = reg_list[reg_num]->type->set(reg_list[reg_num], bin_buf);
-	if (retval != ERROR_OK){
+	if (retval != ERROR_OK) {
 		LOG_DEBUG("Couldn't set register %s.", reg_list[reg_num]->name);
 		free(bin_buf);
 		free(reg_list);

--- a/src/target/riscv/asm.h
+++ b/src/target/riscv/asm.h
@@ -17,7 +17,7 @@ static uint32_t load(const struct target *target, unsigned int rd,
 			return ld(rd, base, offset);
 	}
 	assert(0);
-	return 0; // Silence -Werror=return-type
+	return 0; /* Silence -Werror=return-type */
 }
 
 static uint32_t store(const struct target *target, unsigned int src,
@@ -32,7 +32,7 @@ static uint32_t store(const struct target *target, unsigned int src,
 			return sd(src, base, offset);
 	}
 	assert(0);
-	return 0; // Silence -Werror=return-type
+	return 0; /* Silence -Werror=return-type */
 }
 
 #endif

--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -138,8 +138,8 @@ void riscv_batch_add_nop(struct riscv_batch *batch)
 
 void dump_field(const struct scan_field *field)
 {
-	static const char *op_string[] = {"-", "r", "w", "?"};
-	static const char *status_string[] = {"+", "?", "F", "b"};
+	static const char * const op_string[] = {"-", "r", "w", "?"};
+	static const char * const status_string[] = {"+", "?", "F", "b"};
 
 	if (debug_level < LOG_LVL_DEBUG)
 		return;

--- a/src/target/riscv/debug_defines.h
+++ b/src/target/riscv/debug_defines.h
@@ -295,7 +295,7 @@
 *
 * Other values are reserved for future use.
  */
-#define CSR_TDATA1_TYPE_OFFSET              XLEN-4
+#define CSR_TDATA1_TYPE_OFFSET              (XLEN-4)
 #define CSR_TDATA1_TYPE_LENGTH              4
 #define CSR_TDATA1_TYPE                     (0xfULL << CSR_TDATA1_TYPE_OFFSET)
 /*
@@ -307,14 +307,14 @@
 *
 * This bit is only writable from Debug Mode.
  */
-#define CSR_TDATA1_DMODE_OFFSET             XLEN-5
+#define CSR_TDATA1_DMODE_OFFSET             (XLEN-5)
 #define CSR_TDATA1_DMODE_LENGTH             1
 #define CSR_TDATA1_DMODE                    (0x1ULL << CSR_TDATA1_DMODE_OFFSET)
 /*
 * Trigger-specific data.
  */
 #define CSR_TDATA1_DATA_OFFSET              0
-#define CSR_TDATA1_DATA_LENGTH              XLEN - 5
+#define CSR_TDATA1_DATA_LENGTH              (XLEN - 5)
 #define CSR_TDATA1_DATA                     (((1L<<XLEN - 5)-1) << CSR_TDATA1_DATA_OFFSET)
 #define CSR_TDATA2                          0x7a2
 #define CSR_TDATA2_DATA_OFFSET              0
@@ -325,10 +325,10 @@
 #define CSR_TDATA3_DATA_LENGTH              XLEN
 #define CSR_TDATA3_DATA                     (((1L<<XLEN)-1) << CSR_TDATA3_DATA_OFFSET)
 #define CSR_MCONTROL                        0x7a1
-#define CSR_MCONTROL_TYPE_OFFSET            XLEN-4
+#define CSR_MCONTROL_TYPE_OFFSET            (XLEN-4)
 #define CSR_MCONTROL_TYPE_LENGTH            4
 #define CSR_MCONTROL_TYPE                   (0xfULL << CSR_MCONTROL_TYPE_OFFSET)
-#define CSR_MCONTROL_DMODE_OFFSET           XLEN-5
+#define CSR_MCONTROL_DMODE_OFFSET           (XLEN-5)
 #define CSR_MCONTROL_DMODE_LENGTH           1
 #define CSR_MCONTROL_DMODE                  (0x1ULL << CSR_MCONTROL_DMODE_OFFSET)
 /*
@@ -339,7 +339,7 @@
 * corresponds to the maximum NAPOT range, which is $2^{63}$ bytes in
 * size.
  */
-#define CSR_MCONTROL_MASKMAX_OFFSET         XLEN-11
+#define CSR_MCONTROL_MASKMAX_OFFSET         (XLEN-11)
 #define CSR_MCONTROL_MASKMAX_LENGTH         6
 #define CSR_MCONTROL_MASKMAX                (0x3fULL << CSR_MCONTROL_MASKMAX_OFFSET)
 /*
@@ -478,10 +478,10 @@
 #define CSR_MCONTROL_LOAD_LENGTH            1
 #define CSR_MCONTROL_LOAD                   (0x1ULL << CSR_MCONTROL_LOAD_OFFSET)
 #define CSR_ICOUNT                          0x7a1
-#define CSR_ICOUNT_TYPE_OFFSET              XLEN-4
+#define CSR_ICOUNT_TYPE_OFFSET              (XLEN-4)
 #define CSR_ICOUNT_TYPE_LENGTH              4
 #define CSR_ICOUNT_TYPE                     (0xfULL << CSR_ICOUNT_TYPE_OFFSET)
-#define CSR_ICOUNT_DMODE_OFFSET             XLEN-5
+#define CSR_ICOUNT_DMODE_OFFSET             (XLEN-5)
 #define CSR_ICOUNT_DMODE_LENGTH             1
 #define CSR_ICOUNT_DMODE                    (0x1ULL << CSR_ICOUNT_DMODE_OFFSET)
 /*

--- a/src/target/riscv/gdb_regs.h
+++ b/src/target/riscv/gdb_regs.h
@@ -1,8 +1,8 @@
 #ifndef TARGET__RISCV__GDB_REGS_H
 #define TARGET__RISCV__GDB_REGS_H
 
-// gdb's register list is defined in riscv_gdb_reg_names gdb/riscv-tdep.c in
-// its source tree. We must interpret the numbers the same here.
+/* gdb's register list is defined in riscv_gdb_reg_names gdb/riscv-tdep.c in
+ * its source tree. We must interpret the numbers the same here. */
 enum gdb_regno {
 	GDB_REGNO_ZERO = 0,        /* Read-only register, always 0.  */
 	GDB_REGNO_RA = 1,          /* Return Address.  */

--- a/src/target/riscv/opcodes.h
+++ b/src/target/riscv/opcodes.h
@@ -5,16 +5,19 @@
 #define S0      8
 #define S1      9
 
-static uint32_t bits(uint32_t value, unsigned int hi, unsigned int lo) {
+static uint32_t bits(uint32_t value, unsigned int hi, unsigned int lo)
+{
 	return (value >> lo) & ((1 << (hi+1-lo)) - 1);
 }
 
-static uint32_t bit(uint32_t value, unsigned int b) {
+static uint32_t bit(uint32_t value, unsigned int b)
+{
 	return (value >> b) & 1;
 }
 
 static uint32_t jal(unsigned int rd, uint32_t imm) __attribute__ ((unused));
-static uint32_t jal(unsigned int rd, uint32_t imm) {
+static uint32_t jal(unsigned int rd, uint32_t imm)
+{
 	return (bit(imm, 20) << 31) |
 		(bits(imm, 10, 1) << 21) |
 		(bit(imm, 11) << 20) |
@@ -24,7 +27,8 @@ static uint32_t jal(unsigned int rd, uint32_t imm) {
 }
 
 static uint32_t csrsi(unsigned int csr, uint16_t imm) __attribute__ ((unused));
-static uint32_t csrsi(unsigned int csr, uint16_t imm) {
+static uint32_t csrsi(unsigned int csr, uint16_t imm)
+{
 	return (csr << 20) |
 		(bits(imm, 4, 0) << 15) |
 		MATCH_CSRRSI;
@@ -107,7 +111,8 @@ static uint32_t lb(unsigned int rd, unsigned int base, uint16_t offset)
 }
 
 static uint32_t csrw(unsigned int source, unsigned int csr) __attribute__ ((unused));
-static uint32_t csrw(unsigned int source, unsigned int csr) {
+static uint32_t csrw(unsigned int source, unsigned int csr)
+{
 	return (csr << 20) | (source << 15) | MATCH_CSRRW;
 }
 
@@ -121,17 +126,20 @@ static uint32_t addi(unsigned int dest, unsigned int src, uint16_t imm)
 }
 
 static uint32_t csrr(unsigned int rd, unsigned int csr) __attribute__ ((unused));
-static uint32_t csrr(unsigned int rd, unsigned int csr) {
+static uint32_t csrr(unsigned int rd, unsigned int csr)
+{
 	return (csr << 20) | (rd << 7) | MATCH_CSRRS;
 }
 
 static uint32_t csrrs(unsigned int rd, unsigned int rs, unsigned int csr) __attribute__ ((unused));
-static uint32_t csrrs(unsigned int rd, unsigned int rs, unsigned int csr) {
+static uint32_t csrrs(unsigned int rd, unsigned int rs, unsigned int csr)
+{
 	return (csr << 20) | (rs << 15) | (rd << 7) | MATCH_CSRRS;
 }
 
 static uint32_t csrrw(unsigned int rd, unsigned int rs, unsigned int csr) __attribute__ ((unused));
-static uint32_t csrrw(unsigned int rd, unsigned int rs, unsigned int csr) {
+static uint32_t csrrw(unsigned int rd, unsigned int rs, unsigned int csr)
+{
 	return (csr << 20) | (rs << 15) | (rd << 7) | MATCH_CSRRW;
 }
 
@@ -206,9 +214,15 @@ static uint32_t fmv_d_x(unsigned dest, unsigned src)
 }
 
 static uint32_t ebreak(void) __attribute__ ((unused));
-static uint32_t ebreak(void) { return MATCH_EBREAK; }
+static uint32_t ebreak(void)
+{
+	return MATCH_EBREAK;
+}
 static uint32_t ebreak_c(void) __attribute__ ((unused));
-static uint32_t ebreak_c(void) { return MATCH_C_EBREAK; }
+static uint32_t ebreak_c(void)
+{
+	return MATCH_C_EBREAK;
+}
 
 static uint32_t fence_i(void) __attribute__ ((unused));
 static uint32_t fence_i(void)
@@ -226,7 +240,8 @@ static uint32_t lui(unsigned int dest, uint32_t imm)
 
 /*
 static uint32_t csrci(unsigned int csr, uint16_t imm) __attribute__ ((unused));
-static uint32_t csrci(unsigned int csr, uint16_t imm) {
+static uint32_t csrci(unsigned int csr, uint16_t imm)
+{
   return (csr << 20) |
     (bits(imm, 4, 0) << 15) |
     MATCH_CSRRCI;

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -18,11 +18,10 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 	p->target = target;
 	p->instruction_count = 0;
 	p->target_xlen = riscv_xlen(target);
-	for (size_t i = 0; i < RISCV_REGISTER_COUNT; ++i) {
+	for (size_t i = 0; i < RISCV_REGISTER_COUNT; ++i)
 		p->writes_xreg[i] = 0;
-	}
 
-	for(size_t i = 0; i < RISCV_MAX_DEBUG_BUFFER_SIZE; ++i)
+	for (size_t i = 0; i < RISCV_MAX_DEBUG_BUFFER_SIZE; ++i)
 		p->debug_buffer[i] = -1;
 
 	return ERROR_OK;
@@ -54,7 +53,7 @@ int riscv_program_exec(struct riscv_program *p, struct target *t)
 
 	if (riscv_program_ebreak(p) != ERROR_OK) {
 		LOG_ERROR("Unable to write ebreak");
-		for(size_t i = 0; i < riscv_debug_buffer_size(p->target); ++i)
+		for (size_t i = 0; i < riscv_debug_buffer_size(p->target); ++i)
 			LOG_ERROR("ram[%02x]: DASM(0x%08lx) [0x%08lx]", (int)i, (long)p->debug_buffer[i], (long)p->debug_buffer[i]);
 		abort();
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -34,32 +34,32 @@
  * Code structure
  *
  * At the bottom of the stack are the OpenOCD JTAG functions:
- * 		jtag_add_[id]r_scan
- * 		jtag_execute_query
- * 		jtag_add_runtest
+ *     jtag_add_[id]r_scan
+ *     jtag_execute_query
+ *     jtag_add_runtest
  *
  * There are a few functions to just instantly shift a register and get its
  * value:
- *		dtmcontrol_scan
- *		idcode_scan
- *		dbus_scan
+ *    dtmcontrol_scan
+ *    idcode_scan
+ *    dbus_scan
  *
  * Because doing one scan and waiting for the result is slow, most functions
  * batch up a bunch of dbus writes and then execute them all at once. They use
  * the scans "class" for this:
- *		scans_new
- *		scans_delete
- *		scans_execute
- *		scans_add_...
+ *    scans_new
+ *    scans_delete
+ *    scans_execute
+ *    scans_add_...
  * Usually you new(), call a bunch of add functions, then execute() and look
  * at the results by calling scans_get...()
  *
  * Optimized functions will directly use the scans class above, but slightly
  * lazier code will use the cache functions that in turn use the scans
  * functions:
- *		cache_get...
- *		cache_set...
- *		cache_write
+ *    cache_get...
+ *    cache_set...
+ *    cache_write
  * cache_set... update a local structure, which is then synced to the target
  * with cache_write(). Only Debug RAM words that are actually changed are sent
  * to the target. Afterwards use cache_get... to read results.
@@ -70,7 +70,7 @@
 
 #define DIM(x)		(sizeof(x)/sizeof(*x))
 
-// Constants for legacy SiFive hardware breakpoints.
+/* Constants for legacy SiFive hardware breakpoints. */
 #define CSR_BPCONTROL_X			(1<<0)
 #define CSR_BPCONTROL_W			(1<<1)
 #define CSR_BPCONTROL_R			(1<<2)
@@ -189,19 +189,19 @@ typedef struct {
 
 	struct memory_cache_line dram_cache[DRAM_CACHE_SIZE];
 
-	// Number of run-test/idle cycles the target requests we do after each dbus
-	// access.
+	/* Number of run-test/idle cycles the target requests we do after each dbus
+	 * access. */
 	unsigned int dtmcontrol_idle;
 
-	// This value is incremented every time a dbus access comes back as "busy".
-	// It's used to determine how many run-test/idle cycles to feed the target
-	// in between accesses.
+	/* This value is incremented every time a dbus access comes back as "busy".
+	 * It's used to determine how many run-test/idle cycles to feed the target
+	 * in between accesses. */
 	unsigned int dbus_busy_delay;
 
-	// This value is incremented every time we read the debug interrupt as
-	// high.  It's used to add extra run-test/idle cycles after setting debug
-	// interrupt high, so ideally we never have to perform a whole extra scan
-	// before the interrupt is cleared.
+	/* This value is incremented every time we read the debug interrupt as
+	 * high.  It's used to add extra run-test/idle cycles after setting debug
+	 * interrupt high, so ideally we never have to perform a whole extra scan
+	 * before the interrupt is cleared. */
 	unsigned int interrupt_high_delay;
 
 	bool need_strict_step;
@@ -249,7 +249,7 @@ static unsigned int slot_offset(const struct target *target, slot_t slot)
 	LOG_ERROR("slot_offset called with xlen=%d, slot=%d",
 			riscv_xlen(target), slot);
 	assert(0);
-	return 0; // Silence -Werror=return-type
+	return 0; /* Silence -Werror=return-type */
 }
 
 static uint32_t load_slot(const struct target *target, unsigned int dest,
@@ -368,19 +368,17 @@ static void add_dbus_scan(const struct target *target, struct scan_field *field,
 	jtag_add_dr_scan(target->tap, 1, field, TAP_IDLE);
 
 	int idle_count = info->dtmcontrol_idle + info->dbus_busy_delay;
-	if (data & DMCONTROL_INTERRUPT) {
+	if (data & DMCONTROL_INTERRUPT)
 		idle_count += info->interrupt_high_delay;
-	}
 
-	if (idle_count) {
+	if (idle_count)
 		jtag_add_runtest(idle_count, TAP_IDLE);
-	}
 }
 
 static void dump_field(const struct scan_field *field)
 {
-	static const char *op_string[] = {"nop", "r", "w", "?"};
-	static const char *status_string[] = {"+", "?", "F", "b"};
+	static const char * const op_string[] = {"nop", "r", "w", "?"};
+	static const char * const status_string[] = {"+", "?", "F", "b"};
 
 	if (debug_level < LOG_LVL_DEBUG)
 		return;
@@ -431,9 +429,8 @@ static dbus_status_t dbus_scan(struct target *target, uint16_t *address_in,
 
 	int idle_count = info->dtmcontrol_idle + info->dbus_busy_delay;
 
-	if (idle_count) {
+	if (idle_count)
 		jtag_add_runtest(idle_count, TAP_IDLE);
-	}
 
 	int retval = jtag_execute_queue();
 	if (retval != ERROR_OK) {
@@ -441,13 +438,11 @@ static dbus_status_t dbus_scan(struct target *target, uint16_t *address_in,
 		return retval;
 	}
 
-	if (data_in) {
+	if (data_in)
 		*data_in = buf_get_u64(in, DBUS_DATA_START, DBUS_DATA_SIZE);
-	}
 
-	if (address_in) {
+	if (address_in)
 		*address_in = buf_get_u32(in, DBUS_ADDRESS_START, info->addrbits);
-	}
 
 	dump_field(&field);
 
@@ -463,15 +458,13 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	unsigned i = 0;
 	do {
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);
-		if (status == DBUS_STATUS_BUSY) {
+		if (status == DBUS_STATUS_BUSY)
 			increase_dbus_busy_delay(target);
-		}
 	} while (((status == DBUS_STATUS_BUSY) || (address_in != address)) &&
 			i++ < 256);
 
-	if (status != DBUS_STATUS_SUCCESS) {
+	if (status != DBUS_STATUS_SUCCESS)
 		LOG_ERROR("failed read from 0x%x; value=0x%" PRIx64 ", status=%d\n", address, value, status);
-	}
 
 	return value;
 }
@@ -482,21 +475,19 @@ static void dbus_write(struct target *target, uint16_t address, uint64_t value)
 	unsigned i = 0;
 	while (status == DBUS_STATUS_BUSY && i++ < 256) {
 		status = dbus_scan(target, NULL, NULL, DBUS_OP_WRITE, address, value);
-		if (status == DBUS_STATUS_BUSY) {
+		if (status == DBUS_STATUS_BUSY)
 			increase_dbus_busy_delay(target);
-		}
 	}
-	if (status != DBUS_STATUS_SUCCESS) {
+	if (status != DBUS_STATUS_SUCCESS)
 		LOG_ERROR("failed to write 0x%" PRIx64 " to 0x%x; status=%d\n", value, address, status);
-	}
 }
 
 /*** scans "class" ***/
 
 typedef struct {
-	// Number of scans that space is reserved for.
+	/* Number of scans that space is reserved for. */
 	unsigned int scan_count;
-	// Size reserved in memory for each scan, in bytes.
+	/* Size reserved in memory for each scan, in bytes. */
 	unsigned int scan_size;
 	unsigned int next_scan;
 	uint8_t *in;
@@ -509,7 +500,7 @@ static scans_t *scans_new(struct target *target, unsigned int scan_count)
 {
 	scans_t *scans = malloc(sizeof(scans_t));
 	scans->scan_count = scan_count;
-	// This code also gets called before xlen is detected.
+	/* This code also gets called before xlen is detected. */
 	if (riscv_xlen(target))
 		scans->scan_size = 2 + riscv_xlen(target) / 8;
 	else
@@ -539,9 +530,8 @@ static void scans_reset(scans_t *scans)
 
 static void scans_dump(scans_t *scans)
 {
-	for (unsigned int i = 0; i < scans->next_scan; i++) {
+	for (unsigned int i = 0; i < scans->next_scan; i++)
 		dump_field(&scans->field[i]);
-	}
 }
 
 static int scans_execute(scans_t *scans)
@@ -699,17 +689,16 @@ static int wait_for_debugint_clear(struct target *target, bool ignore_first)
 {
 	time_t start = time(NULL);
 	if (ignore_first) {
-		// Throw away the results of the first read, since they'll contain the
-		// result of the read that happened just before debugint was set.
-		// (Assuming the last scan before calling this function was one that
-		// sets debugint.)
+		/* Throw away the results of the first read, since they'll contain the
+		 * result of the read that happened just before debugint was set.
+		 * (Assuming the last scan before calling this function was one that
+		 * sets debugint.) */
 		read_bits(target);
 	}
 	while (1) {
 		bits_t bits = read_bits(target);
-		if (!bits.interrupt) {
+		if (!bits.interrupt)
 			return ERROR_OK;
-		}
 		if (time(NULL) - start > riscv_command_timeout_sec) {
 			LOG_ERROR("Timed out waiting for debug int to clear."
 				  "Increase timeout with riscv set_command_timeout_sec.");
@@ -736,7 +725,7 @@ static void cache_set32(struct target *target, unsigned int index, uint32_t data
 	riscv011_info_t *info = get_info(target);
 	if (info->dram_cache[index].valid &&
 			info->dram_cache[index].data == data) {
-		// This is already preset on the target.
+		/* This is already preset on the target. */
 		LOG_DEBUG("cache[0x%x] = 0x%08x: DASM(0x%x) (hit)", index, data, data);
 		return;
 	}
@@ -750,9 +739,8 @@ static void cache_set(struct target *target, slot_t slot, uint64_t data)
 {
 	unsigned int offset = slot_offset(target, slot);
 	cache_set32(target, offset, data);
-	if (riscv_xlen(target) > 32) {
+	if (riscv_xlen(target) > 32)
 		cache_set32(target, offset + 1, data >> 32);
-	}
 }
 
 static void cache_set_jump(struct target *target, unsigned int index)
@@ -799,9 +787,8 @@ static void cache_clean(struct target *target)
 {
 	riscv011_info_t *info = get_info(target);
 	for (unsigned int i = 0; i < info->dramsize; i++) {
-		if (i >= 4) {
+		if (i >= 4)
 			info->dram_cache[i].valid = false;
-		}
 		info->dram_cache[i].dirty = false;
 	}
 }
@@ -813,9 +800,8 @@ static int cache_check(struct target *target)
 
 	for (unsigned int i = 0; i < info->dramsize; i++) {
 		if (info->dram_cache[i].valid && !info->dram_cache[i].dirty) {
-			if (dram_check32(target, i, info->dram_cache[i].data) != ERROR_OK) {
+			if (dram_check32(target, i, info->dram_cache[i].data) != ERROR_OK)
 				error++;
-			}
 		}
 	}
 
@@ -838,13 +824,12 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 
 	unsigned int last = info->dramsize;
 	for (unsigned int i = 0; i < info->dramsize; i++) {
-		if (info->dram_cache[i].dirty) {
+		if (info->dram_cache[i].dirty)
 			last = i;
-		}
 	}
 
 	if (last == info->dramsize) {
-		// Nothing needs to be written to RAM.
+		/* Nothing needs to be written to RAM. */
 		dbus_write(target, DMCONTROL, DMCONTROL_HALTNOT | (run ? DMCONTROL_INTERRUPT : 0));
 
 	} else {
@@ -858,12 +843,12 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 	}
 
 	if (run || address < CACHE_NO_READ) {
-		// Throw away the results of the first read, since it'll contain the
-		// result of the read that happened just before debugint was set.
+		/* Throw away the results of the first read, since it'll contain the
+		 * result of the read that happened just before debugint was set. */
 		scans_add_read32(scans, address, false);
 
-		// This scan contains the results of the read the caller requested, as
-		// well as an interrupt bit worth looking at.
+		/* This scan contains the results of the read the caller requested, as
+		 * well as an interrupt bit worth looking at. */
 		scans_add_read32(scans, address, false);
 	}
 
@@ -895,19 +880,17 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 	if (errors) {
 		increase_dbus_busy_delay(target);
 
-		// Try again, using the slow careful code.
-		// Write all RAM, just to be extra cautious.
+		/* Try again, using the slow careful code.
+		 * Write all RAM, just to be extra cautious. */
 		for (unsigned int i = 0; i < info->dramsize; i++) {
-			if (i == last && run) {
+			if (i == last && run)
 				dram_write32(target, last, info->dram_cache[last].data, true);
-			} else {
+			else
 				dram_write32(target, i, info->dram_cache[i].data, false);
-			}
 			info->dram_cache[i].dirty = false;
 		}
-		if (run) {
+		if (run)
 			cache_clean(target);
-		}
 
 		if (wait_for_debugint_clear(target, true) != ERROR_OK) {
 			LOG_ERROR("Debug interrupt didn't clear.");
@@ -919,9 +902,8 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 		if (run) {
 			cache_clean(target);
 		} else {
-			for (unsigned int i = 0; i < info->dramsize; i++) {
+			for (unsigned int i = 0; i < info->dramsize; i++)
 				info->dram_cache[i].dirty = false;
-			}
 		}
 
 		if (run || address < CACHE_NO_READ) {
@@ -929,14 +911,14 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 					DBUS_DATA_START + 33, 1);
 			if (interrupt) {
 				increase_interrupt_high_delay(target);
-				// Slow path wait for it to clear.
+				/* Slow path wait for it to clear. */
 				if (wait_for_debugint_clear(target, false) != ERROR_OK) {
 					LOG_ERROR("Debug interrupt didn't clear.");
 					dump_debug_ram(target);
 					return ERROR_FAIL;
 				}
 			} else {
-				// We read a useful value in that last scan.
+				/* We read a useful value in that last scan. */
 				unsigned int read_addr = scans_get_u32(scans, scans->next_scan-1,
 						DBUS_ADDRESS_START, info->addrbits);
 				if (read_addr != address) {
@@ -970,9 +952,8 @@ static uint64_t cache_get(struct target *target, slot_t slot)
 {
 	unsigned int offset = slot_offset(target, slot);
 	uint64_t value = cache_get32(target, offset);
-	if (riscv_xlen(target) > 32) {
+	if (riscv_xlen(target) > 32)
 		value |= ((uint64_t) cache_get32(target, offset + 1)) << 32;
-	}
 	return value;
 }
 
@@ -991,12 +972,10 @@ static int wait_for_state(struct target *target, enum target_state state)
 	time_t start = time(NULL);
 	while (1) {
 		int result = riscv011_poll(target);
-		if (result != ERROR_OK) {
+		if (result != ERROR_OK)
 			return result;
-		}
-		if (target->state == state) {
+		if (target->state == state)
 			return ERROR_OK;
-		}
 		if (time(NULL) - start > riscv_command_timeout_sec) {
 			LOG_ERROR("Timed out waiting for state %d. "
 				  "Increase timeout with riscv set_command_timeout_sec.", state);
@@ -1011,9 +990,8 @@ static int read_csr(struct target *target, uint64_t *value, uint32_t csr)
 	cache_set32(target, 0, csrr(S0, csr));
 	cache_set_store(target, 1, S0, SLOT0);
 	cache_set_jump(target, 2);
-	if (cache_write(target, 4, true) != ERROR_OK) {
+	if (cache_write(target, 4, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 	*value = cache_get(target, SLOT0);
 	LOG_DEBUG("csr 0x%x = 0x%" PRIx64, csr, *value);
 
@@ -1034,9 +1012,8 @@ static int write_csr(struct target *target, uint32_t csr, uint64_t value)
 	cache_set32(target, 1, csrw(S0, csr));
 	cache_set_jump(target, 2);
 	cache_set(target, SLOT0, value);
-	if (cache_write(target, 4, true) != ERROR_OK) {
+	if (cache_write(target, 4, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	return ERROR_OK;
 }
@@ -1046,9 +1023,8 @@ static int write_gpr(struct target *target, unsigned int gpr, uint64_t value)
 	cache_set_load(target, 0, gpr, SLOT0);
 	cache_set_jump(target, 1);
 	cache_set(target, SLOT0, value);
-	if (cache_write(target, 4, true) != ERROR_OK) {
+	if (cache_write(target, 4, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 	return ERROR_OK;
 }
 
@@ -1088,15 +1064,14 @@ static int execute_resume(struct target *target, bool step)
 
 	maybe_write_tselect(target);
 
-	// TODO: check if dpc is dirty (which also is true if an exception was hit
-	// at any time)
+	/* TODO: check if dpc is dirty (which also is true if an exception was hit
+	 * at any time) */
 	cache_set_load(target, 0, S0, SLOT0);
 	cache_set32(target, 1, csrw(S0, CSR_DPC));
 	cache_set_jump(target, 2);
 	cache_set(target, SLOT0, info->dpc);
-	if (cache_write(target, 4, true) != ERROR_OK) {
+	if (cache_write(target, 4, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	struct reg *mstatus_reg = &target->reg_cache->reg_list[GDB_REGNO_MSTATUS];
 	if (mstatus_reg->valid) {
@@ -1106,27 +1081,25 @@ static int execute_resume(struct target *target, bool step)
 			cache_set32(target, 1, csrw(S0, CSR_MSTATUS));
 			cache_set_jump(target, 2);
 			cache_set(target, SLOT0, mstatus_user);
-			if (cache_write(target, 4, true) != ERROR_OK) {
+			if (cache_write(target, 4, true) != ERROR_OK)
 				return ERROR_FAIL;
-			}
 		}
 	}
 
 	info->dcsr |= DCSR_EBREAKM | DCSR_EBREAKH | DCSR_EBREAKS | DCSR_EBREAKU;
 	info->dcsr &= ~DCSR_HALT;
 
-	if (step) {
+	if (step)
 		info->dcsr |= DCSR_STEP;
-	} else {
+	else
 		info->dcsr &= ~DCSR_STEP;
-	}
 
 	dram_write32(target, 0, lw(S0, ZERO, DEBUG_RAM_START + 16), false);
 	dram_write32(target, 1, csrw(S0, CSR_DCSR), false);
 	dram_write32(target, 2, fence_i(), false);
 	dram_write_jump(target, 3, false);
 
-	// Write DCSR value, set interrupt and clear haltnot.
+	/* Write DCSR value, set interrupt and clear haltnot. */
 	uint64_t dbus_value = DMCONTROL_INTERRUPT | info->dcsr;
 	dbus_write(target, dram_address(4), dbus_value);
 
@@ -1143,7 +1116,7 @@ static int execute_resume(struct target *target, bool step)
 	return ERROR_OK;
 }
 
-// Execute a step, and wait for reentry into Debug Mode.
+/* Execute a step, and wait for reentry into Debug Mode. */
 static int full_step(struct target *target, bool announce)
 {
 	int result = execute_resume(target, true);
@@ -1158,7 +1131,7 @@ static int full_step(struct target *target, bool announce)
 			break;
 		if (time(NULL) - start > riscv_command_timeout_sec) {
 			LOG_ERROR("Timed out waiting for step to complete."
-                                  "Increase timeout with riscv set_command_timeout_sec");
+					"Increase timeout with riscv set_command_timeout_sec");
 			return ERROR_FAIL;
 		}
 	}
@@ -1200,12 +1173,12 @@ static int update_mstatus_actual(struct target *target)
 {
 	struct reg *mstatus_reg = &target->reg_cache->reg_list[GDB_REGNO_MSTATUS];
 	if (mstatus_reg->valid) {
-		// We previously made it valid.
+		/* We previously made it valid. */
 		return ERROR_OK;
 	}
 
-	// Force reading the register. In that process mstatus_actual will be
-	// updated.
+	/* Force reading the register. In that process mstatus_actual will be
+	 * updated. */
 	get_register(target, 0, GDB_REGNO_MSTATUS);
 	return ERROR_OK;
 }
@@ -1224,9 +1197,8 @@ static int register_read(struct target *target, riscv_reg_t *value, int regnum)
 		return ERROR_FAIL;
 	}
 
-	if (cache_write(target, 4, true) != ERROR_OK) {
+	if (cache_write(target, 4, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	uint32_t exception = cache_get32(target, info->dramsize-1);
 	if (exception) {
@@ -1239,14 +1211,13 @@ static int register_read(struct target *target, riscv_reg_t *value, int regnum)
 	*value = cache_get(target, SLOT0);
 	LOG_DEBUG("reg[%d]=0x%" PRIx64, regnum, *value);
 
-	if (regnum == GDB_REGNO_MSTATUS) {
+	if (regnum == GDB_REGNO_MSTATUS)
 		info->mstatus_actual = *value;
-	}
 
 	return ERROR_OK;
 }
 
-// Write the register. No caching or games.
+/* Write the register. No caching or games. */
 static int register_write(struct target *target, unsigned int number,
 		uint64_t value)
 {
@@ -1270,9 +1241,8 @@ static int register_write(struct target *target, unsigned int number,
 		return ERROR_OK;
 	} else if (number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31) {
 		int result = update_mstatus_actual(target);
-		if (result != ERROR_OK) {
+		if (result != ERROR_OK)
 			return result;
-		}
 		unsigned i = 0;
 		if ((info->mstatus_actual & MSTATUS_FS) == 0) {
 			info->mstatus_actual = set_field(info->mstatus_actual, MSTATUS_FS, 1);
@@ -1281,20 +1251,18 @@ static int register_write(struct target *target, unsigned int number,
 			cache_set(target, SLOT1, info->mstatus_actual);
 		}
 
-		if (riscv_xlen(target) == 32) {
+		if (riscv_xlen(target) == 32)
 			cache_set32(target, i++, flw(number - GDB_REGNO_FPR0, 0, DEBUG_RAM_START + 16));
-		} else {
+		else
 			cache_set32(target, i++, fld(number - GDB_REGNO_FPR0, 0, DEBUG_RAM_START + 16));
-		}
 		cache_set_jump(target, i++);
 	} else if (number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095) {
 		cache_set_load(target, 0, S0, SLOT0);
 		cache_set32(target, 1, csrw(S0, number - GDB_REGNO_CSR0));
 		cache_set_jump(target, 2);
 
-		if (number == GDB_REGNO_MSTATUS) {
+		if (number == GDB_REGNO_MSTATUS)
 			info->mstatus_actual = value;
-		}
 	} else if (number == GDB_REGNO_PRIV) {
 		info->dcsr = set_field(info->dcsr, DCSR_PRV, value);
 		return ERROR_OK;
@@ -1304,9 +1272,8 @@ static int register_write(struct target *target, unsigned int number,
 	}
 
 	cache_set(target, SLOT0, value);
-	if (cache_write(target, info->dramsize - 1, true) != ERROR_OK) {
+	if (cache_write(target, info->dramsize - 1, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	uint32_t exception = cache_get32(target, info->dramsize-1);
 	if (exception) {
@@ -1332,9 +1299,8 @@ static riscv_reg_t get_register(struct target *target, int hartid, int regid)
 		value = info->dpc;
 	} else if (regid >= GDB_REGNO_FPR0 && regid <= GDB_REGNO_FPR31) {
 		int result = update_mstatus_actual(target);
-		if (result != ERROR_OK) {
+		if (result != ERROR_OK)
 			return ~0;
-		}
 		unsigned i = 0;
 		if ((info->mstatus_actual & MSTATUS_FS) == 0) {
 			info->mstatus_actual = set_field(info->mstatus_actual, MSTATUS_FS, 1);
@@ -1343,27 +1309,22 @@ static riscv_reg_t get_register(struct target *target, int hartid, int regid)
 			cache_set(target, SLOT1, info->mstatus_actual);
 		}
 
-		if (riscv_xlen(target) == 32) {
+		if (riscv_xlen(target) == 32)
 			cache_set32(target, i++, fsw(regid - GDB_REGNO_FPR0, 0, DEBUG_RAM_START + 16));
-		} else {
+		else
 			cache_set32(target, i++, fsd(regid - GDB_REGNO_FPR0, 0, DEBUG_RAM_START + 16));
-		}
 		cache_set_jump(target, i++);
 
-		if (cache_write(target, 4, true) != ERROR_OK) {
+		if (cache_write(target, 4, true) != ERROR_OK)
 			return ~0;
-		}
 	} else if (regid == GDB_REGNO_PRIV) {
 		value = get_field(info->dcsr, DCSR_PRV);
-	} else {
-		if (register_read(target, &value, regid) != ERROR_OK) {
-			value = ~0;
-		}
+	} else if (register_read(target, &value, regid) != ERROR_OK) {
+		value = ~0;
 	}
 
-	if (regid == GDB_REGNO_MSTATUS) {
+	if (regid == GDB_REGNO_MSTATUS)
 		target->reg_cache->reg_list[regid].valid = true;
-	}
 
 	return value;
 }
@@ -1372,7 +1333,7 @@ static void set_register(struct target *target, int hartid, int regid,
 		uint64_t value)
 {
 	assert(hartid == 0);
-	// TODO: propagate errors
+	/* TODO: propagate errors */
 	register_write(target, regid, value);
 }
 
@@ -1406,7 +1367,7 @@ static int init_target(struct command_context *cmd_ctx,
 	if (!generic_info->version_specific)
 		return ERROR_FAIL;
 
-	// Assume 32-bit until we discover the real value in examine().
+	/* Assume 32-bit until we discover the real value in examine(). */
 	generic_info->xlen[0] = 32;
 	riscv_init_registers(target);
 
@@ -1490,7 +1451,7 @@ static int step(struct target *target, int current, target_addr_t address,
 
 static int examine(struct target *target)
 {
-	// Don't need to select dbus, since the first thing we do is read dtmcontrol.
+	/* Don't need to select dbus, since the first thing we do is read dtmcontrol. */
 
 	uint32_t dtmcontrol = dtmcontrol_scan(target, 0);
 	LOG_DEBUG("dtmcontrol=0x%x", dtmcontrol);
@@ -1514,7 +1475,7 @@ static int examine(struct target *target)
 	info->addrbits = get_field(dtmcontrol, DTMCONTROL_ADDRBITS);
 	info->dtmcontrol_idle = get_field(dtmcontrol, DTMCONTROL_IDLE);
 	if (info->dtmcontrol_idle == 0) {
-		// Some old SiFive cores don't set idle but need it to be 1.
+		/* Some old SiFive cores don't set idle but need it to be 1. */
 		uint32_t idcode = idcode_scan(target);
 		if (idcode == 0x10e31913)
 			info->dtmcontrol_idle = 1;
@@ -1549,29 +1510,27 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 	}
 
-	// Pretend this is a 32-bit system until we have found out the true value.
+	/* Pretend this is a 32-bit system until we have found out the true value. */
 	r->xlen[0] = 32;
 
-	// Figure out XLEN, and test writing all of Debug RAM while we're at it.
+	/* Figure out XLEN, and test writing all of Debug RAM while we're at it. */
 	cache_set32(target, 0, xori(S1, ZERO, -1));
-	// 0xffffffff  0xffffffff:ffffffff  0xffffffff:ffffffff:ffffffff:ffffffff
+	/* 0xffffffff  0xffffffff:ffffffff  0xffffffff:ffffffff:ffffffff:ffffffff */
 	cache_set32(target, 1, srli(S1, S1, 31));
-	// 0x00000001  0x00000001:ffffffff  0x00000001:ffffffff:ffffffff:ffffffff
+	/* 0x00000001  0x00000001:ffffffff  0x00000001:ffffffff:ffffffff:ffffffff */
 	cache_set32(target, 2, sw(S1, ZERO, DEBUG_RAM_START));
 	cache_set32(target, 3, srli(S1, S1, 31));
-	// 0x00000000  0x00000000:00000003  0x00000000:00000003:ffffffff:ffffffff
+	/* 0x00000000  0x00000000:00000003  0x00000000:00000003:ffffffff:ffffffff */
 	cache_set32(target, 4, sw(S1, ZERO, DEBUG_RAM_START + 4));
 	cache_set_jump(target, 5);
-	for (unsigned i = 6; i < info->dramsize; i++) {
+	for (unsigned i = 6; i < info->dramsize; i++)
 		cache_set32(target, i, i * 0x01020304);
-	}
 
 	cache_write(target, 0, false);
 
-	// Check that we can actually read/write dram.
-	if (cache_check(target) != ERROR_OK) {
+	/* Check that we can actually read/write dram. */
+	if (cache_check(target) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	cache_write(target, 0, true);
 	cache_invalidate(target);
@@ -1599,22 +1558,21 @@ static int examine(struct target *target)
 		LOG_WARNING("Failed to read misa at 0x%x; trying 0x%x.", CSR_MISA,
 				old_csr_misa);
 		if (read_csr(target, &r->misa, old_csr_misa) != ERROR_OK) {
-			// Maybe this is an old core that still has $misa at the old
-			// address.
+			/* Maybe this is an old core that still has $misa at the old
+			 * address. */
 			LOG_ERROR("Failed to read misa at 0x%x.", old_csr_misa);
 			return ERROR_FAIL;
 		}
 	}
 
-	// Update register list to match discovered XLEN/supported extensions.
+	/* Update register list to match discovered XLEN/supported extensions. */
 	riscv_init_registers(target);
 
 	info->never_halted = true;
 
 	int result = riscv011_poll(target);
-	if (result != ERROR_OK) {
+	if (result != ERROR_OK)
 		return result;
-	}
 
 	target_set_examined(target);
 	riscv_set_current_hartid(target, 0);
@@ -1632,41 +1590,40 @@ static riscv_error_t handle_halt_routine(struct target *target)
 
 	scans_t *scans = scans_new(target, 256);
 
-	// Read all GPRs as fast as we can, because gdb is going to ask for them
-	// anyway. Reading them one at a time is much slower.
+	/* Read all GPRs as fast as we can, because gdb is going to ask for them
+	 * anyway. Reading them one at a time is much slower. */
 
-	// Write the jump back to address 1.
+	/* Write the jump back to address 1. */
 	scans_add_write_jump(scans, 1, false);
 	for (int reg = 1; reg < 32; reg++) {
-		if (reg == S0 || reg == S1) {
+		if (reg == S0 || reg == S1)
 			continue;
-		}
 
-		// Write store instruction.
+		/* Write store instruction. */
 		scans_add_write_store(scans, 0, reg, SLOT0, true);
 
-		// Read value.
+		/* Read value. */
 		scans_add_read(scans, SLOT0, false);
 	}
 
-	// Write store of s0 at index 1.
+	/* Write store of s0 at index 1. */
 	scans_add_write_store(scans, 1, S0, SLOT0, false);
-	// Write jump at index 2.
+	/* Write jump at index 2. */
 	scans_add_write_jump(scans, 2, false);
 
-	// Read S1 from debug RAM
+	/* Read S1 from debug RAM */
 	scans_add_write_load(scans, 0, S0, SLOT_LAST, true);
-	// Read value.
+	/* Read value. */
 	scans_add_read(scans, SLOT0, false);
 
-	// Read S0 from dscratch
+	/* Read S0 from dscratch */
 	unsigned int csr[] = {CSR_DSCRATCH, CSR_DPC, CSR_DCSR};
 	for (unsigned int i = 0; i < DIM(csr); i++) {
 		scans_add_write32(scans, 0, csrr(S0, csr[i]), true);
 		scans_add_read(scans, SLOT0, false);
 	}
 
-	// Final read to get the last value out.
+	/* Final read to get the last value out. */
 	scans_add_read32(scans, 4, false);
 
 	int retval = scans_execute(scans);
@@ -1680,8 +1637,8 @@ static riscv_error_t handle_halt_routine(struct target *target)
 	unsigned result = 0;
 	uint64_t value = 0;
 	reg_cache_set(target, 0, 0);
-	// The first scan result is the result from something old we don't care
-	// about.
+	/* The first scan result is the result from something old we don't care
+	 * about. */
 	for (unsigned int i = 1; i < scans->next_scan && dbus_busy == 0; i++) {
 		dbus_status_t status = scans_get_u32(scans, i, DBUS_OP_START,
 				DBUS_OP_SIZE);
@@ -1708,43 +1665,109 @@ static riscv_error_t handle_halt_routine(struct target *target)
 		if (address == 4 || address == 5) {
 			unsigned int reg;
 			switch (result) {
-				case 0: reg = 1; break;
-				case 1: reg = 2; break;
-				case 2: reg = 3; break;
-				case 3: reg = 4; break;
-				case 4: reg = 5; break;
-				case 5: reg = 6; break;
-				case 6: reg = 7; break;
-						// S0
-						// S1
-				case 7: reg = 10; break;
-				case 8: reg = 11; break;
-				case 9: reg = 12; break;
-				case 10: reg = 13; break;
-				case 11: reg = 14; break;
-				case 12: reg = 15; break;
-				case 13: reg = 16; break;
-				case 14: reg = 17; break;
-				case 15: reg = 18; break;
-				case 16: reg = 19; break;
-				case 17: reg = 20; break;
-				case 18: reg = 21; break;
-				case 19: reg = 22; break;
-				case 20: reg = 23; break;
-				case 21: reg = 24; break;
-				case 22: reg = 25; break;
-				case 23: reg = 26; break;
-				case 24: reg = 27; break;
-				case 25: reg = 28; break;
-				case 26: reg = 29; break;
-				case 27: reg = 30; break;
-				case 28: reg = 31; break;
-				case 29: reg = S1; break;
-				case 30: reg = S0; break;
-				case 31: reg = CSR_DPC; break;
-				case 32: reg = CSR_DCSR; break;
+				case 0:
+					reg = 1;
+					break;
+				case 1:
+					reg = 2;
+					break;
+				case 2:
+					reg = 3;
+					break;
+				case 3:
+					reg = 4;
+					break;
+				case 4:
+					reg = 5;
+					break;
+				case 5:
+					reg = 6;
+					break;
+				case 6:
+					reg = 7;
+					break;
+					/* S0 */
+					/* S1 */
+				case 7:
+					reg = 10;
+					break;
+				case 8:
+					reg = 11;
+					break;
+				case 9:
+					reg = 12;
+					break;
+				case 10:
+					reg = 13;
+					break;
+				case 11:
+					reg = 14;
+					break;
+				case 12:
+					reg = 15;
+					break;
+				case 13:
+					reg = 16;
+					break;
+				case 14:
+					reg = 17;
+					break;
+				case 15:
+					reg = 18;
+					break;
+				case 16:
+					reg = 19;
+					break;
+				case 17:
+					reg = 20;
+					break;
+				case 18:
+					reg = 21;
+					break;
+				case 19:
+					reg = 22;
+					break;
+				case 20:
+					reg = 23;
+					break;
+				case 21:
+					reg = 24;
+					break;
+				case 22:
+					reg = 25;
+					break;
+				case 23:
+					reg = 26;
+					break;
+				case 24:
+					reg = 27;
+					break;
+				case 25:
+					reg = 28;
+					break;
+				case 26:
+					reg = 29;
+					break;
+				case 27:
+					reg = 30;
+					break;
+				case 28:
+					reg = 31;
+					break;
+				case 29:
+					reg = S1;
+					break;
+				case 30:
+					reg = S0;
+					break;
+				case 31:
+					reg = CSR_DPC;
+					break;
+				case 32:
+					reg = CSR_DCSR;
+					break;
 				default:
-						 assert(0);
+					assert(0);
 			}
 			if (riscv_xlen(target) == 32) {
 				reg_cache_set(target, reg, data & 0xffffffff);
@@ -1770,7 +1793,7 @@ static riscv_error_t handle_halt_routine(struct target *target)
 		return RE_AGAIN;
 	}
 
-	// TODO: get rid of those 2 variables and talk to the cache directly.
+	/* TODO: get rid of those 2 variables and talk to the cache directly. */
 	info->dpc = reg_cache_get(target, CSR_DPC);
 	info->dcsr = reg_cache_get(target, CSR_DCSR);
 
@@ -1806,8 +1829,8 @@ static int handle_halt(struct target *target, bool announce)
 			break;
 		case DCSR_CAUSE_HWBP:
 			target->debug_reason = DBG_REASON_WPTANDBKPT;
-			// If we halted because of a data trigger, gdb doesn't know to do
-			// the disable-breakpoints-step-enable-breakpoints dance.
+			/* If we halted because of a data trigger, gdb doesn't know to do
+			 * the disable-breakpoints-step-enable-breakpoints dance. */
 			info->need_strict_step = true;
 			break;
 		case DCSR_CAUSE_DEBUGINT:
@@ -1831,9 +1854,8 @@ static int handle_halt(struct target *target, bool announce)
 		riscv_enumerate_triggers(target);
 	}
 
-	if (announce) {
+	if (announce)
 		target_call_event_callbacks(target, TARGET_EVENT_HALTED);
-	}
 
 	const char *cause_string[] = {
 		"none",
@@ -1843,10 +1865,10 @@ static int handle_halt(struct target *target, bool announce)
 		"step",
 		"halt"
 	};
-	// This is logged to the user so that gdb will show it when a user types
-	// 'monitor reset init'. At that time gdb appears to have the pc cached
-	// still so if a user manually inspects the pc it will still have the old
-	// value.
+	/* This is logged to the user so that gdb will show it when a user types
+	 * 'monitor reset init'. At that time gdb appears to have the pc cached
+	 * still so if a user manually inspects the pc it will still have the old
+	 * value. */
 	LOG_USER("halted at 0x%" PRIx64 " due to %s", info->dpc, cause_string[cause]);
 
 	return ERROR_OK;
@@ -1856,12 +1878,11 @@ static int poll_target(struct target *target, bool announce)
 {
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
-	// Inhibit debug logging during poll(), which isn't usually interesting and
-	// just fills up the screen/logs with clutter.
+	/* Inhibit debug logging during poll(), which isn't usually interesting and
+	 * just fills up the screen/logs with clutter. */
 	int old_debug_level = debug_level;
-	if (debug_level >= LOG_LVL_DEBUG) {
+	if (debug_level >= LOG_LVL_DEBUG)
 		debug_level = LOG_LVL_INFO;
-	}
 	bits_t bits = read_bits(target);
 	debug_level = old_debug_level;
 
@@ -1869,11 +1890,10 @@ static int poll_target(struct target *target, bool announce)
 		target->state = TARGET_DEBUG_RUNNING;
 		LOG_DEBUG("debug running");
 	} else if (bits.haltnot && !bits.interrupt) {
-		if (target->state != TARGET_HALTED) {
+		if (target->state != TARGET_HALTED)
 			return handle_halt(target, announce);
-		}
 	} else if (!bits.haltnot && bits.interrupt) {
-		// Target is halting. There is no state for that, so don't change anything.
+		/* Target is halting. There is no state for that, so don't change anything. */
 		LOG_DEBUG("halting");
 	} else if (!bits.haltnot && !bits.interrupt) {
 		target->state = TARGET_RUNNING;
@@ -1916,28 +1936,27 @@ static int riscv011_resume(struct target *target, int current,
 static int assert_reset(struct target *target)
 {
 	riscv011_info_t *info = get_info(target);
-	// TODO: Maybe what I implemented here is more like soft_reset_halt()?
+	/* TODO: Maybe what I implemented here is more like soft_reset_halt()? */
 
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
-	// The only assumption we can make is that the TAP was reset.
+	/* The only assumption we can make is that the TAP was reset. */
 	if (wait_for_debugint_clear(target, true) != ERROR_OK) {
 		LOG_ERROR("Debug interrupt didn't clear.");
 		return ERROR_FAIL;
 	}
 
-	// Not sure what we should do when there are multiple cores.
-	// Here just reset the single hart we're talking to.
+	/* Not sure what we should do when there are multiple cores.
+	 * Here just reset the single hart we're talking to. */
 	info->dcsr |= DCSR_EBREAKM | DCSR_EBREAKH | DCSR_EBREAKS |
 		DCSR_EBREAKU | DCSR_HALT;
-	if (target->reset_halt) {
+	if (target->reset_halt)
 		info->dcsr |= DCSR_NDRESET;
-	} else {
+	else
 		info->dcsr |= DCSR_FULLRESET;
-	}
 	dram_write32(target, 0, lw(S0, ZERO, DEBUG_RAM_START + 16), false);
 	dram_write32(target, 1, csrw(S0, CSR_DCSR), false);
-	// We shouldn't actually need the jump because a reset should happen.
+	/* We shouldn't actually need the jump because a reset should happen. */
 	dram_write_jump(target, 2, false);
 	dram_write32(target, 4, info->dcsr, true);
 	cache_invalidate(target);
@@ -1950,11 +1969,10 @@ static int assert_reset(struct target *target)
 static int deassert_reset(struct target *target)
 {
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
-	if (target->reset_halt) {
+	if (target->reset_halt)
 		return wait_for_state(target, TARGET_HALTED);
-	} else {
+	else
 		return wait_for_state(target, TARGET_RUNNING);
-	}
 }
 
 static int read_memory(struct target *target, target_addr_t address,
@@ -1995,13 +2013,13 @@ static int read_memory(struct target *target, target_addr_t address,
 
 		for (unsigned int j = 0; j < batch_size; j++) {
 			if (i + j == count) {
-				// Just insert a read so we can scan out the last value.
+				/* Just insert a read so we can scan out the last value. */
 				scans_add_read32(scans, 4, false);
 			} else if (i + j >= count + 1) {
-				// And check for errors.
+				/* And check for errors. */
 				scans_add_read32(scans, info->dramsize-1, false);
 			} else {
-				// Write the next address and set interrupt.
+				/* Write the next address and set interrupt. */
 				uint32_t offset = size * (i + j);
 				scans_add_write32(scans, 4, address + offset, true);
 			}
@@ -2033,9 +2051,8 @@ static int read_memory(struct target *target, target_addr_t address,
 			}
 			uint64_t data = scans_get_u64(scans, j, DBUS_DATA_START,
 					DBUS_DATA_SIZE);
-			if (data & DMCONTROL_INTERRUPT) {
+			if (data & DMCONTROL_INTERRUPT)
 				execute_busy++;
-			}
 			if (i + j == count + 2) {
 				result_value = data;
 			} else if (i + j > 1) {
@@ -2058,16 +2075,14 @@ static int read_memory(struct target *target, target_addr_t address,
 			}
 			LOG_DEBUG("j=%d status=%d data=%09" PRIx64, j, status, data);
 		}
-		if (dbus_busy) {
+		if (dbus_busy)
 			increase_dbus_busy_delay(target);
-		}
-		if (execute_busy) {
+		if (execute_busy)
 			increase_interrupt_high_delay(target);
-		}
 		if (dbus_busy || execute_busy) {
 			wait_for_debugint_clear(target, false);
 
-			// Retry.
+			/* Retry. */
 			LOG_INFO("Retrying memory read starting from 0x%" TARGET_PRIxADDR
 					" with more delays", address + size * i);
 		} else {
@@ -2129,21 +2144,19 @@ static int write_memory(struct target *target, target_addr_t address,
 	riscv011_info_t *info = get_info(target);
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
-	// Set up the address.
+	/* Set up the address. */
 	cache_set_store(target, 0, T0, SLOT1);
 	cache_set_load(target, 1, T0, SLOT0);
 	cache_set_jump(target, 2);
 	cache_set(target, SLOT0, address);
-	if (cache_write(target, 5, true) != ERROR_OK) {
+	if (cache_write(target, 5, true) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	uint64_t t0 = cache_get(target, SLOT1);
 	LOG_DEBUG("t0 is 0x%" PRIx64, t0);
 
-	if (setup_write_memory(target, size) != ERROR_OK) {
+	if (setup_write_memory(target, size) != ERROR_OK)
 		return ERROR_FAIL;
-	}
 
 	const unsigned max_batch_size = 256;
 	scans_t *scans = scans_new(target, max_batch_size);
@@ -2156,10 +2169,10 @@ static int write_memory(struct target *target, target_addr_t address,
 
 		for (unsigned int j = 0; j < batch_size; j++) {
 			if (i + j >= count) {
-				// Check for an exception.
+				/* Check for an exception. */
 				scans_add_read32(scans, info->dramsize-1, false);
 			} else {
-				// Write the next value and set interrupt.
+				/* Write the next value and set interrupt. */
 				uint32_t value;
 				uint32_t offset = size * (i + j);
 				switch (size) {
@@ -2209,37 +2222,31 @@ static int write_memory(struct target *target, target_addr_t address,
 					return ERROR_FAIL;
 			}
 			int interrupt = scans_get_u32(scans, j, DBUS_DATA_START + 33, 1);
-			if (interrupt) {
+			if (interrupt)
 				execute_busy++;
-			}
-			if (i + j == count + 1) {
+			if (i + j == count + 1)
 				result_value = scans_get_u32(scans, j, DBUS_DATA_START, 32);
-			}
 		}
-		if (dbus_busy) {
+		if (dbus_busy)
 			increase_dbus_busy_delay(target);
-		}
-		if (execute_busy) {
+		if (execute_busy)
 			increase_interrupt_high_delay(target);
-		}
 		if (dbus_busy || execute_busy) {
 			wait_for_debugint_clear(target, false);
 
-			// Retry.
-			// Set t0 back to what it should have been at the beginning of this
-			// batch.
+			/* Retry.
+			 * Set t0 back to what it should have been at the beginning of this
+			 * batch. */
 			LOG_INFO("Retrying memory write starting from 0x%" TARGET_PRIxADDR
 					" with more delays", address + size * i);
 
 			cache_clean(target);
 
-			if (write_gpr(target, T0, address + size * i) != ERROR_OK) {
+			if (write_gpr(target, T0, address + size * i) != ERROR_OK)
 				goto error;
-			}
 
-			if (setup_write_memory(target, size) != ERROR_OK) {
+			if (setup_write_memory(target, size) != ERROR_OK)
 				goto error;
-			}
 		} else {
 			i += batch_size;
 		}
@@ -2271,8 +2278,7 @@ static int arch_state(struct target *target)
 	return ERROR_OK;
 }
 
-struct target_type riscv011_target =
-{
+struct target_type riscv011_target = {
 	.name = "riscv",
 
 	.init_target = init_target,

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -141,7 +141,7 @@ int riscv_openocd_resume(
 	struct target *target,
 	int current,
 	target_addr_t address,
-	int handle_breakpoints, 
+	int handle_breakpoints,
 	int debug_execution
 );
 

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -2830,8 +2830,8 @@ COMMAND_HANDLER(handle_reg_command)
 
 		retval = reg->type->set(reg, buf);
 		if (retval != ERROR_OK) {
-		        LOG_DEBUG("Couldn't set register %s.", reg->name);
-			free (buf);
+			LOG_DEBUG("Couldn't set register %s.", reg->name);
+			free(buf);
 			return retval;
 		}
 


### PR DESCRIPTION
OpenOCD has a pretty strict style guide, along with a script to enforce it. These changes make our code clean (except for encoding.h, which I'll try to improve enough in its source repo).