### PR TITLE
riscv: Do the sign-extending from bit 39 of DPC CSR

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1818,6 +1818,13 @@ static riscv_error_t handle_halt_routine(struct target *target)
 	info->dpc = reg_cache_get(target, CSR_DPC);
 	info->dcsr = reg_cache_get(target, CSR_DCSR);
 
+	/*
+	 * ROCK erratum: The DPC CSR correctly retains only the low 40 bits of
+	 * the PC. Do the sign-extending from bit 39 of DPC.
+	 */
+	if (info->dpc & (1UL << 39))
+		info->dpc |= 0xffffff0000000000UL;
+
 	cache_invalidate(target);
 
 	return RE_OK;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1321,6 +1321,15 @@ static int register_read_direct(struct target *target, uint64_t *value, uint32_t
 			return ERROR_FAIL;
 	}
 
+	/*
+	 * ROCK erratum: The DPC CSR correctly retains only the low 40 bits of
+	 * the PC. Do the sign-extending from bit 39 of DPC.
+	 */
+	if (number == GDB_REGNO_PC || number == GDB_REGNO_DPC) {
+		if (*value & (1UL << 39))
+			*value |= 0xffffff0000000000UL;
+	}
+
 	if (result == ERROR_OK) {
 		LOG_DEBUG("{%d} reg[0x%x] = 0x%" PRIx64, riscv_current_hartid(target),
 				number, *value);


### PR DESCRIPTION
The DPC CSR correctly retains only the low 40 bits of the PC when
entering debug mode. When the CSR is read, the result should be
sign-extended to 64 bits but is not. This is a published erratum
of the ROCK processor. Let's workaround this issue in the debugger.