### PR TITLE
Fix address translation when high bits are set.

### DIFF
--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -176,7 +176,9 @@ typedef struct {
 } riscv_bscan_tunneled_scan_context_t;
 
 typedef struct {
+	const char *name;
 	int level;
+	unsigned va_bits;
 	unsigned pte_shift;
 	unsigned vpn_shift[PG_MAX_LEVEL];
 	unsigned vpn_mask[PG_MAX_LEVEL];


### PR DESCRIPTION
Fixes #452.
Also check that the high bits match the MSB of the virtual address.

Change-Id: Ib1d3d04db9ad9327ef71ea3736d5cf5d3b65b9c4