### PR TITLE
Fix segfault in riscv_deinit_target().

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -280,12 +280,17 @@ static void riscv_deinit_target(struct target *target)
 		free(info);
 	}
 	/* Free the shared structure use for most registers. */
-	free(target->reg_cache->reg_list[0].arch_info);
-	/* Free the ones we allocated separately. */
-	for (unsigned i = GDB_REGNO_COUNT; i < target->reg_cache->num_regs; i++)
-		free(target->reg_cache->reg_list[i].arch_info);
-	free(target->reg_cache->reg_list);
-	free(target->reg_cache);
+	if (target->reg_cache) {
+		if (target->reg_cache->reg_list) {
+			if (target->reg_cache->reg_list[0].arch_info)
+				free(target->reg_cache->reg_list[0].arch_info);
+			/* Free the ones we allocated separately. */
+			for (unsigned i = GDB_REGNO_COUNT; i < target->reg_cache->num_regs; i++)
+				free(target->reg_cache->reg_list[i].arch_info);
+			free(target->reg_cache->reg_list);
+		}
+		free(target->reg_cache);
+	}
 	target->arch_info = NULL;
 }
 


### PR DESCRIPTION
This would happen when OpenOCD is unable to connect to the JTAG device.

Change-Id: I1785fd5f5a20db9b4b574bdddfe3eab9bdc0b0bc