### PR TITLE
Add support for HiFive1 RevB board

### DIFF
--- a/contrib/60-openocd.rules
+++ b/contrib/60-openocd.rules
@@ -109,6 +109,7 @@ ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1015", MODE="660", GROUP="plugdev", 
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1016", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1017", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1018", MODE="660", GROUP="plugdev", TAG+="uaccess"
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1051", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
 # Raisonance RLink
 ATTRS{idVendor}=="138e", ATTRS{idProduct}=="9000", MODE="660", GROUP="plugdev", TAG+="uaccess"

--- a/src/flash/nor/fespi.c
+++ b/src/flash/nor/fespi.c
@@ -136,7 +136,8 @@ struct fespi_target {
 /* TODO !!! What is the right naming convention here? */
 static const struct fespi_target target_devices[] = {
 	/* name,   tap_idcode, ctrl_base */
-	{ "Freedom E300 SPI Flash",  0x10e31913 , 0x10014000 },
+	{ "Freedom E310-G000 SPI Flash",  0x10e31913 , 0x10014000 },
+	{ "Freedom E310-G002 SPI Flash",  0x20000913 , 0x10014000 },
 	{ NULL,    0,           0          }
 };
 

--- a/src/jtag/drivers/libjaylink/contrib/99-libjaylink.rules
+++ b/src/jtag/drivers/libjaylink/contrib/99-libjaylink.rules
@@ -37,5 +37,6 @@ ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1015", MODE="664", GROUP="plugdev"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1016", MODE="664", GROUP="plugdev"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1017", MODE="664", GROUP="plugdev"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1018", MODE="664", GROUP="plugdev"
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1051", MODE="664", GROUP="plugdev"
 
 LABEL="libjaylink_end_rules"

--- a/src/jtag/drivers/libjaylink/libjaylink/discovery_usb.c
+++ b/src/jtag/drivers/libjaylink/libjaylink/discovery_usb.c
@@ -59,7 +59,8 @@ static const uint16_t pids[][2] = {
 	{0x1015, 0},
 	{0x1016, 0},
 	{0x1017, 0},
-	{0x1018, 0}
+	{0x1018, 0},
+	{0x1051, 0},
 };
 
 /** Maximum length of the USB string descriptor for the serial number. */

--- a/tcl/board/sifive-hifive1-revb.cfg
+++ b/tcl/board/sifive-hifive1-revb.cfg
@@ -1,0 +1,24 @@
+adapter_khz 4000
+
+interface jlink
+transport select jtag
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x20000913
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME
+$_TARGETNAME.0 configure -work-area-phys 0x80000000 -work-area-size 0x4000 -work-area-backup 0
+
+riscv set_enable_virt2phys off
+riscv set_enable_virtual off
+
+flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME.0
+
+init
+
+jlink jtag 3
+
+halt
+flash protect 0 64 last off
+echo "Ready for Remote Connections"


### PR DESCRIPTION
Adds new PID (0x1051) used on board to libjaylink, and add config
and flash entry for RevB board and FE310-G002 respectively.