### PR TITLE
Fixed write_memory_progbuf() on RV64.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3204,7 +3204,7 @@ static int write_memory_progbuf(struct target *target, target_addr_t address,
 				/* Write and execute command that moves value into S1 and
 				 * executes program buffer. */
 				uint32_t command = access_register_command(target,
-						GDB_REGNO_S1, size > 4 ? 64 : 32,
+						GDB_REGNO_S1, riscv_xlen(target),
 						AC_ACCESS_REGISTER_POSTEXEC |
 						AC_ACCESS_REGISTER_TRANSFER |
 						AC_ACCESS_REGISTER_WRITE);


### PR DESCRIPTION
Abstract write size (aarsize) shall always match the real
size of the register. This is because abstract write of smaller size
than the register need not be supported per the spec (pg. 13 of RISC-V
External Debug Support ver. 0.13.2).