### PR TITLE
Fix gdb_signal_reply() allocating too small buffer

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -722,7 +722,7 @@ static int gdb_output(struct command_context *context, const char *line)
 static void gdb_signal_reply(struct target *target, struct connection *connection)
 {
 	struct gdb_connection *gdb_connection = connection->priv;
-	char sig_reply[45];
+	char sig_reply[65];
 	char stop_reason[20];
 	char current_thread[25];
 	int sig_reply_len;
@@ -767,7 +767,7 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		current_thread[0] = '\0';
 		if (target->rtos != NULL) {
 			struct target *ct;
-			snprintf(current_thread, sizeof(current_thread), "thread:%016" PRIx64 ";",
+			snprintf(current_thread, sizeof(current_thread), "thread:%" PRIx64 ";",
 					target->rtos->current_thread);
 			target->rtos->current_threadid = target->rtos->current_thread;
 			target->rtos->gdb_target_for_threadid(connection, target->rtos->current_threadid, &ct);


### PR DESCRIPTION
In my test-case (64-bit OpenOCD, 64-bit target), OpenOCD ended up
sending gdb '$T05rwatch:1212340a00;thread:0000000000000002#89'
That's missing the final semi-colon after the thread id.

This fix increases the buffer size, and also removes the 0 padding on
the thread id.

This bug showed up when running MulticoreRtosSwitchActiveHartTest
against dual-hart, 64-bit spike.

Change-Id: I8c7d88e2d37b00cf3099f226a1a32671219802d5