### PR TITLE
Fix of DMI batch scans over 64-bits

### DIFF
--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -60,9 +60,11 @@ int riscv_batch_run(struct riscv_batch *batch);
 void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint64_t data);
 
 /* DMI reads must be handled in two parts: the first one schedules a read and
- * provides a key, the second one actually obtains the value of that read .*/
+ * provides a key, the second one actually obtains the result of the read -
+ * status (op) and the actual data. */
 size_t riscv_batch_add_dmi_read(struct riscv_batch *batch, unsigned address);
-uint64_t riscv_batch_get_dmi_read(struct riscv_batch *batch, size_t key);
+unsigned riscv_batch_get_dmi_read_op(struct riscv_batch *batch, size_t key);
+uint32_t riscv_batch_get_dmi_read_data(struct riscv_batch *batch, size_t key);
 
 /* Scans in a NOP. */
 void riscv_batch_add_nop(struct riscv_batch *batch);

--- a/src/target/riscv/debug_defines.h
+++ b/src/target/riscv/debug_defines.h
@@ -98,6 +98,7 @@
  */
 #define DTM_DMI_ADDRESS_OFFSET              34
 #define DTM_DMI_ADDRESS_LENGTH              abits
+#define DTM_DMI_MAX_ADDRESS_LENGTH          63
 #define DTM_DMI_ADDRESS                     (((1L<<abits)-1) << DTM_DMI_ADDRESS_OFFSET)
 /*
 * The data to send to the DM over the DMI during Update-DR, and


### PR DESCRIPTION
This fixes buffer overrun/data corruption during DMI scan batches
on targets where the DMI scans would be longer than 64 bits.
Needed for targets with large value of dtmcs.abits > 30 (which is 
unusual, but within the spec). 