### PR TITLE
Fix bugs. Do not touch SATP if there is no MMU.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1367,7 +1367,7 @@ static int riscv_mmu(struct target *target, int *enabled)
 	if (!riscv_enable_virt2phys) {
 		*enabled = 0;
 		return ERROR_OK;
-        }
+	}
 
 	if (riscv_rtos_enabled(target))
 		riscv_set_current_hartid(target, target->rtos->current_thread - 1);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1364,6 +1364,11 @@ static int riscv_select_current_hart(struct target *target)
 
 static int riscv_mmu(struct target *target, int *enabled)
 {
+	if (!riscv_enable_virt2phys) {
+		*enabled = 0;
+		return ERROR_OK;
+        }
+
 	if (riscv_rtos_enabled(target))
 		riscv_set_current_hartid(target, target->rtos->current_thread - 1);
 
@@ -1483,9 +1488,6 @@ static int riscv_address_translate(struct target *target,
 
 static int riscv_virt2phys(struct target *target, target_addr_t virtual, target_addr_t *physical)
 {
-	if (!riscv_enable_virt2phys)
-		return ERROR_FAIL;
-
 	int enabled;
 	if (riscv_mmu(target, &enabled) == ERROR_OK) {
 		if (!enabled)


### PR DESCRIPTION
In some platform, there is no SATP register at all. OpenOCD will report unexpected errors if SATP is unreadable. So, use 'riscv_enable_virtual' to guard SATP access.