### PR TITLE
Revert "Don't report exact watchpoint to gdb. (#300)"

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -724,11 +724,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 		if (wp->address == mem_addr) {
 			*hit_watchpoint = wp;
 			LOG_DEBUG("Hit address=%" TARGET_PRIxADDR, wp->address);
-			/* return ERROR_OK; */
-			LOG_DEBUG("Not reporting the exact watchpoint to gdb, until we have "
-					"a fix for "
-					"https://github.com/riscv/riscv-openocd/issues/295.");
-			return ERROR_FAIL;
+			return ERROR_OK;
 		}
 		wp = wp->next;
 	}


### PR DESCRIPTION
This reverts commit 933cb875a8fb6243df52208c725b1c6ebc9662e3.

https://github.com/riscv/riscv-openocd/issues/295 was fixed in gdb.