### PR TITLE
Match on qC, but not qCRC.

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -124,7 +124,7 @@ static int riscv_gdb_thread_packet(struct connection *connection, const char *pa
 			return ERROR_OK;
 		}
 
-		if (strncmp(packet, "qC", 2) == 0) {
+		if (strcmp(packet, "qC") == 0) {
 			char rep_str[32];
 			snprintf(rep_str, 32, "QC%" PRIx64, rtos->current_threadid);
 			gdb_put_packet(connection, rep_str, strlen(rep_str));


### PR DESCRIPTION
Now we pass MulticoreRtosSwitchActiveHartTest again.
It was broken by #292.

Change-Id: I61f0ae41efda09fd48f732b2122fed2400a43d29