### PR TITLE
Don't issue extra FENCE+FENCE.i for the current hart.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2010,6 +2010,10 @@ static int execute_fence(struct target *target)
 		if (!riscv_hart_enabled(target, i))
 			continue;
 
+		if (i == old_hartid)
+			/* Fence already executed for this hart */
+			continue;
+
 		riscv_set_current_hartid(target, i);
 
 		struct riscv_program program;


### PR DESCRIPTION
The original OpenOCD code issued FENCE & FENCE.i twice for the current
hart (which is harmless, but takes time).

Avoiding this extra FENCE is a slight performance improvement. Per my rough
measurements, this improves performance of certain debugger actions
(single-stepping) by approx. 20% in single-hart systems.