### PR TITLE
Don't error if hart select isn't implemented.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1706,7 +1706,7 @@ int riscv_set_current_hartid(struct target *target, int hartid)
 {
 	RISCV_INFO(r);
 	if (!r->select_current_hart)
-		return ERROR_FAIL;
+		return ERROR_OK;
 
 	int previous_hartid = riscv_current_hartid(target);
 	r->current_hartid = hartid;


### PR DESCRIPTION
It's not implemented for 0.11 because we don't need it. Returning error
caused 0.11 targets to not be debuggable since change
848062d0d11679de25be573981df45e2c4880db8.

Change-Id: I8b04a1fcf3c3e8bf8340cbf39aaf475d2a213519