### PR TITLE
For BSCAN tunneling, USER4 only needs to be scanned into IR once

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2257,6 +2257,13 @@ COMMAND_HANDLER(riscv_use_bscan_tunnel)
 
 	bscan_tunnel_type = tunnel_type;
 	bscan_tunnel_ir_width = irwidth;
+	/* Set things up to generate another one-time loading of USER4 into IR the first time
+	   a RISCV scan happens from this point,  in case somebody transitioned out of bscan
+	   tunneling mode and did some other activity on the outer JTAG chain after having
+	   been in bscan tunneling mode at an earlier time within the same lifetime of this
+	   process (which may have loaded a different IR value). */
+	bscan_user4_selected = false;  
+
 	return ERROR_OK;
 }
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -172,7 +172,7 @@ struct scan_field select_idcode = {
 
 bscan_tunnel_type_t bscan_tunnel_type;
 int bscan_tunnel_ir_width; /* if zero, then tunneling is not present/active */
-bool bscan_user4_selected = false;
+bool bscan_user4_selected;
 
 uint8_t bscan_zero[4] = {0};
 uint8_t bscan_one[4] = {1};
@@ -277,7 +277,7 @@ static int riscv_resume_go_all_harts(struct target *target);
 void select_dmi_via_bscan(struct target *target)
 {
 	if (!bscan_user4_selected) {
-		jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);	  
+		jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);
 		bscan_user4_selected = true;
 	}
 	if (bscan_tunnel_type == BSCAN_TUNNEL_DATA_REGISTER)
@@ -356,7 +356,7 @@ uint32_t dtmcontrol_scan_via_bscan(struct target *target, uint32_t out)
 	}
 
 	if (!bscan_user4_selected) {
-		jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);		
+		jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);
 		bscan_user4_selected = true;
 	}
 


### PR DESCRIPTION
Within a debug session, no value other than USER4 ends up getting scanned into the IR of the boundary scan chain.  So as an optimization, we can load IR once, and then refrain from loading it again.