### PR TITLE
Add wall clock timeout to mpsse_flush()

### DIFF
--- a/src/jtag/drivers/mpsse.c
+++ b/src/jtag/drivers/mpsse.c
@@ -22,6 +22,7 @@
 
 #include "mpsse.h"
 #include "helper/log.h"
+#include "helper/time_support.h"
 #include <libusb.h>
 
 /* Compatibility define for older libusb-1.0 */

--- a/src/jtag/drivers/mpsse.c
+++ b/src/jtag/drivers/mpsse.c
@@ -892,6 +892,7 @@ int mpsse_flush(struct mpsse_ctx *ctx)
 	}
 
 	/* Polling loop, more or less taken from libftdi */
+	int64_t start = timeval_ms();
 	while (!write_result.done || !read_result.done) {
 		struct timeval timeout_usb;
 
@@ -913,6 +914,11 @@ int mpsse_flush(struct mpsse_ctx *ctx)
 				if (retval != LIBUSB_SUCCESS)
 					break;
 			}
+		}
+
+		if (timeval_ms() - start > 2000) {
+			LOG_ERROR("Timed out handling USB events in mpsse_flush().");
+			break;
 		}
 	}
 


### PR DESCRIPTION
I think that libusb_handle_events_timeout_completed is supposed to make
progress or time out, but sometimes we hit a case where it makes no
progress, and mpsse_flush() loops forever. This wall clock timeout kicks
it out of that loop. OpenOCD appears to die afterwards, but that's still
an improvement.

Change-Id: Id9220557625834fb5b7dccf65251651a11a887f0