### PR TITLE
In dmi_read(), ignore stale data.

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -455,6 +455,9 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	dbus_status_t status;
 	uint16_t address_in;
 
+	// First, discard stale data
+	dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);
+
 	unsigned i = 0;
 	do {
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -459,7 +459,11 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	 * If there happens to be a busy state pending, we will clear it after we
 	 * discover it as part of the NOP scan. */
 	for (unsigned i = 0; i < 256; i++) {
-		dbus_scan(target, NULL, NULL, DBUS_OP_READ, address, 0);
+		status = dbus_scan(target, NULL, NULL, DBUS_OP_READ, address, 0);
+		if (status == DBUS_STATUS_BUSY) {
+			increase_dbus_busy_delay(target);
+			continue;
+		}
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_NOP, address, 0);
 		if (status == DBUS_STATUS_BUSY)
 			increase_dbus_busy_delay(target);

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -455,7 +455,11 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	dbus_status_t status;
 	uint16_t address_in;
 
-	// First, discard stale data
+	// First scan sends the desired address/operation. This is 
+	// slightly inefficient as, if the previous read was to the same
+	// address, one could have simply used the data directly. However,
+	// that data may may have been captured significantly earlier,
+	// and could be considered stale at the start of this operation.
 	dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);
 
 	unsigned i = 0;
@@ -463,7 +467,7 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);
 		if (status == DBUS_STATUS_BUSY)
 			increase_dbus_busy_delay(target);
-	} while (((status == DBUS_STATUS_BUSY) || (address_in != address)) &&
+	} while (((status == DBUS_STATUS_BUSY)) &&
 			i++ < 256);
 
 	if (status != DBUS_STATUS_SUCCESS)

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -455,6 +455,9 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	dbus_status_t status;
 	uint16_t address_in;
 
+	/* Assume dbus is idle and there aren't any busy/error states pending.
+	 * If there happens to be a busy state pending, we will clear it after we
+	 * discover it as part of the NOP scan. */
 	for (unsigned i = 0; i < 256; i++) {
 		dbus_scan(target, NULL, NULL, DBUS_OP_READ, address, 0);
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_NOP, address, 0);


### PR DESCRIPTION
Fixes Issue #39. Reduces performance about 1%.

Change-Id: I3bfc71cb8e632ecce35c6adeb744177300d54b98