### PR TITLE
Set up halt groups for SMP groups.

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -5839,6 +5839,7 @@ static int jim_target_smp(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 	int i;
 	const char *targetname;
 	int retval, len;
+	static int smp_group = 1;
 	struct target *target = (struct target *) NULL;
 	struct target_list *head, *curr, *new;
 	curr = (struct target_list *) NULL;
@@ -5874,10 +5875,11 @@ static int jim_target_smp(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 
 	while (curr != (struct target_list *)NULL) {
 		target = curr->target;
-		target->smp = 1;
+		target->smp = smp_group;
 		target->head = head;
 		curr = curr->next;
 	}
+	smp_group++;
 
 	if (target && target->rtos)
 		retval = rtos_smp_init(head->target);


### PR DESCRIPTION
If the hardware supports it, when one hart in an SMP group halts all the
other harts in that same SMP group will automatically, quickly, halt as
well.

Change-Id: Ida81f1309c180674e8c9d8060e3d2a4bbb910a6f