### PR TITLE
Add m4 macro dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@ SUBDIRS += jimtcl
 DIST_SUBDIRS += jimtcl
 endif
 
+ACLOCAL_AMFLAGS = -I m4
+
 # common flags used in openocd build
 AM_CFLAGS = $(GCC_WARNINGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ AC_INIT([openocd], [0.10.0+dev],
 AC_CONFIG_SRCDIR([src/openocd.c])
 
 m4_include([config_subdir.m4])dnl
+AC_CONFIG_MACRO_DIR([m4])
 
 # check for makeinfo before calling AM_INIT_AUTOMAKE
 AC_CHECK_PROG([MAKEINFO], [makeinfo], [makeinfo])


### PR DESCRIPTION
This silences the suggestion to add the m4 macrodir automatically created by autotools.