### PR TITLE
sysctl.h is deprecated

### DIFF
--- a/src/helper/options.c
+++ b/src/helper/options.c
@@ -34,9 +34,6 @@
 #if IS_DARWIN
 #include <libproc.h>
 #endif
-#ifdef HAVE_SYS_SYSCTL_H
-#include <sys/sysctl.h>
-#endif
 #if IS_WIN32 && !IS_CYGWIN
 #include <windows.h>
 #endif


### PR DESCRIPTION
In file included from src/helper/options.c:38:
/usr/include/x86_64-linux-gnu/sys/sysctl.h:21:2: error: #warning "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror=cpp]
   21 | #warning "The <sys/sysctl.h> header is deprecated and will be removed."
      |  ^~~~~~~
cc1: all warnings being treated as errors