### PR TITLE
Handle hardware watchpoints hit by RV32 loads and stores

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1838,7 +1838,7 @@ static int handle_halt(struct target *target, bool announce)
 			target->debug_reason = DBG_REASON_BREAKPOINT;
 			break;
 		case DCSR_CAUSE_HWBP:
-			target->debug_reason = DBG_REASON_WPTANDBKPT;
+			target->debug_reason = DBG_REASON_WATCHPOINT;
 			/* If we halted because of a data trigger, gdb doesn't know to do
 			 * the disable-breakpoints-step-enable-breakpoints dance. */
 			info->need_strict_step = true;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -652,7 +652,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 	riscv_reg_t dpc;
 	riscv_get_register(target, &dpc, GDB_REGNO_DPC);
 	const uint8_t length = 4;
-	LOG_DEBUG("dpc is %lx", dpc);
+	LOG_DEBUG("dpc is 0x%" PRIx64, dpc);
 
 	/* fetch the instruction at dpc */
 	uint8_t buffer[length];
@@ -691,7 +691,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 		if (imm & (1 << 11))
 			imm |= 0xf000;
 		mem_addr += imm;
-		LOG_DEBUG("memory address=%lx", mem_addr);
+		LOG_DEBUG("memory address=0x%" PRIx64, mem_addr);
 	} else {
 		LOG_DEBUG("%x is not a load or store", instruction);
 		return ERROR_FAIL;
@@ -700,7 +700,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 	while (wp) {
 		if (wp->address == mem_addr) {
 			*hit_watchpoint = wp;
-			LOG_DEBUG("Hit address=%lx", wp->address);
+			LOG_DEBUG("Hit address=%" PRIx64, wp->address);
 			return ERROR_OK;
 		}
 		wp = wp->next;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -667,7 +667,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 	/* fetch the instruction at dpc */
 	uint8_t buffer[length];
 	if (target_read_buffer(target, dpc, length, buffer) != ERROR_OK) {
-		LOG_ERROR("Failed to read instruction at dpc 0x%" TARGET_PRIxADDR, dpc);
+		LOG_ERROR("Failed to read instruction at dpc 0x%" PRIx64, dpc);
 		return ERROR_FAIL;
 	}
 
@@ -711,7 +711,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 		/*TODO support length/mask */
 		if (wp->address == mem_addr) {
 			*hit_watchpoint = wp;
-			LOG_DEBUG("Hit address=%" PRIx64, wp->address);
+			LOG_DEBUG("Hit address=%" TARGET_PRIxADDR, wp->address);
 			return ERROR_OK;
 		}
 		wp = wp->next;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -643,7 +643,8 @@ int riscv_remove_watchpoint(struct target *target,
 	return ERROR_OK;
 }
 
-int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoint) {
+int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoint)
+{
 	struct watchpoint *wp = target->watchpoints;
 
 	LOG_DEBUG("Current hartid = %d", riscv_current_hartid(target));
@@ -653,7 +654,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 	const uint8_t length = 4;
 	LOG_DEBUG("dpc is %lx", dpc);
 
-       /* fetch the instruction at dpc */
+	/* fetch the instruction at dpc */
 	uint8_t buffer[length];
 	if (target_read_buffer(target, dpc, length, buffer) != ERROR_OK) {
 		LOG_ERROR("Failed to read instruction at dpc 0x%" TARGET_PRIxADDR, dpc);
@@ -662,7 +663,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 
 	uint32_t instruction = 0;
 
-	for (int i=0; i<length; i++) {
+	for (int i = 0; i < length; i++) {
 		LOG_DEBUG("Next byte is %x", buffer[i]);
 		instruction += (buffer[i] << 8 * i);
 	}
@@ -682,8 +683,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 		if (opcode == MATCH_SB) {
 			LOG_DEBUG("%x is store instruction", instruction);
 			imm = ((instruction & 0xf80) >> 7) | ((instruction & 0xfe000000) >> 20);
-		}
-		else {
+		} else {
 			LOG_DEBUG("%x is load instruction", instruction);
 			imm = (instruction & 0xfff00000) >> 20;
 		}
@@ -692,8 +692,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 			imm |= 0xf000;
 		mem_addr += imm;
 		LOG_DEBUG("memory address=%lx", mem_addr);
-	}
-	else {
+	} else {
 		LOG_DEBUG("%x is not a load or store", instruction);
 		return ERROR_FAIL;
 	}

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -253,6 +253,7 @@ int riscv_remove_breakpoint(struct target *target,
 int riscv_add_watchpoint(struct target *target, struct watchpoint *watchpoint);
 int riscv_remove_watchpoint(struct target *target,
 		struct watchpoint *watchpoint);
+int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_wp_address);
 
 int riscv_init_registers(struct target *target);
 


### PR DESCRIPTION
GDB does not report hardware watchpoints correctly when they are hit because OpenOCD does not give enough information. GDB should report the hit variable and its old and new value, but currently we just get a SIGTRAP (see examples below).

Here is an example of the failure from the GDB test suite:
```
(gdb) break main
Breakpoint 1 at 0x40400072: file /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c, line 33.
(gdb) target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
0x4040088a in ?? ()
(gdb) monitor reset halt
JTAG tap: riscv.cpu tap/device found: 0x20000001 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x2)
(gdb) monitor flash protect 0 64 last off
cleared protection for sectors 64 through 255 on flash bank 0
(gdb) load 
Loading section .init, size 0x6c lma 0x40400000
Loading section .text, size 0x650 lma 0x4040006c
Loading section .rodata, size 0x54 lma 0x404006bc
Loading section .eh_frame, size 0x2c lma 0x40400710
Loading section .data, size 0x444 lma 0x4040073c
Start address 0x40400000, load size 2944
Transfer rate: 4 KB/sec, 588 bytes/write.
(gdb) continue
Continuing.
Note: automatically using hardware breakpoints for read-only addresses.

Breakpoint 1, main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:33
33	  for (count = 0; count < 4; count++) {
(gdb) watch ival1
Hardware watchpoint 2: ival1
(gdb) watch ival3
Hardware watchpoint 3: ival3
(gdb) cont
Continuing.

Program received signal SIGTRAP, Trace/breakpoint trap.
0x40400088 in main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:34
34	    ival1 = count; ival2 = count;
(gdb) FAIL: gdb.base/watchpoints.exp: watchpoint hit, first time
cont
Continuing.

Program received signal SIGTRAP, Trace/breakpoint trap.
0x404000a4 in main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:35
35	    ival3 = count; ival4 = count;
(gdb) FAIL: gdb.base/watchpoints.exp: watchpoint hit, first time
info break
Num     Type           Disp Enb Address    What
1       breakpoint     keep y   0x40400072 in main at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:33
	breakpoint already hit 1 time
2       hw watchpoint  keep y              ival1
3       hw watchpoint  keep y              ival3
(gdb) FAIL: gdb.base/watchpoints.exp: watchpoint hit count is 1
cont
Continuing.

Program received signal SIGTRAP, Trace/breakpoint trap.
0x40400088 in main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:34
34	    ival1 = count; ival2 = count;
(gdb) FAIL: gdb.base/watchpoints.exp: watchpoint ival1 hit, second time
```

and after the fix:

```
(gdb) break main
Breakpoint 1 at 0x40400072: file /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c, line 33.
(gdb) target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
0x4040088a in ?? ()
(gdb) monitor reset halt
JTAG tap: riscv.cpu tap/device found: 0x20000001 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x2)
(gdb) monitor flash protect 0 64 last off
cleared protection for sectors 64 through 255 on flash bank 0
(gdb) load 
Loading section .init, size 0x6c lma 0x40400000
Loading section .text, size 0x650 lma 0x4040006c
Loading section .rodata, size 0x54 lma 0x404006bc
Loading section .eh_frame, size 0x2c lma 0x40400710
Loading section .data, size 0x444 lma 0x4040073c
Start address 0x40400000, load size 2944
Transfer rate: 4 KB/sec, 588 bytes/write.
(gdb) continue
Continuing.
Note: automatically using hardware breakpoints for read-only addresses.

Breakpoint 1, main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:33
33	  for (count = 0; count < 4; count++) {
(gdb) watch ival1
Hardware watchpoint 2: ival1
(gdb) watch ival3
Hardware watchpoint 3: ival3
(gdb) cont
Continuing.

Hardware watchpoint 2: ival1

Old value = -1
New value = 0
0x40400088 in main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:34
34	    ival1 = count; ival2 = count;
(gdb) PASS: gdb.base/watchpoints.exp: watchpoint hit, first time
cont
Continuing.

Hardware watchpoint 3: ival3

Old value = -1
New value = 0
0x404000a4 in main () at /home/craig/work/projects/sifive/testing-public/gdb/gdb/testsuite/gdb.base/watchpoints.c:35
35	    ival3 = count; ival4 = count;
(gdb) PASS: gdb.base/watchpoints.exp: watchpoint hit, first time
```

OpenOCD requires the target-specific hit_watchpoint function implemented by this PR to tell GDB which data address has been hit. Ideally, we would use the 'hit' bit to work out which trigger was hit, but this is optional and also legacy hardware will not support it. Alternatively, we can decode the instruction at dpc and find out which memory address it accesses.
  
This PR adds support for RV32I load and store instructions and could be extended for additional instructions in the future.

Note that watchpoints on bitfields were not working previously and still do not work, however, the behaviour has changed. Suppose ```q``` is a bitfield and we ```watch q.c```, previously every single line in the code below would be hit with a SIGTRAP in GDB. Now, the watchpoint on ```q.c``` will not trigger at all. If anyone was relying on this already broken functionality, they can simply do ```watch q``` which will trigger on every line as before *and* print the values of the bitfield rather than a SIGTRAP, which is more useful.

```
  q.a = 1;
  q.b = 2;
  q.c = 3;
  q.d = 4;
  q.e = 5;
```