### PR TITLE
Track misa per-hart even in -rtos mode

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1572,11 +1572,11 @@ static int examine(struct target *target)
 	}
 	LOG_DEBUG("Discovered XLEN is %d", riscv_xlen(target));
 
-	if (read_csr(target, &r->misa, CSR_MISA) != ERROR_OK) {
+	if (read_csr(target, &r->misa[0], CSR_MISA) != ERROR_OK) {
 		const unsigned old_csr_misa = 0xf10;
 		LOG_WARNING("Failed to read misa at 0x%x; trying 0x%x.", CSR_MISA,
 				old_csr_misa);
-		if (read_csr(target, &r->misa, old_csr_misa) != ERROR_OK) {
+		if (read_csr(target, &r->misa[0], old_csr_misa) != ERROR_OK) {
 			/* Maybe this is an old core that still has $misa at the old
 			 * address. */
 			LOG_ERROR("Failed to read misa at 0x%x.", old_csr_misa);
@@ -1598,7 +1598,7 @@ static int examine(struct target *target)
 	for (size_t i = 0; i < 32; ++i)
 		reg_cache_set(target, i, -1);
 	LOG_INFO("Examined RISCV core; XLEN=%d, misa=0x%" PRIx64,
-			riscv_xlen(target), r->misa);
+			riscv_xlen(target), r->misa[0]);
 
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -37,8 +37,6 @@ enum riscv_halt_reason {
 typedef struct {
 	unsigned dtm_version;
 
-	riscv_reg_t misa;
-
 	struct command_context *cmd_ctx;
 	void *version_specific;
 
@@ -68,6 +66,7 @@ typedef struct {
 
 	/* It's possible that each core has a different supported ISA set. */
 	int xlen[RISCV_MAX_HARTS];
+	riscv_reg_t misa[RISCV_MAX_HARTS];
 
 	/* The number of triggers per hart. */
 	unsigned trigger_count[RISCV_MAX_HARTS];
@@ -183,7 +182,7 @@ int riscv_resume_one_hart(struct target *target, int hartid);
  * then the only hart. */
 int riscv_step_rtos_hart(struct target *target);
 
-bool riscv_supports_extension(struct target *target, char letter);
+bool riscv_supports_extension(struct target *target, int hartid, char letter);
 
 /* Returns XLEN for the given (or current) hart. */
 int riscv_xlen(const struct target *target);


### PR DESCRIPTION
This works around some side effects of the -rtos hack, namely that we
were unable to set hardware breakpoints on harts whose misa differed
from the first one. There may be other bugs like this one lurking
elsewhere. The only proper solution is for gdb to have a better user
interface when talking to a server that exposes multiple targets, but
that's a very big project.

This fixes #194.