### PR TITLE
complete reset before writing to hartsel field

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1164,8 +1164,10 @@ static int examine(struct target *target)
 	}
 
 	/* Reset the Debug Module. */
+	dmi_write(target, DMI_DMCONTROL, 0);
+	dmi_write(target, DMI_DMCONTROL, DMI_DMCONTROL_DMACTIVE);
+
 	uint32_t max_hartsel_mask = ((1L<<10)-1) << DMI_DMCONTROL_HARTSEL_OFFSET;
-	dmi_write(target, DMI_DMCONTROL, max_hartsel_mask);
 	dmi_write(target, DMI_DMCONTROL, max_hartsel_mask | DMI_DMCONTROL_DMACTIVE);
 	uint32_t dmcontrol = dmi_read(target, DMI_DMCONTROL);
 


### PR DESCRIPTION
This PR fixes the bug introduced in #198 . Debug controller implementation requires dmactive bit to be set before accessing other fields in dmcontrol.