### PR TITLE
Propagate register read errors

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -281,7 +281,12 @@ static int riscv_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, char 
 	*hex_reg_list[0] = '\0';
 	for (size_t i = 0; i < n_regs; ++i) {
 		if (riscv_has_register(rtos->target, thread_id, i)) {
-			uint64_t reg_value = riscv_get_register_on_hart(rtos->target, thread_id - 1, i);
+			uint64_t reg_value;
+			int result = riscv_get_register_on_hart(rtos->target, &reg_value,
+					thread_id - 1, i);
+			if (result != ERROR_OK)
+				return JIM_ERR;
+
 			for (size_t byte = 0; byte < xlen / 8; ++byte) {
 				uint8_t reg_byte = reg_value >> (byte * 8);
 				char hex[3] = {'x', 'x', 'x'};

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -47,7 +47,9 @@ int riscv_program_exec(struct riscv_program *p, struct target *t)
 	for (size_t i = GDB_REGNO_ZERO + 1; i <= GDB_REGNO_XPR31; ++i) {
 		if (p->writes_xreg[i]) {
 			LOG_DEBUG("Saving register %d as used by program", (int)i);
-			saved_registers[i] = riscv_get_register(t, i);
+			int result = riscv_get_register(t, &saved_registers[i], i);
+			if (result != ERROR_OK)
+				return result;
 		}
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -30,20 +30,21 @@
 #define DMI_DATA1 (DMI_DATA0 + 1)
 #define DMI_PROGBUF1 (DMI_PROGBUF0 + 1)
 
-static void riscv013_on_step_or_resume(struct target *target, bool step);
+static int riscv013_on_step_or_resume(struct target *target, bool step);
 static int riscv013_step_or_resume_current_hart(struct target *target, bool step);
 static void riscv013_clear_abstract_error(struct target *target);
 
 /* Implementations of the functions in riscv_info_t. */
-static riscv_reg_t riscv013_get_register(struct target *target, int hartid, int regid);
+static int riscv013_get_register(struct target *target,
+		riscv_reg_t *value, int hid, int rid);
 static int riscv013_set_register(struct target *target, int hartid, int regid, uint64_t value);
 static void riscv013_select_current_hart(struct target *target);
 static int riscv013_halt_current_hart(struct target *target);
 static int riscv013_resume_current_hart(struct target *target);
 static int riscv013_step_current_hart(struct target *target);
-static void riscv013_on_halt(struct target *target);
-static void riscv013_on_step(struct target *target);
-static void riscv013_on_resume(struct target *target);
+static int riscv013_on_halt(struct target *target);
+static int riscv013_on_step(struct target *target);
+static int riscv013_on_resume(struct target *target);
 static bool riscv013_is_halted(struct target *target);
 static enum riscv_halt_reason riscv013_halt_reason(struct target *target);
 static int riscv013_write_debug_buffer(struct target *target, unsigned index,
@@ -1855,36 +1856,37 @@ struct target_type riscv013_target = {
 };
 
 /*** 0.13-specific implementations of various RISC-V helper functions. ***/
-static riscv_reg_t riscv013_get_register(struct target *target, int hid, int rid)
+static int riscv013_get_register(struct target *target,
+		riscv_reg_t *value, int hid, int rid)
 {
 	LOG_DEBUG("reading register %s on hart %d", gdb_regno_name(rid), hid);
 
 	riscv_set_current_hartid(target, hid);
 
-	uint64_t out;
 	riscv013_info_t *info = get_info(target);
 
+	int result = ERROR_OK;
 	if (rid <= GDB_REGNO_XPR31) {
-		register_read_direct(target, &out, rid);
+		result = register_read_direct(target, value, rid);
 	} else if (rid == GDB_REGNO_PC) {
-		register_read_direct(target, &out, GDB_REGNO_DPC);
-		LOG_DEBUG("read PC from DPC: 0x%016" PRIx64, out);
+		result = register_read_direct(target, value, GDB_REGNO_DPC);
+		LOG_DEBUG("read PC from DPC: 0x%016" PRIx64, *value);
 	} else if (rid == GDB_REGNO_PRIV) {
 		uint64_t dcsr;
-		register_read_direct(target, &dcsr, GDB_REGNO_DCSR);
-		buf_set_u64((unsigned char *)&out, 0, 8, get_field(dcsr, CSR_DCSR_PRV));
+		result = register_read_direct(target, &dcsr, GDB_REGNO_DCSR);
+		buf_set_u64((unsigned char *)value, 0, 8, get_field(dcsr, CSR_DCSR_PRV));
 	} else {
-		int result = register_read_direct(target, &out, rid);
+		result = register_read_direct(target, value, rid);
 		if (result != ERROR_OK) {
 			LOG_ERROR("Unable to read register %d", rid);
-			out = -1;
+			*value = -1;
 		}
 
 		if (rid == GDB_REGNO_MSTATUS)
-			info->mstatus_actual = out;
+			info->mstatus_actual = *value;
 	}
 
-	return out;
+	return result;
 }
 
 static int riscv013_set_register(struct target *target, int hid, int rid, uint64_t value)
@@ -1969,18 +1971,19 @@ static int riscv013_step_current_hart(struct target *target)
 	return riscv013_step_or_resume_current_hart(target, true);
 }
 
-static void riscv013_on_resume(struct target *target)
+static int riscv013_on_resume(struct target *target)
 {
 	return riscv013_on_step_or_resume(target, false);
 }
 
-static void riscv013_on_step(struct target *target)
+static int riscv013_on_step(struct target *target)
 {
 	return riscv013_on_step_or_resume(target, true);
 }
 
-static void riscv013_on_halt(struct target *target)
+static int riscv013_on_halt(struct target *target)
 {
+	return ERROR_OK;
 }
 
 static bool riscv013_is_halted(struct target *target)
@@ -1995,7 +1998,11 @@ static bool riscv013_is_halted(struct target *target)
 
 static enum riscv_halt_reason riscv013_halt_reason(struct target *target)
 {
-	uint64_t dcsr = riscv_get_register(target, GDB_REGNO_DCSR);
+	riscv_reg_t dcsr;
+	int result = register_read_direct(target, &dcsr, GDB_REGNO_DCSR);
+	if (result != ERROR_OK)
+		return RISCV_HALT_UNKNOWN;
+
 	switch (get_field(dcsr, CSR_DCSR_CAUSE)) {
 	case CSR_DCSR_CAUSE_SWBP:
 	case CSR_DCSR_CAUSE_TRIGGER:
@@ -2064,7 +2071,7 @@ int riscv013_dmi_write_u64_bits(struct target *target)
 }
 
 /* Helper Functions. */
-static void riscv013_on_step_or_resume(struct target *target, bool step)
+static int riscv013_on_step_or_resume(struct target *target, bool step)
 {
 	struct riscv_program program;
 	riscv_program_init(&program, target);
@@ -2073,12 +2080,15 @@ static void riscv013_on_step_or_resume(struct target *target, bool step)
 		LOG_ERROR("Unable to execute fence.i");
 
 	/* We want to twiddle some bits in the debug CSR so debugging works. */
-	uint64_t dcsr = riscv_get_register(target, GDB_REGNO_DCSR);
+	riscv_reg_t dcsr;
+	int result = register_read_direct(target, &dcsr, GDB_REGNO_DCSR);
+	if (result != ERROR_OK)
+		return result;
 	dcsr = set_field(dcsr, CSR_DCSR_STEP, step);
 	dcsr = set_field(dcsr, CSR_DCSR_EBREAKM, 1);
 	dcsr = set_field(dcsr, CSR_DCSR_EBREAKS, 1);
 	dcsr = set_field(dcsr, CSR_DCSR_EBREAKU, 1);
-	riscv_set_register(target, GDB_REGNO_DCSR, dcsr);
+	return riscv_set_register(target, GDB_REGNO_DCSR, dcsr);
 }
 
 static int riscv013_step_or_resume_current_hart(struct target *target, bool step)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -88,7 +88,8 @@ typedef struct {
 
 	/* Helper functions that target the various RISC-V debug spec
 	 * implementations. */
-	riscv_reg_t (*get_register)(struct target *, int hartid, int regid);
+	int (*get_register)(struct target *target,
+		riscv_reg_t *value, int hid, int rid);
 	int (*set_register)(struct target *, int hartid, int regid,
 			uint64_t value);
 	void (*select_current_hart)(struct target *);
@@ -96,9 +97,9 @@ typedef struct {
 	int (*halt_current_hart)(struct target *);
 	int (*resume_current_hart)(struct target *target);
 	int (*step_current_hart)(struct target *target);
-	void (*on_halt)(struct target *target);
-	void (*on_resume)(struct target *target);
-	void (*on_step)(struct target *target);
+	int (*on_halt)(struct target *target);
+	int (*on_resume)(struct target *target);
+	int (*on_step)(struct target *target);
 	enum riscv_halt_reason (*halt_reason)(struct target *target);
 	int (*write_debug_buffer)(struct target *target, unsigned index,
 			riscv_insn_t d);
@@ -205,8 +206,10 @@ bool riscv_has_register(struct target *target, int hartid, int regid);
  * are zero extended to 64 bits.  */
 int riscv_set_register(struct target *target, enum gdb_regno i, riscv_reg_t v);
 int riscv_set_register_on_hart(struct target *target, int hid, enum gdb_regno rid, uint64_t v);
-riscv_reg_t riscv_get_register(struct target *target, enum gdb_regno i);
-riscv_reg_t riscv_get_register_on_hart(struct target *target, int hid, enum gdb_regno rid);
+int riscv_get_register(struct target *target, riscv_reg_t *value,
+		enum gdb_regno r);
+int riscv_get_register_on_hart(struct target *target, riscv_reg_t *value,
+		int hartid, enum gdb_regno regid);
 
 /* Checks the state of the current hart -- "is_halted" checks the actual
  * on-device register. */


### PR DESCRIPTION
Let the caller know when reading a register failed.

Add code that temporarily changes mstatus if an FPR is read without any F bits set. (The same change is not necessary for writing, because in that case the hardware will automatically set the F bit.)

Fixes Issue #108