### PR TITLE
Disable the DM when OpenOCD exits.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1334,6 +1334,9 @@ int wait_for_authbusy(struct target *target, uint32_t *dmstatus)
 static void deinit_target(struct target *target)
 {
 	LOG_DEBUG("riscv_deinit_target()");
+
+	dmi_write(target, DMI_DMCONTROL, 0);
+
 	riscv_info_t *info = (riscv_info_t *) target->arch_info;
 	free(info->version_specific);
 	/* TODO: free register arch_info */


### PR DESCRIPTION
gdb/OpenOCD already remove all the breakpoints when exiting, so I think
this is all we need to do to restore the hart to the state it was in
before connecting.

Issue #200.

Change-Id: Ibcde7a3b68d221dd2718b8b51dfc7946350a8fcb