### PR TITLE
Deal with vlenb being unreadable.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1541,8 +1541,12 @@ static int discover_vlenb(struct target *target, int hartid)
 	RISCV_INFO(r);
 	riscv_reg_t vlenb;
 
-	if (register_read(target, &vlenb, GDB_REGNO_VLENB) != ERROR_OK)
-		return ERROR_FAIL;
+	if (register_read(target, &vlenb, GDB_REGNO_VLENB) != ERROR_OK) {
+		LOG_WARNING("Couldn't read vlenb for %s; vector register access won't "
+				"work.", target_name(target));
+		r->vlenb[hartid] = 0;
+		return ERROR_OK;
+	}
 	r->vlenb[hartid] = vlenb;
 
 	LOG_INFO("hart %d: Vector support with vlenb=%d", hartid, r->vlenb[hartid]);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4023,7 +4023,7 @@ int riscv_init_registers(struct target *target)
 
 		} else if (number >= GDB_REGNO_V0 && number <= GDB_REGNO_V31) {
 			r->caller_save = false;
-			r->exist = riscv_supports_extension(target, hartid, 'V');
+			r->exist = riscv_supports_extension(target, hartid, 'V') && info->vlenb[hartid];
 			r->size = info->vlenb[hartid] * 8;
 			sprintf(reg_name, "v%d", number - GDB_REGNO_V0);
 			r->group = "vector";

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -75,6 +75,7 @@ typedef struct {
 	/* It's possible that each core has a different supported ISA set. */
 	int xlen[RISCV_MAX_HARTS];
 	riscv_reg_t misa[RISCV_MAX_HARTS];
+	/* Cached value of vlenb. 0 if vlenb is not readable for some reason. */
 	unsigned vlenb[RISCV_MAX_HARTS];
 
 	/* The number of triggers per hart. */


### PR DESCRIPTION
Instead of exiting during examine(), spit out a warning, and don't
expose the vector data registers. We do provide access to the vector
CSRs, because maybe they do work? It's just that we have no idea what
the size of the data registers is.

Change-Id: I6e9ffeb242e2e22fc62cb1b50782c2efb4ace0bd