### PR TITLE
Remove unused extern declaration.

### DIFF
--- a/src/jtag/interfaces.c
+++ b/src/jtag/interfaces.c
@@ -54,9 +54,6 @@ extern struct jtag_interface dummy_interface;
 #if BUILD_FTDI == 1
 extern struct jtag_interface ftdi_interface;
 #endif
-#if BUILD_FTDI_OSCAN1 == 1
-extern struct jtag_interface oscan1_ftdi_interface;
-#endif
 #if BUILD_USB_BLASTER == 1 || BUILD_USB_BLASTER_2 == 1
 extern struct jtag_interface usb_blaster_interface;
 #endif


### PR DESCRIPTION
An unused extern declaration was inadvertently part of commit 6749c70.  This is a fix for that.