### PR TITLE
RISC-V compliance test: target must be examined

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3564,6 +3564,12 @@ int riscv013_test_compliance(struct target *target)
 		return ERROR_FAIL;
 	}
 
+	if (!target_was_examined(target)) {
+		LOG_ERROR("Cannot run compliance test, because target has not yet "
+			"been examined, or the examination failed.\n");
+		return ERROR_FAIL;
+	}
+
 	int total_tests = 0;
 	int passed_tests = 0;
 


### PR DESCRIPTION
The test assumes that the target has been examined. If that fails (for
whatever reason) the test will segfault:

Program received signal SIGSEGV, Segmentation fault.
register_cache_invalidate (cache=0x0) at ../src/target/register.c:109
109             struct reg *reg = cache->reg_list;
(gdb) bt
0  register_cache_invalidate (cache=0x0) at ../src/target/register.c:109
1  0x0000000000520735 in riscv_invalidate_register_cache (target=target@entry=0x779b50) at ../src/target/riscv/riscv.c:2160
2  0x000000000052224f in riscv_halt_all_harts (target=target@entry=0x779b50) at ../src/target/riscv/riscv.c:2022
3  0x0000000000574e82 in riscv013_test_compliance (target=0x779b50) at ../src/target/riscv/riscv-013.c:3600