### PR TITLE
Handle the qC packet

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -126,7 +126,7 @@ static int riscv_gdb_thread_packet(struct connection *connection, const char *pa
 
 		if (strncmp(packet, "qC", 2) == 0) {
 			char rep_str[32];
-			snprintf(rep_str, 32, "QC%d", rtos->current_threadid);
+			snprintf(rep_str, 32, "QC%" PRIx64, rtos->current_threadid);
 			gdb_put_packet(connection, rep_str, strlen(rep_str));
 			return ERROR_OK;
 		}

--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -124,6 +124,13 @@ static int riscv_gdb_thread_packet(struct connection *connection, const char *pa
 			return ERROR_OK;
 		}
 
+		if (strncmp(packet, "qC", 2) == 0) {
+			char rep_str[32];
+			snprintf(rep_str, 32, "QC%d", rtos->current_threadid);
+			gdb_put_packet(connection, rep_str, strlen(rep_str));
+			return ERROR_OK;
+		}
+
 		return GDB_THREAD_PACKET_NOT_CONSUMED;
 
 	case 'Q':


### PR DESCRIPTION
GDB sends the qC packet to query the current OpenOCD thread. The packet gets sent after ```target remote :port``` and if GDB receives a thread id, it switches to that thread, otherwise it defaults to thread 1.

The following examples show how this can be tested - they are from a test I have written for the GDB test suite.

Without qC packet handling, GDB defaults to thread 1:
```
(gdb) target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x00007fff404005c6 in ?? ()
(gdb) info threads
  Id   Target Id                     Frame 
* 1    Thread 1 (Name: Hart 0, RV32) 0x00007fff404005c6 in ?? ()
  2    Thread 2 (Name: Hart 1, RV32) 0x00007fff404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: Start on thread 1
thread 2
[Switching to thread 2 (Thread 2)]
#0  0x00007fff404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: Switch to thread 2
info threads
  Id   Target Id                     Frame 
  1    Thread 1 (Name: Hart 0, RV32) 0x00007fff404005c6 in ?? ()
* 2    Thread 2 (Name: Hart 1, RV32) 0x00007fff404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: info threads: current thread is 2
disconnect
Ending remote debugging.
(gdb) PASS: gdb.riscv/connect-active-thread.exp: disconnect
target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x00007fff404005c6 in ?? ()
(gdb) info threads
  Id   Target Id                     Frame 
* 1    Thread 1 (Name: Hart 0, RV32) 0x00007fff404005c6 in ?? ()
  2    Thread 2 (Name: Hart 1, RV32) 0x00007fff404005c6 in ?? ()
(gdb) FAIL: gdb.riscv/connect-active-thread.exp: Current thread is 2 after reconnecting to remote target
```

With qC packet handling, GDB switches to the correct thread:
```
(gdb) target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x00007ffe404005c6 in ?? ()
(gdb) info threads
  Id   Target Id                     Frame 
* 1    Thread 1 (Name: Hart 0, RV32) 0x00007ffe404005c6 in ?? ()
  2    Thread 2 (Name: Hart 1, RV32) 0x00007ffe404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: Start on thread 1
thread 2
[Switching to thread 2 (Thread 2)]
#0  0x00007ffe404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: Switch to thread 2
info threads
  Id   Target Id                     Frame 
  1    Thread 1 (Name: Hart 0, RV32) 0x00007ffe404005c6 in ?? ()
* 2    Thread 2 (Name: Hart 1, RV32) 0x00007ffe404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: info threads: current thread is 2
disconnect
Ending remote debugging.
(gdb) PASS: gdb.riscv/connect-active-thread.exp: disconnect
target remote :3333
Remote debugging using :3333
warning: Target-supplied registers are not supported by the current architecture
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x00007ffe404005c6 in ?? ()
(gdb) info threads
  Id   Target Id                     Frame 
  1    Thread 1 (Name: Hart 0, RV32) 0x00007ffe404005c6 in ?? ()
* 2    Thread 2 (Name: Hart 1, RV32) 0x00007ffe404005c6 in ?? ()
(gdb) PASS: gdb.riscv/connect-active-thread.exp: Current thread is 2 after reconnecting to remote target
```