### PR TITLE
Deal with a case where DMI read returns busy.

### DIFF
--- a/src/helper/log.h
+++ b/src/helper/log.h
@@ -151,6 +151,7 @@ extern int debug_level;
 #define ERROR_WAIT						(-5)
 /* ERROR_TIMEOUT is already taken by winerror.h. */
 #define ERROR_TIMEOUT_REACHED			(-6)
+#define ERROR_BUSY						(-7)
 
 
 #endif /* OPENOCD_HELPER_LOG_H */

--- a/src/helper/log.h
+++ b/src/helper/log.h
@@ -151,7 +151,7 @@ extern int debug_level;
 #define ERROR_WAIT						(-5)
 /* ERROR_TIMEOUT is already taken by winerror.h. */
 #define ERROR_TIMEOUT_REACHED			(-6)
-#define ERROR_BUSY						(-7)
+#define ERROR_TARGET_BUSY				(-7)
 
 
 #endif /* OPENOCD_HELPER_LOG_H */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -610,7 +610,7 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
 					/* The scan where we should have gotten the read value
 					 * returned busy.  It's anybody's guess whether the read
 					 * actually happened or not. */
-					return ERROR_BUSY;
+					return ERROR_TARGET_BUSY;
 				}
 			} else if (status == DMI_STATUS_SUCCESS) {
 				break;
@@ -2312,7 +2312,7 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 				i++) {
 			int result = read_memory_bus_word(target, address + i * size, size,
 					buffer + i * size);
-			if (result == ERROR_BUSY) {
+			if (result == ERROR_TARGET_BUSY) {
 				busy = true;
 				break;
 			} else if (result != ERROR_OK) {
@@ -2337,7 +2337,7 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 				!get_field(sbcs_read, DMI_SBCS_SBBUSYERROR)) {
 			int result = read_memory_bus_word(target, address + (count - 1) * size, size,
 						buffer + (count - 1) * size);
-			if (result == ERROR_BUSY)
+			if (result == ERROR_TARGET_BUSY)
 				busy = true;
 			else if (result != ERROR_OK)
 				return result;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2337,11 +2337,10 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 				!get_field(sbcs_read, DMI_SBCS_SBBUSYERROR)) {
 			int result = read_memory_bus_word(target, address + (count - 1) * size, size,
 						buffer + (count - 1) * size);
-			if (result == ERROR_BUSY) {
+			if (result == ERROR_BUSY)
 				busy = true;
-			} else if (result != ERROR_OK) {
+			else if (result != ERROR_OK)
 				return result;
-			}
 
 			if (read_sbcs_nonbusy(target, &sbcs_read) != ERROR_OK)
 				return ERROR_FAIL;


### PR DESCRIPTION
This was exposed by the latest change, which modifies the number of
scans enough that this problem is now exposed by the testsuite.

This particular failure could happen in more cases, but I don't have the
time to address everything right now. In the real world they'll be very
rare. It only shows up in the test because it intentionally resets the
learned delays while a memory access is happening..

Change-Id: Ia865eb76ed630c3d836131a065ec2dad0657c9b4