### PR TITLE
Support simultaneous resume using hasel

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -259,7 +259,7 @@ static int riscv_gdb_v_packet(struct connection *connection, const char *packet,
 		target_call_event_callbacks(target, TARGET_EVENT_GDB_START);
 		target_call_event_callbacks(target, TARGET_EVENT_RESUME_START);
 		riscv_set_all_rtos_harts(target);
-		riscv_openocd_resume(target, 1, 0, 0, 0);
+		riscv_resume(target, 1, 0, 0, 0);
 		target->state = TARGET_RUNNING;
 		gdb_set_frontend_state_running(connection);
 		target_call_event_callbacks(target, TARGET_EVENT_RESUMED);

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1927,12 +1927,6 @@ static int riscv011_resume(struct target *target, int current,
 {
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
-	if (!current) {
-		int result = register_write(target, GDB_REGNO_PC, address);
-		if (result != ERROR_OK)
-			return result;
-	}
-
 	if (handle_breakpoints) {
 		int result = strict_step(target, false);
 		if (result != ERROR_OK)

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1927,12 +1927,6 @@ static int riscv011_resume(struct target *target, int current,
 {
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
-	if (handle_breakpoints) {
-		int result = strict_step(target, false);
-		if (result != ERROR_OK)
-			return result;
-	}
-
 	return resume(target, debug_execution, false);
 }
 

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1479,7 +1479,6 @@ static int examine(struct target *target)
 	}
 
 	RISCV_INFO(r);
-	r->hart_count = 1;
 
 	riscv011_info_t *info = get_info(target);
 	info->addrbits = get_field(dtmcontrol, DTMCONTROL_ADDRBITS);
@@ -1925,8 +1924,10 @@ static int riscv011_poll(struct target *target)
 static int riscv011_resume(struct target *target, int current,
 		target_addr_t address, int handle_breakpoints, int debug_execution)
 {
+	RISCV_INFO(r);
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
+	r->prepped = false;
 	return resume(target, debug_execution, false);
 }
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3011,7 +3011,7 @@ static int select_prepped_harts(struct target *target, bool *use_hasel)
 	}
 
 	for (unsigned i = 0; i < hawindow_count; i++) {
-		if (dmi_write(target, DMI_HAWINDOWSEL, 0) != ERROR_OK)
+		if (dmi_write(target, DMI_HAWINDOWSEL, i) != ERROR_OK)
 			return ERROR_FAIL;
 		if (dmi_write(target, DMI_HAWINDOW, hawindow[i]) != ERROR_OK)
 			return ERROR_FAIL;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2822,7 +2822,7 @@ struct target_type riscv013_target = {
 
 	.poll = &riscv_openocd_poll,
 	.halt = &riscv_openocd_halt,
-	.resume = &riscv_openocd_resume,
+	.resume = &riscv_resume,
 	.step = &riscv_openocd_step,
 
 	.assert_reset = assert_reset,

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -163,7 +163,7 @@ int riscv_openocd_poll(struct target *target);
 
 int riscv_openocd_halt(struct target *target);
 
-int riscv_openocd_resume(
+int riscv_resume(
 	struct target *target,
 	int current,
 	target_addr_t address,
@@ -192,7 +192,6 @@ void riscv_info_init(struct target *target, riscv_info_t *r);
 int riscv_halt_all_harts(struct target *target);
 int riscv_halt_one_hart(struct target *target, int hartid);
 int riscv_resume_all_harts(struct target *target);
-int riscv_resume_one_hart(struct target *target, int hartid);
 
 /* Steps the hart that's currently selected in the RTOS, or if there is no RTOS
  * then the only hart. */

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -110,7 +110,8 @@ typedef struct {
 	bool (*is_halted)(struct target *target);
 	int (*halt_current_hart)(struct target *);
 	/* Resume this target, as well as every other prepped target that can be
-	 * resumed near-simultaneously. */
+	 * resumed near-simultaneously. Clear the prepped flag on any target that
+	 * was resumed. */
 	int (*resume_go)(struct target *target);
 	int (*step_current_hart)(struct target *target);
 	int (*on_halt)(struct target *target);
@@ -198,7 +199,6 @@ void riscv_info_init(struct target *target, riscv_info_t *r);
  * the system. */
 int riscv_halt_all_harts(struct target *target);
 int riscv_halt_one_hart(struct target *target, int hartid);
-int riscv_resume_all_harts(struct target *target);
 
 /* Steps the hart that's currently selected in the RTOS, or if there is no RTOS
  * then the only hart. */


### PR DESCRIPTION
This involved a lot of refactoring, breaking up resume into prep/go/finish. I took the opportunity to pull some common code out of riscv-0{11,13} into riscv.c, and to get rid of a some of the unused layers of abstraction.

This code works great with spike, but doesn't seem effective with the Arty board. I don't know where that problem lies, but I suspect if there is an OpenOCD bug it'll be a relatively small change to address it, so it's worth reviewing now.