### PR TITLE
`-rtos hwthread` support

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -9858,55 +9858,6 @@ and GDB would require stopping the target to get the prompt back.
 Do not use this mode under an IDE like Eclipse as it caches values of
 previously shown varibles.
 
-@anchor{usingopenocdsmpwithgdb}
-@section Using OpenOCD SMP with GDB
-@cindex SMP
-For SMP support following GDB serial protocol packet have been defined :
-@itemize @bullet
-@item j - smp status request
-@item J - smp set request
-@end itemize
-
-OpenOCD implements :
-@itemize @bullet
-@item @option{jc} packet for reading core id displayed by
-GDB connection. Reply is @option{XXXXXXXX} (8 hex digits giving core id) or
- @option{E01} for target not smp.
-@item @option{JcXXXXXXXX} (8 hex digits) packet for setting core id displayed at next GDB continue
-(core id -1 is reserved for returning to normal resume mode). Reply @option{E01}
-for target not smp or @option{OK} on success.
-@end itemize
-
-Handling of this packet within GDB can be done :
-@itemize @bullet
-@item by the creation of an internal variable (i.e @option{_core}) by mean
-of function allocate_computed_value allowing following GDB command.
-@example
-set $_core 1
-#Jc01 packet is sent
-print $_core
-#jc packet is sent and result is affected in $
-@end example
-
-@item by the usage of GDB maintenance command as described in following example (2 cpus in SMP with
-core id 0 and 1 @pxref{definecputargetsworkinginsmp,,Define CPU targets working in SMP}).
-
-@example
-# toggle0 : force display of coreid 0
-define toggle0
-maint packet Jc0
-continue
-main packet Jc-1
-end
-# toggle1 : force display of coreid 1
-define toggle1
-maint packet Jc1
-continue
-main packet Jc-1
-end
-@end example
-@end itemize
-
 @section RTOS Support
 @cindex RTOS Support
 @anchor{gdbrtossupport}
@@ -9937,12 +9888,11 @@ Currently supported rtos's include:
 @item @option{mqx}
 @item @option{uCOS-III}
 @item @option{nuttx}
+@item @option{hwthread} (This is not an actual RTOS. @xref{usingopenocdsmpwithgdb,,Using OpenOCD SMP with GDB}.)
 @end itemize
 
-@quotation Note
 Before an RTOS can be detected, it must export certain symbols; otherwise, it cannot
 be used by OpenOCD. Below is a list of the required symbols for each supported RTOS.
-@end quotation
 
 @table @code
 @item eCos symbols
@@ -9988,6 +9938,72 @@ contrib/rtos-helpers/FreeRTOS-openocd.c
 @item uC/OS-III
 contrib/rtos-helpers/uCOS-III-openocd.c
 @end table
+
+@anchor{usingopenocdsmpwithgdb}
+@section Using OpenOCD SMP with GDB
+@cindex SMP
+@cindex RTOS
+@cindex hwthread
+OpenOCD includes a pseudo RTOS called @emph{hwthread} that presents CPU cores
+("hardware threads") in an SMP system as threads to GDB. With this extension,
+GDB can be used to inspect the state of an SMP system in a natural way.
+After halting the system, using the GDB command @command{info threads} will
+list the context of each active CPU core in the system. GDB's @command{thread}
+command can be used to switch the view to a different CPU core.
+The @command{step} and @command{stepi} commands can be used to step a specific core
+while other cores are free-running or remain halted, depending on the
+scheduler-locking mode configured in GDB.
+
+@section Legacy SMP core switching support
+@quotation Note
+This method is deprecated in favor of the @emph{hwthread} pseudo RTOS.
+@end quotation
+
+For SMP support following GDB serial protocol packet have been defined :
+@itemize @bullet
+@item j - smp status request
+@item J - smp set request
+@end itemize
+
+OpenOCD implements :
+@itemize @bullet
+@item @option{jc} packet for reading core id displayed by
+GDB connection. Reply is @option{XXXXXXXX} (8 hex digits giving core id) or
+ @option{E01} for target not smp.
+@item @option{JcXXXXXXXX} (8 hex digits) packet for setting core id displayed at next GDB continue
+(core id -1 is reserved for returning to normal resume mode). Reply @option{E01}
+for target not smp or @option{OK} on success.
+@end itemize
+
+Handling of this packet within GDB can be done :
+@itemize @bullet
+@item by the creation of an internal variable (i.e @option{_core}) by mean
+of function allocate_computed_value allowing following GDB command.
+@example
+set $_core 1
+#Jc01 packet is sent
+print $_core
+#jc packet is sent and result is affected in $
+@end example
+
+@item by the usage of GDB maintenance command as described in following example (2 cpus in SMP with
+core id 0 and 1 @pxref{definecputargetsworkinginsmp,,Define CPU targets working in SMP}).
+
+@example
+# toggle0 : force display of coreid 0
+define toggle0
+maint packet Jc0
+continue
+main packet Jc-1
+end
+# toggle1 : force display of coreid 1
+define toggle1
+maint packet Jc1
+continue
+main packet Jc-1
+end
+@end example
+@end itemize
 
 @node Tcl Scripting API
 @chapter Tcl Scripting API

--- a/src/rtos/Makefile.am
+++ b/src/rtos/Makefile.am
@@ -17,6 +17,7 @@ noinst_LTLIBRARIES += %D%/librtos.la
 	%D%/riscv_debug.c \
 	%D%/uCOS-III.c \
 	%D%/nuttx.c \
+	%D%/hwthread.c \
 	%D%/rtos.h \
 	%D%/rtos_standard_stackings.h \
 	%D%/rtos_ecos_stackings.h \

--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -1,0 +1,394 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <helper/time_support.h>
+#include <jtag/jtag.h>
+#include "target/target.h"
+#include "target/target_type.h"
+#include "target/register.h"
+#include "rtos.h"
+#include "helper/log.h"
+#include "helper/types.h"
+#include "server/gdb_server.h"
+
+static bool hwthread_detect_rtos(struct target *target);
+static int hwthread_create(struct target *target);
+static int hwthread_update_threads(struct rtos *rtos);
+static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, char **hex_reg_list);
+static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[]);
+static int hwthread_smp_init(struct target *target);
+
+#define HW_THREAD_NAME_STR_SIZE (32)
+
+extern int rtos_thread_packet(struct connection *connection, const char *packet, int packet_size);
+
+static inline threadid_t threadid_from_target(const struct target *target)
+{
+	return target->coreid + 1;
+}
+
+const struct rtos_type hwthread_rtos = {
+	.name = "hwthread",
+	.detect_rtos = hwthread_detect_rtos,
+	.create = hwthread_create,
+	.update_threads = hwthread_update_threads,
+	.get_thread_reg_list = hwthread_get_thread_reg_list,
+	.get_symbol_list_to_lookup = hwthread_get_symbol_list_to_lookup,
+	.smp_init = hwthread_smp_init,
+};
+
+struct hwthread_params {
+	int dummy_param;
+};
+
+static int hwthread_fill_thread(struct rtos *rtos, struct target *curr, int thread_num)
+{
+	char tmp_str[HW_THREAD_NAME_STR_SIZE];
+	threadid_t tid = threadid_from_target(curr);
+
+	memset(tmp_str, 0, HW_THREAD_NAME_STR_SIZE);
+
+	/* thread-id is the core-id of this core inside the SMP group plus 1 */
+	rtos->thread_details[thread_num].threadid = tid;
+	/* create the thread name */
+	rtos->thread_details[thread_num].exists = true;
+	rtos->thread_details[thread_num].thread_name_str = strdup(target_name(curr));
+	snprintf(tmp_str, HW_THREAD_NAME_STR_SIZE-1, "state: %s", debug_reason_name(curr));
+	rtos->thread_details[thread_num].extra_info_str = strdup(tmp_str);
+
+	return ERROR_OK;
+}
+
+static int hwthread_update_threads(struct rtos *rtos)
+{
+	int threads_found = 0;
+	int thread_list_size = 0;
+	struct target_list *head;
+	struct target *target;
+	int64_t current_thread = 0;
+	enum target_debug_reason current_reason = DBG_REASON_UNDEFINED;
+
+	if (rtos == NULL)
+		return -1;
+
+	target = rtos->target;
+
+	/* wipe out previous thread details if any */
+	rtos_free_threadlist(rtos);
+
+	/* determine the number of "threads" */
+	if (target->smp) {
+		for (head = target->head; head != NULL; head = head->next) {
+			struct target *curr = head->target;
+
+			if (!target_was_examined(curr))
+				continue;
+
+			++thread_list_size;
+		}
+	} else
+		thread_list_size = 1;
+
+	/* create space for new thread details */
+	rtos->thread_details = malloc(sizeof(struct thread_detail) * thread_list_size);
+
+	if (target->smp) {
+		/* loop over all threads */
+		for (head = target->head; head != NULL; head = head->next) {
+			struct target *curr = head->target;
+
+			if (!target_was_examined(curr))
+				continue;
+
+			threadid_t tid = threadid_from_target(curr);
+
+			hwthread_fill_thread(rtos, curr, threads_found);
+
+			/* find an interesting thread to set as current */
+			switch (current_reason) {
+			case DBG_REASON_UNDEFINED:
+				current_reason = curr->debug_reason;
+				current_thread = tid;
+				break;
+			case DBG_REASON_SINGLESTEP:
+				/* single-step can only be overridden by itself */
+				if (curr->debug_reason == DBG_REASON_SINGLESTEP) {
+					if (tid == rtos->current_threadid)
+						current_thread = tid;
+				}
+				break;
+			case DBG_REASON_BREAKPOINT:
+				/* single-step overrides breakpoint */
+				if (curr->debug_reason == DBG_REASON_SINGLESTEP) {
+					current_reason = curr->debug_reason;
+					current_thread = tid;
+				} else
+				/* multiple breakpoints, prefer gdbs' threadid */
+				if (curr->debug_reason == DBG_REASON_BREAKPOINT) {
+					if (tid == rtos->current_threadid)
+						current_thread = tid;
+				}
+				break;
+			case DBG_REASON_WATCHPOINT:
+				/* breakpoint and single-step override watchpoint */
+				if (curr->debug_reason == DBG_REASON_SINGLESTEP ||
+						curr->debug_reason == DBG_REASON_BREAKPOINT) {
+					current_reason = curr->debug_reason;
+					current_thread = tid;
+				}
+				break;
+			case DBG_REASON_DBGRQ:
+				/* all other reasons override debug-request */
+				if (curr->debug_reason == DBG_REASON_SINGLESTEP ||
+						curr->debug_reason == DBG_REASON_WATCHPOINT ||
+						curr->debug_reason == DBG_REASON_BREAKPOINT) {
+					current_reason = curr->debug_reason;
+					current_thread = tid;
+				} else
+				if (curr->debug_reason == DBG_REASON_DBGRQ) {
+					if (tid == rtos->current_threadid)
+						current_thread = tid;
+				}
+
+				break;
+
+			default:
+				break;
+			}
+
+			threads_found++;
+		}
+	} else {
+		hwthread_fill_thread(rtos, target, threads_found);
+		current_thread = threadid_from_target(target);
+		threads_found++;
+	}
+
+	rtos->thread_count = threads_found;
+
+	/* we found an interesting thread, set it as current */
+	if (current_thread != 0)
+		rtos->current_thread = current_thread;
+	else if (rtos->current_threadid != 0)
+		rtos->current_thread = rtos->current_threadid;
+	else
+		rtos->current_thread = threadid_from_target(target);
+
+	LOG_DEBUG("%s current_thread=%i", __func__, (int)rtos->current_thread);
+	return 0;
+}
+
+static int hwthread_smp_init(struct target *target)
+{
+	return hwthread_update_threads(target->rtos);
+}
+
+static inline int gdb_reg_pos(struct target *target, int pos, int len)
+{
+	if (target->endianness == TARGET_LITTLE_ENDIAN)
+		return pos;
+	else
+		return len - 1 - pos;
+}
+
+/* Convert register to string of bytes. NB! The # of bits in the
+ * register might be non-divisible by 8(a byte), in which
+ * case an entire byte is shown.
+ *
+ * NB! the format on the wire is the target endianness
+ *
+ * The format of reg->value is little endian
+ *
+ */
+static void gdb_str_to_target(struct target *target,
+		char *tstr, struct reg *reg)
+{
+	int i;
+
+	uint8_t *buf;
+	int buf_len;
+	buf = reg->value;
+	buf_len = DIV_ROUND_UP(reg->size, 8);
+
+	for (i = 0; i < buf_len; i++) {
+		int j = gdb_reg_pos(target, i, buf_len);
+		tstr += sprintf(tstr, "%02x", buf[j]);
+	}
+}
+
+
+static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, char **hex_reg_list)
+{
+	struct target_list *head;
+	struct target *target;
+	struct target *curr;
+	struct reg **reg_list;
+	int reg_list_size;
+	int reg_packet_size = 0;
+	char *reg_packet;
+	char *reg_packet_p;
+	int i;
+
+	int retval;
+
+	*hex_reg_list = NULL;
+
+	if (rtos == NULL)
+		return ERROR_FAIL;
+
+	target = rtos->target;
+
+	/* Find the thread with that thread_id */
+	if (target->smp) {
+		curr = NULL;
+		for (head = target->head; head != NULL; head = head->next) {
+			curr = head->target;
+
+			if (thread_id == threadid_from_target(curr))
+				break;
+		}
+
+		if (head == NULL)
+			return ERROR_FAIL;
+	} else {
+		curr = target;
+		if (thread_id != threadid_from_target(curr))
+			return ERROR_FAIL;
+
+	}
+
+	if (!target_was_examined(curr))
+		return ERROR_FAIL;
+
+	retval = target_get_gdb_reg_list(curr, &reg_list, &reg_list_size,
+			REG_CLASS_GENERAL);
+	if (retval != ERROR_OK)
+		return retval;
+
+	for (i = 0; i < reg_list_size; i++)
+		reg_packet_size += DIV_ROUND_UP(reg_list[i]->size, 8) * 2;
+
+	if (reg_packet_size == 0)
+		return ERROR_FAIL;
+
+	reg_packet = malloc(reg_packet_size + 1); /* plus one for string termination null */
+	if (reg_packet == NULL)
+		return ERROR_FAIL;
+
+	reg_packet_p = reg_packet;
+
+	for (i = 0; i < reg_list_size; i++) {
+		if (!reg_list[i]->valid)
+			reg_list[i]->type->get(reg_list[i]);
+		gdb_str_to_target(target, reg_packet_p, reg_list[i]);
+		reg_packet_p += DIV_ROUND_UP(reg_list[i]->size, 8) * 2;
+	}
+
+	*hex_reg_list = reg_packet;
+	free(reg_list);
+
+	return ERROR_OK;
+
+}
+
+static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[])
+{
+	/* return an empty list, we don't have any symbols to look up */
+	*symbol_list = calloc(1, sizeof(symbol_table_elem_t));
+	(*symbol_list)[0].symbol_name = NULL;
+	return 0;
+}
+
+static int hwthread_target_for_threadid(struct connection *connection, int64_t thread_id, struct target **p_target)
+{
+	struct target *target = get_target_from_connection(connection);
+	struct target_list *head;
+	struct target *curr;
+
+	if (target->smp) {
+		/* Find the thread with that thread_id */
+		curr = NULL;
+		for (head = target->head; head != NULL; head = head->next) {
+			curr = head->target;
+
+			if (thread_id == threadid_from_target(curr))
+				break;
+		}
+
+		if (head == NULL)
+			return ERROR_FAIL;
+	} else {
+		curr = target;
+		if (thread_id != threadid_from_target(curr))
+			return ERROR_FAIL;
+	}
+
+	*p_target = curr;
+
+	return ERROR_OK;
+}
+
+static bool hwthread_detect_rtos(struct target *target)
+{
+	/* always return 0, avoid auto-detection */
+	return false;
+}
+
+static int hwthread_thread_packet(struct connection *connection, const char *packet, int packet_size)
+{
+	struct target *target = get_target_from_connection(connection);
+
+	struct target *curr = NULL;
+	int64_t current_threadid;
+
+	if (packet[0] == 'H' && packet[1] == 'g') {
+		sscanf(packet, "Hg%16" SCNx64, &current_threadid);
+
+		if (current_threadid > 0) {
+			if (hwthread_target_for_threadid(connection, current_threadid, &curr) != ERROR_OK) {
+				LOG_ERROR("hwthread: cannot find thread id %"PRId64, current_threadid);
+				gdb_put_packet(connection, "E01", 3);
+				return ERROR_FAIL;
+			}
+			target->rtos->current_thread = current_threadid;
+		} else
+		if (current_threadid == 0 || current_threadid == -1)
+			target->rtos->current_thread = threadid_from_target(target);
+
+		target->rtos->current_threadid = current_threadid;
+
+		gdb_put_packet(connection, "OK", 2);
+		return ERROR_OK;
+	}
+
+	return rtos_thread_packet(connection, packet, packet_size);
+}
+
+static int hwthread_create(struct target *target)
+{
+	LOG_INFO("Hardware thread awareness created");
+
+	target->rtos->rtos_specific_params = NULL;
+	target->rtos->current_thread = 0;
+	target->rtos->thread_details = NULL;
+	target->rtos->gdb_target_for_threadid = hwthread_target_for_threadid;
+	target->rtos->gdb_thread_packet = hwthread_thread_packet;
+	return 0;
+}

--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -35,6 +35,7 @@ static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
 		struct rtos_reg **reg_list, int *num_regs);
 static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[]);
 static int hwthread_smp_init(struct target *target);
+int hwthread_set_reg(struct rtos *rtos, int reg_num, uint8_t *reg_value);
 
 #define HW_THREAD_NAME_STR_SIZE (32)
 
@@ -53,6 +54,7 @@ const struct rtos_type hwthread_rtos = {
 	.get_thread_reg_list = hwthread_get_thread_reg_list,
 	.get_symbol_list_to_lookup = hwthread_get_symbol_list_to_lookup,
 	.smp_init = hwthread_smp_init,
+	.set_reg = hwthread_set_reg,
 };
 
 struct hwthread_params {
@@ -201,44 +203,33 @@ static int hwthread_smp_init(struct target *target)
 	return hwthread_update_threads(target->rtos);
 }
 
-static inline int gdb_reg_pos(struct target *target, int pos, int len)
+static struct target *find_thread(struct target *target, int64_t thread_id)
 {
-	if (target->endianness == TARGET_LITTLE_ENDIAN)
-		return pos;
-	else
-		return len - 1 - pos;
+	/* Find the thread with that thread_id */
+	if (target == NULL)
+		return NULL;
+	if (target->smp) {
+		for (struct target_list *head = target->head; head != NULL; head = head->next) {
+			if (thread_id == threadid_from_target(head->target))
+				return head->target;
+		}
+	} else if (thread_id == threadid_from_target(target)) {
+		return target;
+	}
+	return NULL;
 }
-
 
 static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
 		struct rtos_reg **rtos_reg_list, int *rtos_reg_list_size)
 {
-	struct target_list *head;
-	struct target *target;
-	struct target *curr;
-
 	if (rtos == NULL)
 		return ERROR_FAIL;
 
-	target = rtos->target;
+	struct target *target = rtos->target;
 
-	/* Find the thread with that thread_id */
-	if (target->smp) {
-		curr = NULL;
-		for (head = target->head; head != NULL; head = head->next) {
-			curr = head->target;
-
-			if (thread_id == threadid_from_target(curr))
-				break;
-		}
-
-		if (head == NULL)
-			return ERROR_FAIL;
-	} else {
-		curr = target;
-		if (thread_id != threadid_from_target(curr))
-			return ERROR_FAIL;
-	}
+	struct target *curr = find_thread(target, thread_id);
+	if (curr == NULL)
+		return ERROR_FAIL;
 
 	if (!target_was_examined(curr))
 		return ERROR_FAIL;
@@ -266,6 +257,32 @@ static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
 	return ERROR_OK;
 }
 
+int hwthread_set_reg(struct rtos *rtos, int reg_num, uint8_t *reg_value)
+{
+	if (rtos == NULL)
+		return ERROR_FAIL;
+
+	struct target *target = rtos->target;
+
+	struct target *curr = find_thread(target, rtos->current_thread);
+	LOG_DEBUG(">>> found %ld: %p", rtos->current_thread, curr);
+	if (curr == NULL)
+		return ERROR_FAIL;
+
+	struct reg **reg_list;
+	int reg_list_size;
+	if (target_get_gdb_reg_list(curr, &reg_list, &reg_list_size,
+				REG_CLASS_ALL) != ERROR_OK)
+		return ERROR_FAIL;
+
+	if (reg_list_size <= reg_num) {
+		LOG_ERROR("Register %d requested, but only %d registers exist.",
+				reg_num, reg_list_size);
+		return ERROR_FAIL;
+	}
+	return reg_list[reg_num]->type->set(reg_list[reg_num], reg_value);
+}
+
 static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[])
 {
 	/* return an empty list, we don't have any symbols to look up */
@@ -277,26 +294,10 @@ static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[]
 static int hwthread_target_for_threadid(struct connection *connection, int64_t thread_id, struct target **p_target)
 {
 	struct target *target = get_target_from_connection(connection);
-	struct target_list *head;
-	struct target *curr;
 
-	if (target->smp) {
-		/* Find the thread with that thread_id */
-		curr = NULL;
-		for (head = target->head; head != NULL; head = head->next) {
-			curr = head->target;
-
-			if (thread_id == threadid_from_target(curr))
-				break;
-		}
-
-		if (head == NULL)
-			return ERROR_FAIL;
-	} else {
-		curr = target;
-		if (thread_id != threadid_from_target(curr))
-			return ERROR_FAIL;
-	}
+	struct target *curr = find_thread(target, thread_id);
+	if (curr == NULL)
+		return ERROR_FAIL;
 
 	*p_target = curr;
 
@@ -331,6 +332,7 @@ static int hwthread_thread_packet(struct connection *connection, const char *pac
 			target->rtos->current_thread = threadid_from_target(target);
 
 		target->rtos->current_threadid = current_threadid;
+		LOG_DEBUG(">>> current_threadid=%ld", current_threadid);
 
 		gdb_put_packet(connection, "OK", 2);
 		return ERROR_OK;

--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -360,7 +360,7 @@ static int hwthread_thread_packet(struct connection *connection, const char *pac
 			target->rtos->current_thread = threadid_from_target(target);
 
 		target->rtos->current_threadid = current_threadid;
-		LOG_DEBUG("current_threadid=%ld", current_threadid);
+		LOG_DEBUG("current_threadid=%" PRId64, current_threadid);
 
 		gdb_put_packet(connection, "OK", 2);
 		return ERROR_OK;

--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -31,7 +31,8 @@
 static bool hwthread_detect_rtos(struct target *target);
 static int hwthread_create(struct target *target);
 static int hwthread_update_threads(struct rtos *rtos);
-static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, char **hex_reg_list);
+static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
+		struct rtos_reg **reg_list, int *num_regs);
 static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[]);
 static int hwthread_smp_init(struct target *target);
 
@@ -208,47 +209,13 @@ static inline int gdb_reg_pos(struct target *target, int pos, int len)
 		return len - 1 - pos;
 }
 
-/* Convert register to string of bytes. NB! The # of bits in the
- * register might be non-divisible by 8(a byte), in which
- * case an entire byte is shown.
- *
- * NB! the format on the wire is the target endianness
- *
- * The format of reg->value is little endian
- *
- */
-static void gdb_str_to_target(struct target *target,
-		char *tstr, struct reg *reg)
-{
-	int i;
 
-	uint8_t *buf;
-	int buf_len;
-	buf = reg->value;
-	buf_len = DIV_ROUND_UP(reg->size, 8);
-
-	for (i = 0; i < buf_len; i++) {
-		int j = gdb_reg_pos(target, i, buf_len);
-		tstr += sprintf(tstr, "%02x", buf[j]);
-	}
-}
-
-
-static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, char **hex_reg_list)
+static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
+		struct rtos_reg **reg_list, int *num_regs)
 {
 	struct target_list *head;
 	struct target *target;
 	struct target *curr;
-	struct reg **reg_list;
-	int reg_list_size;
-	int reg_packet_size = 0;
-	char *reg_packet;
-	char *reg_packet_p;
-	int i;
-
-	int retval;
-
-	*hex_reg_list = NULL;
 
 	if (rtos == NULL)
 		return ERROR_FAIL;
@@ -277,35 +244,8 @@ static int hwthread_get_thread_reg_list(struct rtos *rtos, int64_t thread_id, ch
 	if (!target_was_examined(curr))
 		return ERROR_FAIL;
 
-	retval = target_get_gdb_reg_list(curr, &reg_list, &reg_list_size,
-			REG_CLASS_GENERAL);
-	if (retval != ERROR_OK)
-		return retval;
-
-	for (i = 0; i < reg_list_size; i++)
-		reg_packet_size += DIV_ROUND_UP(reg_list[i]->size, 8) * 2;
-
-	if (reg_packet_size == 0)
-		return ERROR_FAIL;
-
-	reg_packet = malloc(reg_packet_size + 1); /* plus one for string termination null */
-	if (reg_packet == NULL)
-		return ERROR_FAIL;
-
-	reg_packet_p = reg_packet;
-
-	for (i = 0; i < reg_list_size; i++) {
-		if (!reg_list[i]->valid)
-			reg_list[i]->type->get(reg_list[i]);
-		gdb_str_to_target(target, reg_packet_p, reg_list[i]);
-		reg_packet_p += DIV_ROUND_UP(reg_list[i]->size, 8) * 2;
-	}
-
-	*hex_reg_list = reg_packet;
-	free(reg_list);
-
-	return ERROR_OK;
-
+	LOG_ERROR("TODO: not implemented");
+	return ERROR_FAIL;
 }
 
 static int hwthread_get_symbol_list_to_lookup(symbol_table_elem_t *symbol_list[])

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -36,6 +36,7 @@ extern struct rtos_type embKernel_rtos;
 extern struct rtos_type mqx_rtos;
 extern struct rtos_type uCOS_III_rtos;
 extern struct rtos_type nuttx_rtos;
+extern struct rtos_type hwthread_rtos;
 extern struct rtos_type riscv_rtos;
 
 static struct rtos_type *rtos_types[] = {
@@ -48,6 +49,7 @@ static struct rtos_type *rtos_types[] = {
 	&mqx_rtos,
 	&uCOS_III_rtos,
 	&nuttx_rtos,
+	&hwthread_rtos,
 	&riscv_rtos,
 	NULL
 };

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -552,7 +552,6 @@ int rtos_set_reg(struct connection *connection, int reg_num,
 {
 	struct target *target = get_target_from_connection(connection);
 	int64_t current_threadid = target->rtos->current_threadid;
-	LOG_DEBUG(">>> thread %ld, reg %d", current_threadid, reg_num);
 	if ((target->rtos != NULL) &&
 			(target->rtos->type->set_reg != NULL) &&
 			(current_threadid != -1) &&

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -432,7 +432,6 @@ int rtos_thread_packet(struct connection *connection, char const *packet, int pa
 				target->rtos->current_threadid = target->rtos->current_thread;
 			else
 				target->rtos->current_threadid = threadid;
-			LOG_DEBUG("current_threadid=%ld", target->rtos->current_threadid);
 		}
 		gdb_put_packet(connection, "OK", 2);
 		return ERROR_OK;
@@ -517,7 +516,6 @@ int rtos_get_gdb_reg_list(struct connection *connection)
 {
 	struct target *target = get_target_from_connection(connection);
 	int64_t current_threadid = target->rtos->current_threadid;
-	LOG_DEBUG("current_threadid=%ld", target->rtos->current_threadid);
 	if ((target->rtos != NULL) && (current_threadid != -1) &&
 			(current_threadid != 0) &&
 			((current_threadid != target->rtos->current_thread) ||

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -535,6 +535,21 @@ int rtos_get_gdb_reg_list(struct connection *connection)
 	return ERROR_FAIL;
 }
 
+int rtos_set_reg(struct connection *connection, int reg_num,
+		uint8_t *reg_value)
+{
+	struct target *target = get_target_from_connection(connection);
+	int64_t current_threadid = target->rtos->current_threadid;
+	LOG_DEBUG(">>> reg_num=%d", reg_num);
+	if ((target->rtos != NULL) &&
+			(target->rtos->type->set_reg != NULL) &&
+			(current_threadid != -1) &&
+			(current_threadid != 0)) {
+		return target->rtos->type->set_reg(target->rtos, reg_num, reg_value);
+	}
+	return ERROR_FAIL;
+}
+
 int rtos_generic_stack_read(struct target *target,
 	const struct rtos_register_stacking *stacking,
 	int64_t stack_ptr,

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -432,6 +432,7 @@ int rtos_thread_packet(struct connection *connection, char const *packet, int pa
 				target->rtos->current_threadid = target->rtos->current_thread;
 			else
 				target->rtos->current_threadid = threadid;
+			LOG_DEBUG("current_threadid=%ld", target->rtos->current_threadid);
 		}
 		gdb_put_packet(connection, "OK", 2);
 		return ERROR_OK;
@@ -516,6 +517,7 @@ int rtos_get_gdb_reg_list(struct connection *connection)
 {
 	struct target *target = get_target_from_connection(connection);
 	int64_t current_threadid = target->rtos->current_threadid;
+	LOG_DEBUG("current_threadid=%ld", target->rtos->current_threadid);
 	if ((target->rtos != NULL) && (current_threadid != -1) &&
 			(current_threadid != 0) &&
 			((current_threadid != target->rtos->current_thread) ||

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -76,6 +76,7 @@ struct rtos_type {
 	int (*get_symbol_list_to_lookup)(symbol_table_elem_t *symbol_list[]);
 	int (*clean)(struct target *target);
 	char * (*ps_command)(struct target *target);
+	int (*set_reg)(struct rtos *rtos, int reg_num, uint8_t *reg_value);
 };
 
 struct stack_register_offset {
@@ -105,6 +106,8 @@ struct rtos_register_stacking {
 #define GDB_THREAD_PACKET_NOT_CONSUMED (-40)
 
 int rtos_create(Jim_GetOptInfo *goi, struct target *target);
+int rtos_set_reg(struct connection *connection, int reg_num,
+		uint8_t *reg_value);
 int rtos_generic_stack_read(struct target *target,
 		const struct rtos_register_stacking *stacking,
 		int64_t stack_ptr,

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -20,6 +20,7 @@
 #define OPENOCD_RTOS_RTOS_H
 
 #include "server/server.h"
+#include "target/target.h"
 #include <jim-nvp.h>
 
 typedef int64_t threadid_t;
@@ -71,11 +72,15 @@ struct rtos_type {
 	int (*create)(struct target *target);
 	int (*smp_init)(struct target *target);
 	int (*update_threads)(struct rtos *rtos);
+	/** Return a list of general registers, with their values filled out. */
 	int (*get_thread_reg_list)(struct rtos *rtos, int64_t thread_id,
 			struct rtos_reg **reg_list, int *num_regs);
+	int (*get_thread_reg)(struct rtos *rtos, int64_t thread_id,
+			uint32_t reg_num, struct rtos_reg *reg);
 	int (*get_symbol_list_to_lookup)(symbol_table_elem_t *symbol_list[]);
 	int (*clean)(struct target *target);
 	char * (*ps_command)(struct target *target);
+	// TODO: int or uint32_t for reg_num?
 	int (*set_reg)(struct rtos *rtos, int reg_num, uint8_t *reg_value);
 };
 

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -82,8 +82,7 @@ struct rtos_type {
 	int (*get_symbol_list_to_lookup)(symbol_table_elem_t *symbol_list[]);
 	int (*clean)(struct target *target);
 	char * (*ps_command)(struct target *target);
-	// TODO: int or uint32_t for reg_num?
-	int (*set_reg)(struct rtos *rtos, int reg_num, uint8_t *reg_value);
+	int (*set_reg)(struct rtos *rtos, uint32_t reg_num, uint8_t *reg_value);
 };
 
 struct stack_register_offset {

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -50,7 +50,9 @@ struct rtos {
 	symbol_table_elem_t *symbols;
 	struct target *target;
 	/*  add a context variable instead of global variable */
+	/* The thread currently selected by gdb. */
 	int64_t current_threadid;
+	/* The currently selected thread according to the target. */
 	threadid_t current_thread;
 	struct thread_detail *thread_details;
 	int thread_count;

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -96,7 +96,7 @@ struct gdb_connection {
 	char *thread_list;
 };
 
-#if 0
+#if 1
 #define _DEBUG_GDB_IO_
 #endif
 

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -144,7 +144,6 @@ static char gdb_running_type;
 
 static int gdb_last_signal(struct target *target)
 {
-	LOG_DEBUG(">>> [%d] debug_reason=%d", target->coreid, target->debug_reason);
 	switch (target->debug_reason) {
 		case DBG_REASON_DBGRQ:
 			return 0x2;		/* SIGINT */
@@ -747,8 +746,6 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 			signal_var = 0x2;
 		} else
 			signal_var = gdb_last_signal(ct);
-		LOG_DEBUG(">>> ctrl_c=%d, signal_var=%d", gdb_connection->ctrl_c,
-				signal_var);
 
 		stop_reason[0] = '\0';
 		if (ct->debug_reason == DBG_REASON_WATCHPOINT) {
@@ -780,7 +777,6 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		if (target->rtos != NULL)
 			snprintf(current_thread, sizeof(current_thread), "thread:%" PRIx64 ";",
 					target->rtos->current_thread);
-		LOG_DEBUG(">>> signal_var=%d", signal_var);
 
 		sig_reply_len = snprintf(sig_reply, sizeof(sig_reply), "T%2.2x%s%s",
 				signal_var, stop_reason, current_thread);
@@ -3185,7 +3181,6 @@ static int gdb_input_inner(struct connection *connection)
 		}
 
 		if (packet_size > 0) {
-			LOG_DEBUG(">>> current_threadid=%ld", target->rtos ? target->rtos->current_threadid : 1234);
 			retval = ERROR_OK;
 			switch (packet[0]) {
 				case 'T':	/* Is thread alive? */

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -2399,6 +2399,7 @@ static int gdb_target_description_supported(struct target *target, int *supporte
 			&reg_list_size, REG_CLASS_ALL);
 	if (retval != ERROR_OK) {
 		LOG_ERROR("get register list failed");
+		reg_list = NULL;
 		goto error;
 	}
 

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -96,7 +96,7 @@ struct gdb_connection {
 	char *thread_list;
 };
 
-#if 1
+#if 0
 #define _DEBUG_GDB_IO_
 #endif
 
@@ -736,7 +736,7 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		struct target *ct;
 		if (target->rtos != NULL) {
 			target->rtos->current_threadid = target->rtos->current_thread;
-			LOG_DEBUG("current_threadid=%ld", target->rtos->current_threadid);
+			LOG_DEBUG("current_threadid=%" PRId64, target->rtos->current_threadid);
 			target->rtos->gdb_target_for_threadid(connection, target->rtos->current_threadid, &ct);
 		} else {
 			ct = target;

--- a/src/target/breakpoints.c
+++ b/src/target/breakpoints.c
@@ -98,7 +98,9 @@ fail:
 			return retval;
 	}
 
-	LOG_DEBUG("added %s breakpoint at " TARGET_ADDR_FMT " of length 0x%8.8x, (BPID: %" PRIu32 ")",
+	LOG_DEBUG("[%d] added %s breakpoint at " TARGET_ADDR_FMT
+			" of length 0x%8.8x, (BPID: %" PRIu32 ")",
+		target->coreid,
 		breakpoint_type_strings[(*breakpoint_p)->type],
 		(*breakpoint_p)->address, (*breakpoint_p)->length,
 		(*breakpoint_p)->unique_id);
@@ -385,8 +387,8 @@ struct breakpoint *breakpoint_find(struct target *target, target_addr_t address)
 	return NULL;
 }
 
-int watchpoint_add(struct target *target, target_addr_t address, uint32_t length,
-	enum watchpoint_rw rw, uint32_t value, uint32_t mask)
+int watchpoint_add_internal(struct target *target, target_addr_t address,
+		uint32_t length, enum watchpoint_rw rw, uint32_t value, uint32_t mask)
 {
 	struct watchpoint *watchpoint = target->watchpoints;
 	struct watchpoint **watchpoint_p = &target->watchpoints;
@@ -451,6 +453,29 @@ bye:
 	return ERROR_OK;
 }
 
+int watchpoint_add(struct target *target, target_addr_t address,
+		uint32_t length, enum watchpoint_rw rw, uint32_t value, uint32_t mask)
+{
+	int retval = ERROR_OK;
+	if (target->smp) {
+		struct target_list *head;
+		struct target *curr;
+		head = target->head;
+
+		while (head != (struct target_list *)NULL) {
+			curr = head->target;
+			retval = watchpoint_add_internal(curr, address, length, rw, value,
+					mask);
+			if (retval != ERROR_OK)
+				return retval;
+			head = head->next;
+		}
+		return retval;
+	} else
+		return watchpoint_add_internal(target, address, length, rw, value,
+				mask);
+}
+
 static void watchpoint_free(struct target *target, struct watchpoint *watchpoint_to_remove)
 {
 	struct watchpoint *watchpoint = target->watchpoints;
@@ -501,6 +526,8 @@ int watchpoint_hit(struct target *target, enum watchpoint_rw *rw,
 {
 	int retval;
 	struct watchpoint *hit_watchpoint;
+
+	LOG_DEBUG("[%d]", target->coreid);
 
 	retval = target_hit_watchpoint(target, &hit_watchpoint);
 	if (retval != ERROR_OK)

--- a/src/target/breakpoints.c
+++ b/src/target/breakpoints.c
@@ -549,8 +549,6 @@ int watchpoint_hit(struct target *target, enum watchpoint_rw *rw,
 	int retval;
 	struct watchpoint *hit_watchpoint;
 
-	LOG_DEBUG("[%d]", target->coreid);
-
 	retval = target_hit_watchpoint(target, &hit_watchpoint);
 	if (retval != ERROR_OK)
 		return ERROR_FAIL;

--- a/src/target/register.c
+++ b/src/target/register.c
@@ -36,6 +36,29 @@
  * may be separate registers associated with debug or trace modules.
  */
 
+struct reg *register_get_by_number(struct reg_cache *first,
+		uint32_t reg_num, bool search_all)
+{
+	unsigned i;
+	struct reg_cache *cache = first;
+
+	while (cache) {
+		for (i = 0; i < cache->num_regs; i++) {
+			if (cache->reg_list[i].exist == false)
+				continue;
+			if (cache->reg_list[i].number == reg_num)
+				return &(cache->reg_list[i]);
+		}
+
+		if (search_all)
+			cache = cache->next;
+		else
+			break;
+	}
+
+	return NULL;
+}
+
 struct reg *register_get_by_name(struct reg_cache *first,
 		const char *name, bool search_all)
 {

--- a/src/target/register.h
+++ b/src/target/register.h
@@ -159,6 +159,8 @@ struct reg_arch_type {
 	int (*set)(struct reg *reg, uint8_t *buf);
 };
 
+struct reg *register_get_by_number(struct reg_cache *first,
+		uint32_t reg_num, bool search_all);
 struct reg *register_get_by_name(struct reg_cache *first,
 		const char *name, bool search_all);
 struct reg_cache **register_get_last_cache_p(struct reg_cache **first);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2798,7 +2798,7 @@ static int riscv013_get_register(struct target *target,
 	int result = ERROR_OK;
 	if (rid == GDB_REGNO_PC) {
 		result = register_read(target, value, GDB_REGNO_DPC);
-		LOG_DEBUG("read PC from DPC: 0x%016" PRIx64, *value);
+		LOG_DEBUG("read PC from DPC: 0x%" PRIx64, *value);
 	} else if (rid == GDB_REGNO_PRIV) {
 		uint64_t dcsr;
 		result = register_read(target, &dcsr, GDB_REGNO_DCSR);
@@ -2822,7 +2822,7 @@ static int riscv013_set_register(struct target *target, int hid, int rid, uint64
 	if (rid <= GDB_REGNO_XPR31) {
 		return register_write_direct(target, rid, value);
 	} else if (rid == GDB_REGNO_PC) {
-		LOG_DEBUG("writing PC to DPC: 0x%016" PRIx64, value);
+		LOG_DEBUG("writing PC to DPC: 0x%" PRIx64, value);
 		register_write_direct(target, GDB_REGNO_DPC, value);
 		uint64_t actual_value;
 		register_read_direct(target, &actual_value, GDB_REGNO_DPC);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2952,6 +2952,7 @@ static enum riscv_halt_reason riscv013_halt_reason(struct target *target)
 		 * already set when we connected. Force enumeration now, which has the
 		 * side effect of clearing any triggers we did not set. */
 		riscv_enumerate_triggers(target);
+		LOG_DEBUG("[%d] halted because of trigger", target->coreid);
 		return RISCV_HALT_TRIGGER;
 	case CSR_DCSR_CAUSE_STEP:
 		return RISCV_HALT_SINGLESTEP;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1127,7 +1127,6 @@ static int register_write_direct(struct target *target, unsigned number,
 	if (result == ERROR_OK && target->reg_cache) {
 		struct reg *reg = &target->reg_cache->reg_list[number];
 		buf_set_u64(reg->value, 0, reg->size, value);
-		reg->valid = true;
 	}
 	if (result == ERROR_OK || info->progbufsize + r->impebreak < 2 ||
 			!riscv_is_halted(target))
@@ -1186,7 +1185,6 @@ static int register_write_direct(struct target *target, unsigned number,
 	if (exec_out == ERROR_OK && target->reg_cache) {
 		struct reg *reg = &target->reg_cache->reg_list[number];
 		buf_set_u64(reg->value, 0, reg->size, value);
-		reg->valid = true;
 	}
 
 	if (use_scratch)
@@ -1206,24 +1204,12 @@ static int register_read(struct target *target, uint64_t *value, uint32_t number
 		*value = 0;
 		return ERROR_OK;
 	}
-	if (target->reg_cache &&
-			(number <= GDB_REGNO_XPR31 ||
-			 (number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31))) {
-		/* Only check the cache for registers that we know won't spontaneously
-		 * change. */
-		struct reg *reg = &target->reg_cache->reg_list[number];
-		if (reg && reg->valid) {
-			*value = buf_get_u64(reg->value, 0, reg->size);
-			return ERROR_OK;
-		}
-	}
 	int result = register_read_direct(target, value, number);
 	if (result != ERROR_OK)
 		return ERROR_FAIL;
 	if (target->reg_cache) {
 		struct reg *reg = &target->reg_cache->reg_list[number];
 		buf_set_u64(reg->value, 0, reg->size, *value);
-		reg->valid = true;
 	}
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -267,7 +267,6 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 	riscv_semihosting_init(target);
 
 	target->debug_reason = DBG_REASON_DBGRQ;
-	LOG_DEBUG(">>> [%d] debug_reason=%d", target->coreid, target->debug_reason);
 
 	return ERROR_OK;
 }
@@ -991,13 +990,9 @@ static int riscv_get_gdb_reg_list(struct target *target,
 				target->reg_cache->reg_list[i].size > 0);
 		(*reg_list)[i] = &target->reg_cache->reg_list[i];
 		if (read && !target->reg_cache->reg_list[i].valid) {
-			// TODO: Confirm that this function is supposed to actually read
-			// registers. I'm just adding this because maybe
-			// hwthread_get_thread_reg_list() expects it.
-
-			// This function gets called from
-			// gdb_target_description_supported(), and we end up failing in
-			// that case. Allow failures for now.
+			/* This function gets called from
+			 * gdb_target_description_supported(), and we end up failing in
+			 * that case. Allow failures for now. */
 			if (target->reg_cache->reg_list[i].type->get(
 						&target->reg_cache->reg_list[i]) != ERROR_OK)
 				read = false;
@@ -1204,7 +1199,6 @@ int set_debug_reason(struct target *target, int hartid)
 		case RISCV_HALT_ERROR:
 			return ERROR_FAIL;
 	}
-	LOG_DEBUG(">>> [%d] debug_reason=%d", target->coreid, target->debug_reason);
 	return ERROR_OK;
 }
 
@@ -1368,7 +1362,6 @@ int riscv_openocd_halt(struct target *target)
 
 	target->state = TARGET_HALTED;
 	target->debug_reason = DBG_REASON_DBGRQ;
-	LOG_DEBUG(">>> [%d] debug_reason=%d", target->coreid, target->debug_reason);
 	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 	return result;
 }
@@ -1457,7 +1450,6 @@ int riscv_openocd_step(
 	target_call_event_callbacks(target, TARGET_EVENT_RESUMED);
 	target->state = TARGET_HALTED;
 	target->debug_reason = DBG_REASON_SINGLESTEP;
-	LOG_DEBUG(">>> [%d] debug_reason=%d", target->coreid, target->debug_reason);
 	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 	return out;
 }
@@ -2171,7 +2163,6 @@ int riscv_set_current_hartid(struct target *target, int hartid)
 
 	/* This might get called during init, in which case we shouldn't be
 	 * setting up the register cache. */
-	//if (target_was_examined(target) && hartid != previous_hartid)
 	if (target_was_examined(target) && riscv_rtos_enabled(target))
 		riscv_invalidate_register_cache(target);
 
@@ -2181,8 +2172,6 @@ int riscv_set_current_hartid(struct target *target, int hartid)
 void riscv_invalidate_register_cache(struct target *target)
 {
 	RISCV_INFO(r);
-
-	LOG_DEBUG(">>>");
 
 	register_cache_invalidate(target->reg_cache);
 	for (size_t i = 0; i < target->reg_cache->num_regs; ++i) {

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -867,13 +867,15 @@ static int old_or_new_riscv_halt(struct target *target)
 
 static int riscv_assert_reset(struct target *target)
 {
+	LOG_DEBUG("[%d]", target->coreid);
 	struct target_type *tt = get_target_type(target);
+	riscv_invalidate_register_cache(target);
 	return tt->assert_reset(target);
 }
 
 static int riscv_deassert_reset(struct target *target)
 {
-	LOG_DEBUG("RISCV DEASSERT RESET");
+	LOG_DEBUG("[%d]", target->coreid);
 	struct target_type *tt = get_target_type(target);
 	return tt->deassert_reset(target);
 }

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -1206,8 +1206,6 @@ int target_hit_watchpoint(struct target *target,
 		return ERROR_FAIL;
 	}
 
-	LOG_DEBUG("[%d]", target->coreid);
-
 	return target->type->hit_watchpoint(target, hit_watchpoint);
 }
 

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -1575,8 +1575,9 @@ int target_call_event_callbacks(struct target *target, enum target_event event)
 		target_call_event_callbacks(target, TARGET_EVENT_GDB_HALT);
 	}
 
-	LOG_DEBUG("target event %i (%s)", event,
-			Jim_Nvp_value2name_simple(nvp_target_event, event)->name);
+	LOG_DEBUG("target event %i (%s) for core %d", event,
+			Jim_Nvp_value2name_simple(nvp_target_event, event)->name,
+			target->coreid);
 
 	target_handle_event(target, event);
 

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -1206,6 +1206,8 @@ int target_hit_watchpoint(struct target *target,
 		return ERROR_FAIL;
 	}
 
+	LOG_DEBUG("[%d]", target->coreid);
+
 	return target->type->hit_watchpoint(target, hit_watchpoint);
 }
 


### PR DESCRIPTION
`-rtos hwthread` is a target-independent alternative to `-rtos riscv`. It's not in mainline OpenOCD yet. I took the code from http://openocd.zylin.com/#/c/3999/, and made some changes to get all our tests to pass. Specifically there's now a mechanism to read and write arbitrary registers. Another independent change is to treat triggers on SMP targets the same as hardware breakpoints: e.g. make sure they're set on each target that's part of the SMP group.

All our existing tests pass with either of the -rtos options now. To use this new feature, openocd.cfg needs to explicitly list each hart. So instead of:
```
target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
```

Use:
```
target create $_TARGETNAME_0 riscv -chain-position $_CHIPNAME.cpu -rtos hwthread
target create $_TARGETNAME_1 riscv -chain-position $_CHIPNAME.cpu -coreid 1
target smp $_TARGETNAME_0 $_TARGETNAME_1
```

It would be nice to deprecate `-rtos riscv` because it's more of a hack than `-rtos hwthread` and getting rid of it would make the riscv code a lot simpler.