### PR TITLE
Switch active rtos thread on any hart halt.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1067,6 +1067,7 @@ int riscv_openocd_poll(struct target *target)
 	if (riscv_rtos_enabled(target)) {
 		target->rtos->current_threadid = halted_hart + 1;
 		target->rtos->current_thread = halted_hart + 1;
+		riscv_set_rtos_hartid(target, halted_hart);
 	}
 
 	target->state = TARGET_HALTED;


### PR DESCRIPTION
When openocd runs in rtos mode there is a miscommunication between openocd and gdb in the situation when one of harts hits breakpoint. Gdb expects that active thread is switched to the hart that was halted, but openocd keeps previous active thread. So the following incorrect situation takes place: after a continue command several harts simultaneously hit a breakpoint; openocd notifies gdb, that some thread is at breakpoint; we command to continue once again; gdb steps hart which was on a breakpoint and send a continue to openocd; it immediately halts on another hart but previous hart could have a time to execute several instructions. Then gdb is thinking that it is reading a pc of halted hart, reads it on previous hart and shows the state of wrong thread. The following log illustrates such situation:

    (gdb) file /tmp/spike64ima-2-rtos_multicore-64_PdprHh
    Reading symbols from /tmp/spike64ima-2-rtos_multicore-64_PdprHh...done.
    (gdb) info threads 
      Id   Target Id         Frame 
    * 1    Thread 1 (Name: Hart 0, RV64) 0x0000000080000e50 in ?? ()
      2    Thread 2 (Name: Hart 1, RV64) 0x0000000080000e20 in ?? ()
    (gdb) load
    Loading section .text, size 0xd68 lma 0x80000000
    Loading section .sdata, size 0x4 lma 0x80000d68
    Start address 0x80000000, load size 3436
    Transfer rate: 46 KB/sec, 1718 bytes/write.
    (gdb) thread 1
    [Switching to thread 1 (Thread 1)]
    #0  _start () at debug/programs/entry.S:18
    18        j handle_reset
    (gdb) p/x $pc=_start
    $1 = 0x80000000
    (gdb) thread 2
    [Switching to thread 2 (Thread 2)]
    #0  0x0000000080000e20 in ?? ()
    (gdb) p/x $pc=_start
    $2 = 0x80000000
    (gdb) b set_trap_handler
    Breakpoint 1 at 0x80000c1c: file debug/programs/init.c, line 10.
    (gdb) c
    Continuing.
    
    Thread 2 hit Breakpoint 1, set_trap_handler (handler=0x800008a0 <increment_count>) at debug/programs/init.c:10
    10          unsigned hartid = csr_read(mhartid);
    (gdb) c
    Continuing.
    
    Thread 1 received signal SIGTRAP, Trace/breakpoint trap.
    [Switching to Thread 1]
    0x0000000080000b08 in main () at debug/programs/multicore.c:81
    81                      buf[i] = 'A' + ((i + hartid + hart_count[hartid]) % 26);
    (gdb) 

Actually it was thread 2 that is halted on pc 0x80000b08 and thread 1 - on 0x80000c1c, which is on a breakpoint.
And fragment from openocd log:

    Debug: 29034 71419 riscv.c:976 riscv_poll_hart():   triggered a halt
    Debug: 29048 71420 riscv.c:1012 riscv_openocd_poll():   hart 0 halted
    Debug: 29049 71420 riscv.c:1587 riscv_halt_one_hart(): halting hart 0
    Debug: 29062 71420 riscv.c:1591 riscv_halt_one_hart():   hart 0 requested halt, but was already halted
    Debug: 29063 71420 riscv.c:1587 riscv_halt_one_hart(): halting hart 1
    Debug: 29076 71421 riscv-013.c:2732 riscv013_halt_current_hart(): halting hart 1
    ...
    Debug: 29154 71428 target.c:1550 target_call_event_callbacks(): target event 0 (gdb-halt)
    Debug: 29155 71428 riscv_debug.c:42 riscv_update_threads(): Updating the RISC-V Hart List
    Debug: 29156 71428 gdb_server.c:398 gdb_put_packet_inner(): sending packet '$T05thread:0000000000000001;#a7'
    Debug: 29157 71428 target.c:1550 target_call_event_callbacks(): target event 1 (halted)
    Debug: 29158 71428 target.c:1550 target_call_event_callbacks(): target event 6 (gdb-end)
    Debug: 29159 71428 gdb_server.c:3138 gdb_input_inner(): received packet: 'p20'
    Debug: 29160 71428 riscv.c:776 riscv_get_gdb_reg_list(): reg_class=0
    Debug: 29161 71428 riscv.c:777 riscv_get_gdb_reg_list(): rtos_hartid=1 current_hartid=0
    Debug: 29162 71428 riscv.c:1697 riscv_set_current_hartid(): setting hartid to 1, was 0
    ...
    Debug: 29171 71429 riscv-013.c:2659 riscv013_get_register(): reading register pc on hart 1

Please note that the harts are numbered from 0 while threads - from 1.

After a current fix everything works as expected:

    (gdb) file /tmp/spike64ima-2-rtos_multicore-64_PdprHh
    Reading symbols from /tmp/spike64ima-2-rtos_multicore-64_PdprHh...done.
    (gdb) info threads 
      Id   Target Id         Frame 
    * 1    Thread 1 (Name: Hart 0, RV64) 0x0000000000001000 in ?? ()
      2    Thread 2 (Name: Hart 1, RV64) 0x0000000000001000 in ?? ()
    (gdb) load
    Loading section .text, size 0xd68 lma 0x80000000
    Loading section .sdata, size 0x4 lma 0x80000d68
    Start address 0x80000000, load size 3436
    Transfer rate: 55 KB/sec, 1718 bytes/write.
    (gdb) thread 1
    [Switching to thread 1 (Thread 1)]
    #0  _start () at debug/programs/entry.S:18
    18        j handle_reset
    (gdb) p/x $pc=_start
    $3 = 0x80000000
    (gdb) thread 2
    [Switching to thread 2 (Thread 2)]
    #0  0x0000000000001000 in ?? ()
    (gdb) p/x $pc=_start
    $4 = 0x80000000
    (gdb) b set_trap_handler
    Breakpoint 4 at 0x80000c1c: file debug/programs/init.c, line 10.
    (gdb) c
    Continuing.
    
    Thread 2 hit Breakpoint 4, set_trap_handler (handler=0x800008a0 <increment_count>) at debug/programs/init.c:10
    10          unsigned hartid = csr_read(mhartid);
    (gdb) c
    Continuing.
    [Switching to Thread 1]
    
    Thread 1 hit Breakpoint 4, set_trap_handler (handler=0x800008a0 <increment_count>) at debug/programs/init.c:10
    10          unsigned hartid = csr_read(mhartid);
    (gdb) 

This test I will add to the riscv-tests/debug.
