### PR TITLE
target/riscv: add some switch fallthrough comments

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -603,6 +603,7 @@ static riscv_reg_t read_abstract_arg(struct target *target, unsigned index)
 			return ~0;
 		case 64:
 			value |= ((uint64_t) dmi_read(target, DMI_DATA0 + offset + 1)) << 32;
+			/* falls through */
 		case 32:
 			value |= dmi_read(target, DMI_DATA0 + offset);
 	}
@@ -620,6 +621,7 @@ static int write_abstract_arg(struct target *target, unsigned index,
 			return ~0;
 		case 64:
 			dmi_write(target, DMI_DATA0 + offset + 1, value >> 32);
+			/* falls through */
 		case 32:
 			dmi_write(target, DMI_DATA0 + offset, value);
 	}
@@ -1414,11 +1416,14 @@ static void write_to_buf(uint8_t *buffer, uint64_t value, unsigned size)
 			buffer[6] = value >> 48;
 			buffer[5] = value >> 40;
 			buffer[4] = value >> 32;
+			/* falls through */
 		case 4:
 			buffer[3] = value >> 24;
 			buffer[2] = value >> 16;
+			/* falls through */
 		case 2:
 			buffer[1] = value >> 8;
+			/* falls through */
 		case 1:
 			buffer[0] = value;
 			break;


### PR DESCRIPTION
This PR adds some comments that prevent gcc 7 errors like:

```
src/target/riscv/riscv-013.c: In function ‘read_abstract_arg’:
src/target/riscv/riscv-013.c:605:10: error: this statement may fall through [-Werror=implicit-fallthrough=]
    value |= ((uint64_t) dmi_read(target, DMI_DATA0 + offset + 1)) << 32;
          ^~
src/target/riscv/riscv-013.c:606:3: note: here
   case 32:
   ^~~~
```