### PR TITLE
helper: skip including sys/sysctl.h on Linux

### DIFF
--- a/src/helper/options.c
+++ b/src/helper/options.c
@@ -34,8 +34,11 @@
 #if IS_DARWIN
 #include <libproc.h>
 #endif
+/* sys/sysctl.h is deprecated on Linux from glibc 2.30 */
+#ifndef __linux__
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 #endif
 #if IS_WIN32 && !IS_CYGWIN
 #include <windows.h>


### PR DESCRIPTION
Starting from glibc 2.30, the header file sys/sysctl.h gets
deprecated on Linux, after the commit 744e82963716 ("Linux:
Deprecate <sys/sysctl.h> and sysctl")
	https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=744e82963716

The associated NEWS reports
	The Linux-specific <sys/sysctl.h> header and the sysctl
	function have been deprecated and will be removed from a
	future version of glibc.

Latest automake 1.16.1 still does not handle this case.
Current OpenOCD build fails with warning and requires configure
with "--disable-werror" to build.

Prevent including sys/sysctl.h on Linux build.

Change-Id: I5310976573352a96e5aef123352f73475f0c35fe
Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>
Reviewed-on: http://openocd.zylin.com/5317
Tested-by: jenkins
Reviewed-by: Moritz Fischer <moritz.fischer.private@gmail.com>
Reviewed-by: Paul Fertser <fercerpav@gmail.com>

Cherry picked this from mainline, as an alternative to #447.