### PR TITLE
RISC-V: Make compliance tests more verbose

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3528,14 +3528,22 @@ void riscv013_clear_abstract_error(struct target *target)
 	dmi_write(target, DMI_ABSTRACTCS, abstractcs & DMI_ABSTRACTCS_CMDERR);
 }
 
+#ifdef _WIN32
+#define FILE_SEP '\\'
+#else
+#define FILE_SEP '/'
+#endif
 #define COMPLIANCE_TEST(b, message) \
-{                                   \
+{ \
+	const char *last_sep = strrchr(__FILE__, FILE_SEP); \
+	const char *fname = (last_sep == NULL ? __FILE__ : last_sep + 1); \
+	LOG_INFO("Executing test %d (%s:%d): %s", total_tests, fname, __LINE__, message); \
 	int pass = 0;		    \
 	if (b) {		    \
 		pass = 1;	    \
 		passed_tests++;     \
 	}			    \
-	LOG_INFO("%s test %d (%s)\n", (pass) ? "PASSED" : "FAILED",  total_tests, message); \
+	LOG_INFO("  %s", (pass) ? "PASSED" : "FAILED"); \
 	assert(pass);		    \
 	total_tests++;		    \
 }


### PR DESCRIPTION
Currently the RISC-V compliance test suite doesn't output the test is
currently runs before it succeeds. It also uses the same message for
many tests. This makes it very hard to find out which test fails.

This commit makes things slightly easier by printing the test that's
being executed before it actually runs, and by adding the source code
line where the test is located, making it easier to look up the test in
the source code.

New output looks like this:

Info : Executing test 149 (riscv-013.c:3800): Regular calls must return ERROR_OK
Info :   PASSED