### PR TITLE
BSCAN batch fix

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -56,11 +56,11 @@ int riscv_batch_run(struct riscv_batch *batch)
 	riscv_batch_add_nop(batch);
 
 	for (size_t i = 0; i < batch->used_scans; ++i) {
-		if (bscan_tunnel_ir_width != 0) {
+		if (bscan_tunnel_ir_width != 0)
 			riscv_add_bscan_tunneled_scan(batch->target, batch->fields+i, batch->bscan_ctxt+i);
-		} else {
+		else
 			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
-		}
+
 		if (batch->idle_count > 0)
 			jtag_add_runtest(batch->idle_count, TAP_IDLE);
 	}

--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -43,9 +43,9 @@ bool riscv_batch_full(struct riscv_batch *batch)
 
 int riscv_batch_run(struct riscv_batch *batch)
 {
-	uint8_t tunneled_dr_width;  
+	uint8_t tunneled_dr_width;
 	struct scan_field tunneled_dr[4];
-	
+
 	if (batch->used_scans == 0) {
 		LOG_DEBUG("Ignoring empty batch.");
 		return ERROR_OK;
@@ -77,7 +77,7 @@ int riscv_batch_run(struct riscv_batch *batch)
 				tunneled_dr[0].num_bits = 3;
 				tunneled_dr[0].out_value = bscan_zero;
 			} else {
-			  	/* BSCAN_TUNNEL_NESTED_TAP */
+				/* BSCAN_TUNNEL_NESTED_TAP */
 				tunneled_dr[0].num_bits = 1;
 				tunneled_dr[0].out_value = bscan_one;
 				tunneled_dr[1].num_bits = 7;
@@ -92,7 +92,6 @@ int riscv_batch_run(struct riscv_batch *batch)
 				tunneled_dr[3].out_value = bscan_zero;
 			}
 			jtag_add_dr_scan(batch->target->tap, DIM(tunneled_dr), tunneled_dr, TAP_IDLE);
-		  
 		} else {
 			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
 		}
@@ -105,9 +104,11 @@ int riscv_batch_run(struct riscv_batch *batch)
 		return ERROR_FAIL;
 	}
 
-	if (bscan_tunnel_ir_width != 0)
+	if (bscan_tunnel_ir_width != 0) {
+		/* need to right-shift "in" by one bit, because of clock skew between BSCAN TAP and DM TAP */
 		for (size_t i = 0; i < batch->used_scans; ++i)
-			buffer_shr((batch->fields + i)->in_value, sizeof(uint64_t), 1);	/* need to right-shift "in" by one bit, because of clock skew between BSCAN TAP and DM TAP */
+			buffer_shr((batch->fields + i)->in_value, sizeof(uint64_t), 1);
+	}
 
 	for (size_t i = 0; i < batch->used_scans; ++i)
 		dump_field(batch->idle_count, batch->fields + i);

--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -8,7 +8,6 @@
 
 #define get_field(reg, mask) (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
 #define set_field(reg, mask, val) (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
-#define DIM(x)		(sizeof(x)/sizeof(*x))
 
 static void dump_field(int idle, const struct scan_field *field);
 
@@ -91,7 +90,7 @@ int riscv_batch_run(struct riscv_batch *batch)
 				tunneled_dr[3].num_bits = 3;
 				tunneled_dr[3].out_value = bscan_zero;
 			}
-			jtag_add_dr_scan(batch->target->tap, DIM(tunneled_dr), tunneled_dr, TAP_IDLE);
+			jtag_add_dr_scan(batch->target->tap, ARRAY_SIZE(tunneled_dr), tunneled_dr, TAP_IDLE);
 		} else {
 			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
 		}

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -3,6 +3,7 @@
 
 #include "target/target.h"
 #include "jtag/jtag.h"
+#include "riscv.h"
 
 enum riscv_scan_type {
 	RISCV_SCAN_TYPE_INVALID,
@@ -26,6 +27,11 @@ struct riscv_batch {
 	uint8_t *data_out;
 	uint8_t *data_in;
 	struct scan_field *fields;
+
+	/* If in BSCAN mode, this field will be allocated (one per scan),
+	   and utilized to tunnel all the scans in the batch.  If not in
+	   BSCAN mode, this field is unallocated and stays NULL */
+	riscv_bscan_tunneled_scan_context_t *bscan_ctxt;
 
 	/* In JTAG we scan out the previous value's output when performing a
 	 * scan.  This is a pain for users, so we just provide them the

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -484,8 +484,7 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
 		.out_value = out,
 		.in_value = in
 	};
-	uint8_t tunneled_dr_width;
-	struct scan_field tunneled_dr[4];
+	riscv_bscan_tunneled_scan_context_t bscan_ctxt;
 
 	if (r->reset_delays_wait >= 0) {
 		r->reset_delays_wait--;
@@ -510,48 +509,7 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
 	   the best fit.  Declaring stack based field values in a subsidiary function call wouldn't
 	   work. */
 	if (bscan_tunnel_ir_width != 0) {
-		jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);
-
-		/* I wanted to use struct initialization syntax, but that would involve either
-		   declaring the variable within this scope (which would go out of scope at runtime
-		   before the JTAG queue gets executed, which is an error waiting to happen), or
-		   initializing outside of the check for whether a BSCAN tunnel was active (which
-		   would be a waste of CPU time when BSCAN tunnel is not being used. So I declared the
-		   struct at the function's top-level, so its lifetime exceeds the point at which
-		   the queue is executed, and initializing with assignments here. */
-		memset(tunneled_dr, 0, sizeof(tunneled_dr));
-		if (bscan_tunnel_type == BSCAN_TUNNEL_DATA_REGISTER) {
-			tunneled_dr[3].num_bits = 1;
-			tunneled_dr[3].out_value = bscan_one;
-			tunneled_dr[2].num_bits = 7;
-			tunneled_dr_width = num_bits;
-			tunneled_dr[2].out_value = &tunneled_dr_width;
-			/* for BSCAN tunnel, there is a one-TCK skew between shift in and shift out, so
-			   scanning num_bits + 1, and then will right shift the input field after executing the queues */
-
-			tunneled_dr[1].num_bits = num_bits+1;
-			tunneled_dr[1].out_value = out;
-			tunneled_dr[1].in_value = in;
-
-
-			tunneled_dr[0].num_bits = 3;
-			tunneled_dr[0].out_value = bscan_zero;
-		} else {
-			/* BSCAN_TUNNEL_NESTED_TAP */
-			tunneled_dr[0].num_bits = 1;
-			tunneled_dr[0].out_value = bscan_one;
-			tunneled_dr[1].num_bits = 7;
-			tunneled_dr_width = num_bits;
-			tunneled_dr[1].out_value = &tunneled_dr_width;
-			/* for BSCAN tunnel, there is a one-TCK skew between shift in and shift out, so
-			   scanning num_bits + 1, and then will right shift the input field after executing the queues */
-			tunneled_dr[2].num_bits = num_bits+1;
-			tunneled_dr[2].out_value = out;
-			tunneled_dr[2].in_value = in;
-			tunneled_dr[3].num_bits = 3;
-			tunneled_dr[3].out_value = bscan_zero;
-		}
-		jtag_add_dr_scan(target->tap, DIM(tunneled_dr), tunneled_dr, TAP_IDLE);
+		riscv_add_bscan_tunneled_scan(target, &field, &bscan_ctxt);
 	} else {
 		/* Assume dbus is already selected. */
 		jtag_add_dr_scan(target->tap, 1, &field, TAP_IDLE);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -6,6 +6,7 @@ struct riscv_program;
 #include <stdint.h>
 #include "opcodes.h"
 #include "gdb_regs.h"
+#include "jtag/jtag.h"
 
 /* The register cache is statically allocated. */
 #define RISCV_MAX_HARTS 32
@@ -146,6 +147,12 @@ typedef struct {
 	/* How many harts are attached to the DM that this target is attached to? */
 	int (*hart_count)(struct target *target);
 } riscv_info_t;
+
+typedef struct {
+	uint8_t tunneled_dr_width;
+	struct scan_field tunneled_dr[4];
+} riscv_bscan_tunneled_scan_context_t;
+
 
 /* Wall-clock timeout for a command/access. Settable via RISC-V Target commands.*/
 extern int riscv_command_timeout_sec;
@@ -290,5 +297,8 @@ int riscv_init_registers(struct target *target);
 
 void riscv_semihosting_init(struct target *target);
 int riscv_semihosting(struct target *target, int *retval);
+
+void riscv_add_bscan_tunneled_scan(struct target *target, struct scan_field *field,
+		riscv_bscan_tunneled_scan_context_t *ctxt);
 
 #endif


### PR DESCRIPTION
The batch submission of DMI scans was not taking appropriate action in the case of BSCAN mode, but instead sending non-tunnel formatted JTAG scans instead, which was causing undefined behavior.