### PR TITLE
Remove unused data structure.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2523,12 +2523,8 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 
 	memset(r->trigger_unique_id, 0xff, sizeof(r->trigger_unique_id));
 
-	for (size_t h = 0; h < RISCV_MAX_HARTS; ++h) {
+	for (size_t h = 0; h < RISCV_MAX_HARTS; ++h)
 		r->xlen[h] = -1;
-
-		for (size_t e = 0; e < RISCV_MAX_REGISTERS; ++e)
-			r->valid_saved_registers[h][e] = false;
-	}
 }
 
 static int riscv_resume_go_all_harts(struct target *target)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -56,11 +56,6 @@ typedef struct {
 	 * every function than an actual */
 	int current_hartid;
 
-	/* Enough space to store all the registers we might need to save. */
-	/* FIXME: This should probably be a bunch of register caches. */
-	uint64_t saved_registers[RISCV_MAX_HARTS][RISCV_MAX_REGISTERS];
-	bool valid_saved_registers[RISCV_MAX_HARTS][RISCV_MAX_REGISTERS];
-
 	/* OpenOCD's register cache points into here. This is not per-hart because
 	 * we just invalidate the entire cache when we change which hart is
 	 * selected. */


### PR DESCRIPTION
Saves 1.4MiB of RAM too, with just 1 hart configured.

Change-Id: I68d8c003a67c280b62ff6c9285ac6f54865f99f2