### PR TITLE
Propagate error instead of calling abort().

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -42,11 +42,11 @@ bool riscv_batch_full(struct riscv_batch *batch)
 	return batch->used_scans > (batch->allocated_scans - 4);
 }
 
-void riscv_batch_run(struct riscv_batch *batch)
+int riscv_batch_run(struct riscv_batch *batch)
 {
 	if (batch->used_scans == 0) {
 		LOG_DEBUG("Ignoring empty batch.");
-		return;
+		return ERROR_OK;
 	}
 
 	keep_alive();
@@ -63,11 +63,13 @@ void riscv_batch_run(struct riscv_batch *batch)
 	LOG_DEBUG("executing queue");
 	if (jtag_execute_queue() != ERROR_OK) {
 		LOG_ERROR("Unable to execute JTAG queue");
-		abort();
+		return ERROR_FAIL;
 	}
 
 	for (size_t i = 0; i < batch->used_scans; ++i)
 		dump_field(batch->fields + i);
+
+	return ERROR_OK;
 }
 
 void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint64_t data)

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -48,7 +48,7 @@ void riscv_batch_free(struct riscv_batch *batch);
 bool riscv_batch_full(struct riscv_batch *batch);
 
 /* Executes this scan batch. */
-void riscv_batch_run(struct riscv_batch *batch);
+int riscv_batch_run(struct riscv_batch *batch);
 
 /* Adds a DMI write to this batch. */
 void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint64_t data);


### PR DESCRIPTION
As part of this I improved the memory read/write fatal error handling a
bit. Now at least we try to leave autoexec turned off, and will even
restore the temp registers if the situation isn't too hosed for that.

Partly addresses Issue #142

Change-Id: I79fe3f862f11c6d20441f39162423357e73a40c1