### PR TITLE
Fix sending memory-map for 64-bit targets.

### DIFF
--- a/src/flash/nor/at91sam4.c
+++ b/src/flash/nor/at91sam4.c
@@ -2598,7 +2598,7 @@ static int sam4_info(struct flash_bank *bank, char *buf, int buf_size)
 	}
 
 	snprintf(buf, buf_size,
-		"%s bank %d: %d kB at 0x%08" PRIx32,
+		"%s bank %d: %d kB at 0x%08" TARGET_PRIxADDR,
 		pPrivate->pChip->details.name,
 		pPrivate->bank_number,
 		k,
@@ -2642,7 +2642,9 @@ static int sam4_probe(struct flash_bank *bank)
 	for (x = 0; x < SAM4_MAX_FLASH_BANKS; x++) {
 		if (bank->base == pPrivate->pChip->details.bank[x].base_address) {
 			bank->size = pPrivate->pChip->details.bank[x].size_bytes;
-			LOG_DEBUG("SAM4 Set flash bank to %08X - %08X, idx %d", bank->base, bank->base + bank->size, x);
+			LOG_DEBUG("SAM4 Set flash bank to %" TARGET_PRIxADDR " - %"
+					TARGET_PRIxADDR ", idx %d", bank->base,
+					bank->base + bank->size, x);
 			break;
 		}
 	}

--- a/src/flash/nor/at91sam4l.c
+++ b/src/flash/nor/at91sam4l.c
@@ -203,7 +203,8 @@ static int sam4l_flash_command(struct target *target, uint8_t cmd, int page)
 FLASH_BANK_COMMAND_HANDLER(sam4l_flash_bank_command)
 {
 	if (bank->base != SAM4L_FLASH) {
-		LOG_ERROR("Address 0x%08" PRIx32 " invalid bank address (try 0x%08" PRIx32
+		LOG_ERROR("Address 0x%08" TARGET_PRIxADDR
+				" invalid bank address (try 0x%08" PRIx32
 				"[at91sam4l series] )",
 				bank->base, SAM4L_FLASH);
 		return ERROR_FAIL;

--- a/src/flash/nor/at91samd.c
+++ b/src/flash/nor/at91samd.c
@@ -877,7 +877,8 @@ free_pb:
 FLASH_BANK_COMMAND_HANDLER(samd_flash_bank_command)
 {
 	if (bank->base != SAMD_FLASH) {
-		LOG_ERROR("Address 0x%08" PRIx32 " invalid bank address (try 0x%08" PRIx32
+		LOG_ERROR("Address 0x%08" TARGET_PRIxADDR
+				" invalid bank address (try 0x%08" PRIx32
 				"[at91samd series] )",
 				bank->base, SAMD_FLASH);
 		return ERROR_FAIL;

--- a/src/flash/nor/ath79.c
+++ b/src/flash/nor/ath79.c
@@ -796,7 +796,7 @@ static int ath79_probe(struct flash_bank *bank)
 
 	ath79_info->io_base = target_device->io_base;
 
-	LOG_DEBUG("Found device %s at address 0x%" PRIx32,
+	LOG_DEBUG("Found device %s at address 0x%" TARGET_PRIxADDR,
 		  target_device->name, bank->base);
 
 	retval = read_flash_id(bank, &id);

--- a/src/flash/nor/cfi.c
+++ b/src/flash/nor/cfi.c
@@ -890,7 +890,7 @@ static int cfi_intel_erase(struct flash_bank *bank, int first, int last)
 				return retval;
 
 			LOG_ERROR("couldn't erase block %i of flash bank at base 0x%"
-					PRIx32, i, bank->base);
+					TARGET_PRIxADDR, i, bank->base);
 			return ERROR_FLASH_OPERATION_FAILED;
 		}
 	}
@@ -938,7 +938,7 @@ static int cfi_spansion_erase(struct flash_bank *bank, int first, int last)
 				return retval;
 
 			LOG_ERROR("couldn't erase block %i of flash bank at base 0x%"
-				PRIx32, i, bank->base);
+				TARGET_PRIxADDR, i, bank->base);
 			return ERROR_FLASH_OPERATION_FAILED;
 		}
 	}
@@ -2006,8 +2006,9 @@ static int cfi_intel_write_word(struct flash_bank *bank, uint8_t *word, uint32_t
 		if (retval != ERROR_OK)
 			return retval;
 
-		LOG_ERROR("couldn't write word at base 0x%" PRIx32 ", address 0x%" PRIx32,
-			bank->base, address);
+		LOG_ERROR("couldn't write word at base 0x%" TARGET_PRIxADDR
+				", address 0x%" PRIx32,
+				bank->base, address);
 		return ERROR_FLASH_OPERATION_FAILED;
 	}
 
@@ -2031,9 +2032,9 @@ static int cfi_intel_write_words(struct flash_bank *bank, const uint8_t *word,
 
 	/* Check for valid range */
 	if (address & buffermask) {
-		LOG_ERROR("Write address at base 0x%" PRIx32 ", address 0x%" PRIx32
-			" not aligned to 2^%d boundary",
-			bank->base, address, cfi_info->max_buf_write_size);
+		LOG_ERROR("Write address at base 0x%" TARGET_PRIxADDR ", address 0x%"
+				PRIx32 " not aligned to 2^%d boundary",
+				bank->base, address, cfi_info->max_buf_write_size);
 		return ERROR_FLASH_OPERATION_FAILED;
 	}
 
@@ -2061,7 +2062,8 @@ static int cfi_intel_write_words(struct flash_bank *bank, const uint8_t *word,
 			return retval;
 
 		LOG_ERROR(
-			"couldn't start buffer write operation at base 0x%" PRIx32 ", address 0x%" PRIx32,
+			"couldn't start buffer write operation at base 0x%" TARGET_PRIxADDR
+			", address 0x%" PRIx32,
 			bank->base,
 			address);
 		return ERROR_FLASH_OPERATION_FAILED;
@@ -2090,7 +2092,7 @@ static int cfi_intel_write_words(struct flash_bank *bank, const uint8_t *word,
 		if (retval != ERROR_OK)
 			return retval;
 
-		LOG_ERROR("Buffer write at base 0x%" PRIx32
+		LOG_ERROR("Buffer write at base 0x%" TARGET_PRIxADDR
 			", address 0x%" PRIx32 " failed.", bank->base, address);
 		return ERROR_FLASH_OPERATION_FAILED;
 	}
@@ -2126,7 +2128,7 @@ static int cfi_spansion_write_word(struct flash_bank *bank, uint8_t *word, uint3
 		if (retval != ERROR_OK)
 			return retval;
 
-		LOG_ERROR("couldn't write word at base 0x%" PRIx32
+		LOG_ERROR("couldn't write word at base 0x%" TARGET_PRIxADDR
 			", address 0x%" PRIx32, bank->base, address);
 		return ERROR_FLASH_OPERATION_FAILED;
 	}
@@ -2152,7 +2154,7 @@ static int cfi_spansion_write_words(struct flash_bank *bank, const uint8_t *word
 
 	/* Check for valid range */
 	if (address & buffermask) {
-		LOG_ERROR("Write address at base 0x%" PRIx32
+		LOG_ERROR("Write address at base 0x%" TARGET_PRIxADDR
 			", address 0x%" PRIx32 " not aligned to 2^%d boundary",
 			bank->base, address, cfi_info->max_buf_write_size);
 		return ERROR_FLASH_OPERATION_FAILED;
@@ -2198,7 +2200,7 @@ static int cfi_spansion_write_words(struct flash_bank *bank, const uint8_t *word
 		if (retval != ERROR_OK)
 			return retval;
 
-		LOG_ERROR("couldn't write block at base 0x%" PRIx32
+		LOG_ERROR("couldn't write block at base 0x%" TARGET_PRIxADDR
 			", address 0x%" PRIx32 ", size 0x%" PRIx32, bank->base, address,
 			bufferwsize);
 		return ERROR_FLASH_OPERATION_FAILED;

--- a/src/flash/nor/core.c
+++ b/src/flash/nor/core.c
@@ -94,7 +94,8 @@ int flash_driver_write(struct flash_bank *bank,
 	retval = bank->driver->write(bank, buffer, offset, count);
 	if (retval != ERROR_OK) {
 		LOG_ERROR(
-			"error writing to flash at address 0x%08" PRIx32 " at offset 0x%8.8" PRIx32,
+			"error writing to flash at address 0x%08" TARGET_PRIxADDR
+			" at offset 0x%8.8" PRIx32,
 			bank->base,
 			offset);
 	}
@@ -112,7 +113,8 @@ int flash_driver_read(struct flash_bank *bank,
 	retval = bank->driver->read(bank, buffer, offset, count);
 	if (retval != ERROR_OK) {
 		LOG_ERROR(
-			"error reading to flash at address 0x%08" PRIx32 " at offset 0x%8.8" PRIx32,
+			"error reading to flash at address 0x%08" TARGET_PRIxADDR
+			" at offset 0x%8.8" PRIx32,
 			bank->base,
 			offset);
 	}

--- a/src/flash/nor/core.h
+++ b/src/flash/nor/core.h
@@ -91,7 +91,7 @@ struct flash_bank {
 	void *driver_priv; /**< Private driver storage pointer */
 
 	int bank_number; /**< The 'bank' (or chip number) of this instance. */
-	uint32_t base; /**< The base address of this bank */
+	target_addr_t base; /**< The base address of this bank */
 	uint32_t size; /**< The size of this chip bank, in bytes */
 
 	int chip_width; /**< Width of the chip in bytes (1,2,4 bytes) */

--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -929,12 +929,13 @@ static int fespi_probe(struct flash_bank *bank)
 
 		fespi_info->ctrl_base = target_device->ctrl_base;
 
-		LOG_DEBUG("Valid FESPI on device %s at address 0x%" PRIx32,
+		LOG_DEBUG("Valid FESPI on device %s at address 0x%" TARGET_PRIxADDR,
 				target_device->name, bank->base);
 
 	} else {
 	  LOG_DEBUG("Assuming FESPI as specified at address 0x%" TARGET_PRIxADDR
-			  " with ctrl at 0x%x", fespi_info->ctrl_base, bank->base);
+			  " with ctrl at 0x%" TARGET_PRIxADDR, fespi_info->ctrl_base,
+			  bank->base);
 	}
 
 	/* read and decode flash ID; returns in SW mode */

--- a/src/flash/nor/kinetis.c
+++ b/src/flash/nor/kinetis.c
@@ -1755,13 +1755,15 @@ static int kinetis_write_sections(struct flash_bank *bank, const uint8_t *buffer
 			result = target_write_memory(bank->target, k_chip->progr_accel_ram,
 						4, size_aligned / 4, buffer_aligned);
 
-			LOG_DEBUG("section @ %08" PRIx32 " aligned begin %" PRIu32 ", end %" PRIu32,
+			LOG_DEBUG("section @ %08" TARGET_PRIxADDR " aligned begin %" PRIu32
+					", end %" PRIu32,
 					bank->base + offset, align_begin, align_end);
 		} else
 			result = target_write_memory(bank->target, k_chip->progr_accel_ram,
 						4, size_aligned / 4, buffer);
 
-		LOG_DEBUG("write section @ %08" PRIx32 " with length %" PRIu32 " bytes",
+		LOG_DEBUG("write section @ %08" TARGET_PRIxADDR " with length %" PRIu32
+				" bytes",
 			  bank->base + offset, size);
 
 		if (result != ERROR_OK) {
@@ -1776,12 +1778,14 @@ static int kinetis_write_sections(struct flash_bank *bank, const uint8_t *buffer
 				0, 0, 0, 0,  &ftfx_fstat);
 
 		if (result != ERROR_OK) {
-			LOG_ERROR("Error writing section at %08" PRIx32, bank->base + offset);
+			LOG_ERROR("Error writing section at %08" TARGET_PRIxADDR,
+					bank->base + offset);
 			break;
 		}
 
 		if (ftfx_fstat & 0x01) {
-			LOG_ERROR("Flash write error at %08" PRIx32, bank->base + offset);
+			LOG_ERROR("Flash write error at %08" TARGET_PRIxADDR,
+					bank->base + offset);
 			if (k_bank->prog_base == 0 && offset == FCF_ADDRESS + FCF_SIZE
 					&& (k_chip->flash_support & FS_WIDTH_256BIT)) {
 				LOG_ERROR("Flash write immediately after the end of Flash Config Field shows error");
@@ -1820,7 +1824,7 @@ static int kinetis_write_inner(struct flash_bank *bank, const uint8_t *buffer,
 		}
 	}
 
-	LOG_DEBUG("flash write @ %08" PRIx32, bank->base + offset);
+	LOG_DEBUG("flash write @ %08" TARGET_PRIxADDR, bank->base + offset);
 
 	if (fallback == 0) {
 		/* program section command */
@@ -1873,12 +1877,14 @@ static int kinetis_write_inner(struct flash_bank *bank, const uint8_t *buffer,
 						0, 0, 0, 0,  &ftfx_fstat);
 
 				if (result != ERROR_OK) {
-					LOG_ERROR("Error writing longword at %08" PRIx32, bank->base + offset);
+					LOG_ERROR("Error writing longword at %08" TARGET_PRIxADDR,
+							bank->base + offset);
 					break;
 				}
 
 				if (ftfx_fstat & 0x01)
-					LOG_ERROR("Flash write error at %08" PRIx32, bank->base + offset);
+					LOG_ERROR("Flash write error at %08" TARGET_PRIxADDR,
+							bank->base + offset);
 
 				buffer += 4;
 				offset += 4;
@@ -2769,7 +2775,7 @@ static int kinetis_info(struct flash_bank *bank, char *buf, int buf_size)
 	uint32_t size_k = bank->size / 1024;
 
 	snprintf(buf, buf_size,
-		"%s %s: %" PRIu32 "k %s bank %s at 0x%08" PRIx32,
+		"%s %s: %" PRIu32 "k %s bank %s at 0x%08" TARGET_PRIxADDR,
 		bank->driver->name, k_chip->name,
 		size_k, bank_class_names[k_bank->flash_class],
 		bank->name, bank->base);

--- a/src/flash/nor/kinetis_ke.c
+++ b/src/flash/nor/kinetis_ke.c
@@ -1175,7 +1175,7 @@ static int kinetis_ke_auto_probe(struct flash_bank *bank)
 static int kinetis_ke_info(struct flash_bank *bank, char *buf, int buf_size)
 {
 	(void) snprintf(buf, buf_size,
-			"%s driver for flash bank %s at 0x%8.8" PRIx32 "",
+			"%s driver for flash bank %s at 0x%8.8" TARGET_PRIxADDR,
 			bank->driver->name,	bank->name, bank->base);
 
 	return ERROR_OK;

--- a/src/flash/nor/lpc2000.c
+++ b/src/flash/nor/lpc2000.c
@@ -1156,8 +1156,8 @@ static int lpc2000_write(struct flash_bank *bank, const uint8_t *buffer, uint32_
 			free(last_buffer);
 		}
 
-		LOG_DEBUG("writing 0x%" PRIx32 " bytes to address 0x%" PRIx32, thisrun_bytes,
-				bank->base + offset + bytes_written);
+		LOG_DEBUG("writing 0x%" PRIx32 " bytes to address 0x%" TARGET_PRIxADDR,
+				thisrun_bytes, bank->base + offset + bytes_written);
 
 		/* Write data */
 		param_table[0] = bank->base + offset + bytes_written;

--- a/src/flash/nor/niietcm4.c
+++ b/src/flash/nor/niietcm4.c
@@ -1584,9 +1584,11 @@ static int niietcm4_probe_k1921vk01t(struct flash_bank *bank)
 
 		char info_bootflash_addr_str[64];
 		if (niietcm4_info->bflash_info_remap)
-			snprintf(info_bootflash_addr_str, sizeof(info_bootflash_addr_str), "0x%08x base adress", bank->base);
+			snprintf(info_bootflash_addr_str, sizeof(info_bootflash_addr_str),
+					"0x%" TARGET_PRIxADDR " base adress", bank->base);
 		else
-			snprintf(info_bootflash_addr_str, sizeof(info_bootflash_addr_str), "not maped to global adress space");
+			snprintf(info_bootflash_addr_str, sizeof(info_bootflash_addr_str),
+					"not mapped to global adress space");
 
 		snprintf(niietcm4_info->chip_brief,
 				sizeof(niietcm4_info->chip_brief),

--- a/src/flash/nor/nrf5.c
+++ b/src/flash/nor/nrf5.c
@@ -905,7 +905,7 @@ FLASH_BANK_COMMAND_HANDLER(nrf5_flash_bank_command)
 		bank->bank_number = 1;
 		break;
 	default:
-		LOG_ERROR("Invalid bank address 0x%08" PRIx32, bank->base);
+		LOG_ERROR("Invalid bank address 0x%08" TARGET_PRIxADDR, bank->base);
 		return ERROR_FAIL;
 	}
 

--- a/src/flash/nor/numicro.c
+++ b/src/flash/nor/numicro.c
@@ -1496,7 +1496,8 @@ static int numicro_erase(struct flash_bank *bank, int first, int last)
 		return retval;
 
 	for (i = first; i <= last; i++) {
-		LOG_DEBUG("erasing sector %d at address 0x%" PRIx32 "", i, bank->base + bank->sectors[i].offset);
+		LOG_DEBUG("erasing sector %d at address 0x%" TARGET_PRIxADDR, i,
+				bank->base + bank->sectors[i].offset);
 		retval = target_write_u32(target, NUMICRO_FLASH_ISPADR, bank->base + bank->sectors[i].offset);
 		if (retval != ERROR_OK)
 			return retval;
@@ -1678,7 +1679,8 @@ static int numicro_get_flash_size(struct flash_bank *bank, const struct numicro_
 	for (size_t i = 0; i < cpu->n_banks; i++) {
 		if (bank->base == cpu->bank[i].base) {
 			*flash_size = cpu->bank[i].size;
-			LOG_INFO("bank base = 0x%08" PRIx32 ", size = 0x%08" PRIx32 "", bank->base, *flash_size);
+			LOG_INFO("bank base = 0x%08" TARGET_PRIxADDR ", size = 0x%08"
+					PRIx32, bank->base, *flash_size);
 			return ERROR_OK;
 		}
 	}

--- a/src/flash/nor/pic32mx.c
+++ b/src/flash/nor/pic32mx.c
@@ -620,7 +620,7 @@ static int pic32mx_write(struct flash_bank *bank, const uint8_t *buffer, uint32_
 		return ERROR_TARGET_NOT_HALTED;
 	}
 
-	LOG_DEBUG("writing to flash at address 0x%08" PRIx32 " at offset 0x%8.8" PRIx32
+	LOG_DEBUG("writing to flash at address 0x%08" TARGET_PRIxADDR " at offset 0x%8.8" PRIx32
 			" count: 0x%8.8" PRIx32 "", bank->base, offset, count);
 
 	if (offset & 0x3) {

--- a/src/flash/nor/stm32h7x.c
+++ b/src/flash/nor/stm32h7x.c
@@ -834,7 +834,7 @@ static int stm32x_probe(struct flash_bank *bank)
 			flash_size_in_kb = stm32x_info->part_info->first_bank_size_kb;
 		} else {
 			LOG_WARNING("STM32H flash bank base address config is incorrect."
-				    " 0x%" PRIx32 " but should rather be 0x%" PRIx32 " or 0x%" PRIx32,
+				    " 0x%" TARGET_PRIxADDR " but should rather be 0x%" PRIx32 " or 0x%" PRIx32,
 					bank->base, base_address, second_bank_base);
 			return ERROR_FAIL;
 		}

--- a/src/flash/nor/stm32lx.c
+++ b/src/flash/nor/stm32lx.c
@@ -824,7 +824,8 @@ static int stm32lx_probe(struct flash_bank *bank)
 			flash_size_in_kb = stm32lx_info->part_info.first_bank_size_kb;
 		} else {
 			LOG_WARNING("STM32L flash bank base address config is incorrect."
-				    " 0x%" PRIx32 " but should rather be 0x%" PRIx32 " or 0x%" PRIx32,
+					" 0x%" TARGET_PRIxADDR " but should rather be 0x%" PRIx32
+					" or 0x%" PRIx32,
 						bank->base, base_address, second_bank_base);
 			return ERROR_FAIL;
 		}

--- a/src/flash/nor/stmsmi.c
+++ b/src/flash/nor/stmsmi.c
@@ -557,13 +557,13 @@ static int stmsmi_probe(struct flash_bank *bank)
 			stmsmi_info->bank_num = SMI_SEL_BANK3;
 			break;
 		default:
-			LOG_ERROR("Invalid SMI base address 0x%" PRIx32, bank->base);
+			LOG_ERROR("Invalid SMI base address 0x%" TARGET_PRIxADDR, bank->base);
 			return ERROR_FAIL;
 	}
 	io_base = target_device->io_base;
 	stmsmi_info->io_base = io_base;
 
-	LOG_DEBUG("Valid SMI on device %s at address 0x%" PRIx32,
+	LOG_DEBUG("Valid SMI on device %s at address 0x%" TARGET_PRIxADDR,
 		target_device->name, bank->base);
 
 	/* read and decode flash ID; returns in SW mode */

--- a/src/flash/nor/tcl.c
+++ b/src/flash/nor/tcl.c
@@ -104,7 +104,7 @@ COMMAND_HANDLER(handle_flash_info_command)
 			return retval;
 
 		command_print(CMD_CTX,
-			"#%d : %s at 0x%8.8" PRIx32 ", size 0x%8.8" PRIx32
+			"#%d : %s at 0x%8.8" TARGET_PRIxADDR ", size 0x%8.8" PRIx32
 			", buswidth %i, chipwidth %i",
 			p->bank_number,
 			p->driver->name,
@@ -169,7 +169,7 @@ COMMAND_HANDLER(handle_flash_probe_command)
 		retval = p->driver->probe(p);
 		if (retval == ERROR_OK)
 			command_print(CMD_CTX,
-				"flash '%s' found at 0x%8.8" PRIx32,
+				"flash '%s' found at 0x%8.8" TARGET_PRIxADDR,
 				p->driver->name,
 				p->base);
 	} else {
@@ -197,7 +197,8 @@ COMMAND_HANDLER(handle_flash_erase_check_command)
 		command_print(CMD_CTX, "successfully checked erase state");
 	else {
 		command_print(CMD_CTX,
-			"unknown error when checking erase state of flash bank #%s at 0x%8.8" PRIx32,
+			"unknown error when checking erase state of flash bank #%s at 0x%8.8"
+			TARGET_PRIxADDR,
 			CMD_ARGV[0],
 			p->base);
 	}
@@ -1130,7 +1131,7 @@ COMMAND_HANDLER(handle_flash_bank_command)
 	c->name = strdup(bank_name);
 	c->target = target;
 	c->driver = driver;
-	COMMAND_PARSE_NUMBER(u32, CMD_ARGV[1], c->base);
+	COMMAND_PARSE_NUMBER(target_addr, CMD_ARGV[1], c->base);
 	COMMAND_PARSE_NUMBER(u32, CMD_ARGV[2], c->size);
 	COMMAND_PARSE_NUMBER(int, CMD_ARGV[3], c->chip_width);
 	COMMAND_PARSE_NUMBER(int, CMD_ARGV[4], c->bus_width);
@@ -1140,8 +1141,8 @@ COMMAND_HANDLER(handle_flash_bank_command)
 	int retval;
 	retval = CALL_COMMAND_HANDLER(driver->flash_bank_command, c);
 	if (ERROR_OK != retval) {
-		LOG_ERROR("'%s' driver rejected flash bank at 0x%8.8" PRIx32 "; usage: %s",
-			driver_name, c->base, driver->usage);
+		LOG_ERROR("'%s' driver rejected flash bank at 0x%8.8" TARGET_PRIxADDR
+				"; usage: %s", driver_name, c->base, driver->usage);
 		free(c);
 		return retval;
 	}
@@ -1161,7 +1162,7 @@ COMMAND_HANDLER(handle_flash_banks_command)
 
 	unsigned n = 0;
 	for (struct flash_bank *p = flash_bank_list(); p; p = p->next, n++) {
-		LOG_USER("#%d : %s (%s) at 0x%8.8" PRIx32 ", size 0x%8.8" PRIx32 ", "
+		LOG_USER("#%d : %s (%s) at 0x%8.8" TARGET_PRIxADDR ", size 0x%8.8" PRIx32 ", "
 			"buswidth %u, chipwidth %u", p->bank_number,
 			p->name, p->driver->name, p->base, p->size,
 			p->bus_width, p->chip_width);

--- a/src/flash/nor/tms470.c
+++ b/src/flash/nor/tms470.c
@@ -165,7 +165,8 @@ static int tms470_read_part_info(struct flash_bank *bank)
 			part_name = "TMS470R1A256";
 
 			if (bank->base >= 0x00040000) {
-				LOG_ERROR("No %s flash bank contains base address 0x%08" PRIx32 ".",
+				LOG_ERROR("No %s flash bank contains base address 0x%08"
+						TARGET_PRIxADDR ".",
 						part_name,
 						bank->base);
 				return ERROR_FLASH_OPERATION_FAILED;
@@ -204,7 +205,7 @@ static int tms470_read_part_info(struct flash_bank *bank)
 				(void)memcpy(bank->sectors, TMS470R1A288_BANK1_SECTORS,
 						sizeof(TMS470R1A288_BANK1_SECTORS));
 			} else {
-				LOG_ERROR("No %s flash bank contains base address 0x%08" PRIx32 ".",
+				LOG_ERROR("No %s flash bank contains base address 0x%08" TARGET_PRIxADDR ".",
 						part_name, bank->base);
 				return ERROR_FLASH_OPERATION_FAILED;
 			}
@@ -244,7 +245,7 @@ static int tms470_read_part_info(struct flash_bank *bank)
 				(void)memcpy(bank->sectors, TMS470R1A384_BANK2_SECTORS,
 						sizeof(TMS470R1A384_BANK2_SECTORS));
 			} else {
-				LOG_ERROR("No %s flash bank contains base address 0x%08" PRIx32 ".",
+				LOG_ERROR("No %s flash bank contains base address 0x%08" TARGET_PRIxADDR ".",
 						part_name, bank->base);
 				return ERROR_FLASH_OPERATION_FAILED;
 			}
@@ -900,8 +901,8 @@ static int tms470_write(struct flash_bank *bank, const uint8_t *buffer, uint32_t
 
 	tms470_read_part_info(bank);
 
-	LOG_INFO("Writing %" PRId32 " bytes starting at 0x%08" PRIx32 "", count, bank->base +
-		offset);
+	LOG_INFO("Writing %" PRId32 " bytes starting at 0x%08" TARGET_PRIxADDR,
+			count, bank->base + offset);
 
 	/* set GLBCTRL.4  */
 	target_read_u32(target, 0xFFFFFFDC, &glbctrl);

--- a/src/flash/nor/virtual.c
+++ b/src/flash/nor/virtual.c
@@ -185,7 +185,7 @@ static int virtual_info(struct flash_bank *bank, char *buf, int buf_size)
 	if (master_bank == NULL)
 		return ERROR_FLASH_OPERATION_FAILED;
 
-	snprintf(buf, buf_size, "%s driver for flash bank %s at 0x%8.8" PRIx32 "",
+	snprintf(buf, buf_size, "%s driver for flash bank %s at 0x%8.8" TARGET_PRIxADDR,
 			bank->driver->name, master_bank->name, master_bank->base);
 
 	return ERROR_OK;

--- a/src/flash/nor/xmc4xxx.c
+++ b/src/flash/nor/xmc4xxx.c
@@ -778,7 +778,7 @@ static int xmc4xxx_write(struct flash_bank *bank, const uint8_t *buffer,
 		memcpy(&tmp_buf[start_pad], buffer, remaining);
 
 		if (end_pad) {
-			LOG_INFO("Padding end of page @%08"PRIx32" by %d bytes",
+			LOG_INFO("Padding end of page @%08" TARGET_PRIxADDR " by %d bytes",
 				 bank->base + offset, end_pad);
 			memset(&tmp_buf[256 - end_pad], 0xff, end_pad);
 		}

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -96,7 +96,7 @@ struct gdb_connection {
 	char *thread_list;
 };
 
-#if 0
+#if 1
 #define _DEBUG_GDB_IO_
 #endif
 
@@ -1919,11 +1919,10 @@ static int gdb_memory_map(struct connection *connection,
 	if (ram_start != 0)
 		xml_printf(&retval, &xml, &pos, &size,
 			"<memory type=\"ram\" start=\"" TARGET_ADDR_FMT "\" "
-			"length=\"0x%x\"/>\n",
-			ram_start, 0-ram_start);
-	/* ELSE a flash chip could be at the very end of the 32 bit address
-	 * space, in which case ram_start will be precisely 0
-	 */
+			"length=\"" TARGET_ADDR_FMT "\"/>\n",
+			ram_start, TARGET_ADDR_MAX - ram_start + 1);
+	/* ELSE a flash chip could be at the very end of the address space, in
+	 * which case ram_start will be precisely 0 */
 
 	free(banks);
 


### PR DESCRIPTION
See #202. I don't have a proper target with >32-bit flash and memory
location, so I've been unable to properly test this. However, if I hack
the fespi driver to not do anything and run the 64-bit spike tests I can
see that the memory map OpenOCD sends now includes the full 64-bit
address space:
Debug: 3443 975 gdb_server.c:400 gdb_put_packet_inner(): sending packet
'$l<memory-map>
<memory type="ram" start="0x00000000" length="0x20000000"/>
<memory type="ram" start="0x20000000" length="0xffffffffe0000000"/>
</memory-map>

It will also do this when the target is 32-bit, but that doesn't seem to
have any ill effects on gdb.

Change-Id: I0fd070ab7366188ff0259d90386f5e1f6985ce21