### PR TITLE
Mimic openrisc Makefile structure

### DIFF
--- a/src/target/Makefile.am
+++ b/src/target/Makefile.am
@@ -4,7 +4,9 @@ else
 OOCD_TRACE_FILES =
 endif
 
-%C%_libtarget_la_LIBADD = %D%/openrisc/libopenrisc.la
+%C%_libtarget_la_LIBADD = %D%/openrisc/libopenrisc.la \
+	%D%/riscv/libriscv.la
+
 
 STARTUP_TCL_SRCS += %D%/startup.tcl
 
@@ -21,7 +23,6 @@ noinst_LTLIBRARIES += %D%/libtarget.la
 	$(NDS32_SRC) \
 	$(STM8_SRC) \
 	$(INTEL_IA32_SRC) \
-	$(RISCV_SRC) \
 	%D%/avrt.c \
 	%D%/dsp563xx.c \
 	%D%/dsp563xx_once.c \
@@ -137,14 +138,6 @@ INTEL_IA32_SRC = \
 	%D%/lakemont.c \
 	%D%/x86_32_common.c
 
-RISCV_SRC = \
-	%D%/riscv/riscv-011.c \
-	%D%/riscv/riscv-013.c \
-	%D%/riscv/riscv.c \
-	%D%/riscv/riscv_semihosting.c \
-	%D%/riscv/program.c \
-	%D%/riscv/batch.c
-
 %C%_libtarget_la_SOURCES += \
 	%D%/algorithm.h \
 	%D%/arm.h \
@@ -227,3 +220,4 @@ RISCV_SRC = \
 	%D%/arm_cti.h
 
 include %D%/openrisc/Makefile.am
+include %D%/riscv/Makefile.am

--- a/src/target/riscv/Makefile.am
+++ b/src/target/riscv/Makefile.am
@@ -1,0 +1,16 @@
+noinst_LTLIBRARIES += %D%/libriscv.la
+%C%_libriscv_la_SOURCES = \
+       %D%/asm.h \
+       %D%/batch.h \
+       %D%/debug_defines.h \
+       %D%/encoding.h \
+       %D%/gdb_regs.h \
+       %D%/opcodes.h \
+       %D%/program.h \
+       %D%/riscv.h \
+       %D%/batch.c \
+       %D%/program.c \
+       %D%/riscv-011.c \
+       %D%/riscv-013.c \
+       %D%/riscv.c \
+       %D%/riscv_semihosting.c


### PR DESCRIPTION
That's better than inventing our own. Also this fixes a build issue in
the official OpenOCD regression build.

Change-Id: I042faa5b93b26e6f6b2d62bee62f21474ec74131