### PR TITLE
Handle DMI busy in sba write.

### DIFF
--- a/src/helper/log.h
+++ b/src/helper/log.h
@@ -151,6 +151,6 @@ extern int debug_level;
 #define ERROR_WAIT						(-5)
 /* ERROR_TIMEOUT is already taken by winerror.h. */
 #define ERROR_TIMEOUT_REACHED			(-6)
-
+#define ERROR_TARGET_BUSY				(-7)
 
 #endif /* OPENOCD_HELPER_LOG_H */

--- a/src/helper/log.h
+++ b/src/helper/log.h
@@ -152,4 +152,5 @@ extern int debug_level;
 /* ERROR_TIMEOUT is already taken by winerror.h. */
 #define ERROR_TIMEOUT_REACHED			(-6)
 
+
 #endif /* OPENOCD_HELPER_LOG_H */

--- a/src/helper/log.h
+++ b/src/helper/log.h
@@ -151,6 +151,5 @@ extern int debug_level;
 #define ERROR_WAIT						(-5)
 /* ERROR_TIMEOUT is already taken by winerror.h. */
 #define ERROR_TIMEOUT_REACHED			(-6)
-#define ERROR_TARGET_BUSY				(-7)
 
 #endif /* OPENOCD_HELPER_LOG_H */

--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -162,14 +162,13 @@ void dump_field(int idle, const struct scan_field *field)
 
 		log_printf_lf(LOG_LVL_DEBUG,
 				__FILE__, __LINE__, __PRETTY_FUNCTION__,
-				"%db %di %s %08x @%02x -> %s %08x @%02x",
-				field->num_bits, idle,
-				op_string[out_op], out_data, out_address,
-				status_string[in_op], in_data, in_address);
+				"%db %s %08x @%02x -> %s %08x @%02x; %di",
+				field->num_bits, op_string[out_op], out_data, out_address,
+				status_string[in_op], in_data, in_address, idle);
 	} else {
 		log_printf_lf(LOG_LVL_DEBUG,
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, "%db %di %s %08x @%02x -> ?",
-				field->num_bits, idle, op_string[out_op], out_data, out_address);
+				__FILE__, __LINE__, __PRETTY_FUNCTION__, "%db %s %08x @%02x -> ?; %di",
+				field->num_bits, op_string[out_op], out_data, out_address, idle);
 	}
 }
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -548,7 +548,7 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
  * @param address  The address argument to that operation.
  * @param data_out The data to send to the target.
  * @param exec     When true, this scan will execute something, so extra RTI
- * 				   cycles may be added.
+ *                 cycles may be added.
  * @param ensure_success
  *                 Scan a nop after the requested operation, ensuring the
  *                 DMI operation succeeded.

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -552,7 +552,9 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
  * @param ensure_success
  *                 Scan a nop after the requested operation, ensuring the
  *                 DMI operation succeeded.
- * @param retry    When true, retry the operation if busy was encountered.
+ * @param retry    When true, retry the operation if busy was encountered. This
+ *                 convenient and generally desirable, unless the command
+ *                 has side effects (e.g. incrementing an address).
  */
 static int dmi_op_timeout(struct target *target, uint32_t *data_in,
 		int dmi_op, uint32_t address, uint32_t data_out, int timeout_sec,

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -622,14 +622,6 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
 			} else if (status == DMI_STATUS_SUCCESS) {
 				break;
 			} else {
-				LOG_ERROR("failed %s (NOP) at 0x%x, status=%d", op_name, address,
-						status);
-				return ERROR_FAIL;
-			}
-			if (time(NULL) - start > timeout_sec)
-				return ERROR_TIMEOUT_REACHED;
-
-			if (status == DMI_STATUS_FAILED) {
 				if (data_in) {
 					LOG_ERROR("Failed %s (NOP) at 0x%x; value=0x%x, status=%d",
 							op_name, address, *data_in, status);
@@ -639,6 +631,8 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
 				}
 				return ERROR_FAIL;
 			}
+			if (time(NULL) - start > timeout_sec)
+				return ERROR_TIMEOUT_REACHED;
 		}
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -395,10 +395,9 @@ static void dump_field(int idle, const struct scan_field *field)
 
 	log_printf_lf(LOG_LVL_DEBUG,
 			__FILE__, __LINE__, "scan",
-			"%db %di %s %08x @%02x -> %s %08x @%02x",
-			field->num_bits, idle,
-			op_string[out_op], out_data, out_address,
-			status_string[in_op], in_data, in_address);
+			"%db %s %08x @%02x -> %s %08x @%02x; %di",
+			field->num_bits, op_string[out_op], out_data, out_address,
+			status_string[in_op], in_data, in_address, idle);
 
 	char out_text[500];
 	char in_text[500];


### PR DESCRIPTION
If we encounter DMI busy on the NOP after a read, we'll never get the
value out because DMI busy is sticky. The read must be retried, but we
don't know whether it was ever issued. Since the read has side effects
(incrementing of the address) this retry must be handled at a higher
layer. So now dmi_op_timeout can be told to retry or not, and if retry
is disabled it'll return an error when busy.

Also actually properly do the retry in dmi_op_timeout(). Previously the
code would not reissue the command and end up returning a garbage value.

This is a cleaner alternative to #434 