### PR TITLE
Complete single step before returning.

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1451,7 +1451,7 @@ static int step(struct target *target, int current, target_addr_t address,
 		if (result != ERROR_OK)
 			return result;
 	} else {
-		return resume(target, 0, true);
+		return full_step(target, false);
 	}
 
 	return ERROR_OK;


### PR DESCRIPTION
This fixes the following error, that has been reported occasionally:
Error: 34072 2712 riscv-011.c:1175 reg_cache_get(): Register cache entry for 0 is invalid!
openocd: ../src/target/riscv/riscv-011.c:1176: reg_cache_get: Assertion `r->valid' failed.

The problem was that we'd tell the target to step, and then gdb (which
assumed the target halted already) asked to read a register before the
target had actually halted. With this fix the target is actually halted,
and everything works.

Change-Id: Icfcef456f3cec4bb352fb90186f5bbabb00a5ff8