### PR TITLE
Update debug defines to match spec

### DIFF
--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -7,7 +7,7 @@ struct riscv_program;
 #include "opcodes.h"
 #include "gdb_regs.h"
 
-/* The register cache is staticly allocated. */
+/* The register cache is statically allocated. */
 #define RISCV_MAX_HARTS 32
 #define RISCV_MAX_REGISTERS 5000
 #define RISCV_MAX_TRIGGERS 32


### PR DESCRIPTION
The main difference is we need to deal with hartsello/hartselhi. (Note
that there's a compile-time limit to 16 harts, but that can be changed.)
My largest target has 4 harts, so I can't tell how well this really
works. But it doesn't break anything.

Fixes #240.

Change-Id: Ie1a2a789b5e00f55174994568749da1cf3a33b92