### PR TITLE
More carefully ignore line numbers/time stamps.

### DIFF
--- a/tools/filter_openocd_log.py
+++ b/tools/filter_openocd_log.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 import sys
+import re
 
 # This function is the only OpenOCD-specific part of this script.
 def make_canonical(line):
     # Remove the line number and time stamp.
-    parts = line.split(None, 3)
-    if len(parts) > 3:
-        return "%s - - %s" % (parts[0], parts[3])
+    m = re.match(r"(Debug|Error|Info |User |Warn ): \d+ \d+ (.*)", line)
+    if m:
+        return "%s: - - %s\n" % (m.group(1), m.group(2))
     else:
         return line
 


### PR DESCRIPTION
This helps when there are other kinds of text in the same file as the
openocd log.

Change-Id: I38da7d6685769a323930d6aab6cd83b7f27ea90f