### PR TITLE
target/riscv : Fix resume PC value after semihosting file IO operation

### DIFF
--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -190,5 +190,11 @@ static int riscv_semihosting_post_result(struct target *target)
 
 	LOG_DEBUG("0x%" PRIx64, semihosting->result);
 	riscv_set_register(target, GDB_REGNO_A0, semihosting->result);
+
+	riscv_reg_t dpc;
+	riscv_get_register(target, &dpc, GDB_REGNO_DPC);
+	riscv_set_register(target, GDB_REGNO_DPC, dpc + 4);
+
+
 	return 0;
 }


### PR DESCRIPTION
After performing semihosting file io operation the target is resumed at its current pc ( an ebreak ).
Which re-trigger a semihosting operation.

Adding 4 ( semihosting code use norvc ) to the PC  to resume on the next instruction.

Signed-off-by: Benjamin Vinot <benjamin.vinot@emmicroelectronic.com>