### PR TITLE
Fix accesses for true-64bit destinations in RPC

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -4206,7 +4206,7 @@ static int target_mem2array(Jim_Interp *interp, struct target *target, int argc,
 	long l;
 	uint32_t width;
 	int len;
-	uint32_t addr;
+	uint64_t addr;
 	uint32_t count;
 	uint32_t v;
 	const char *varname;
@@ -4288,7 +4288,7 @@ static int target_mem2array(Jim_Interp *interp, struct target *target, int argc,
 	} else {
 		char buf[100];
 		Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
-		sprintf(buf, "mem2array address: 0x%08" PRIx32 " is not aligned for %" PRId32 " byte reads",
+		sprintf(buf, "mem2array address: 0x%016" PRIx64 " is not aligned for %" PRId32 " byte reads",
 				addr,
 				width);
 		Jim_AppendStrings(interp, Jim_GetResult(interp), buf, NULL);
@@ -4320,7 +4320,7 @@ static int target_mem2array(Jim_Interp *interp, struct target *target, int argc,
 			retval = target_read_memory(target, addr, width, count, buffer);
 		if (retval != ERROR_OK) {
 			/* BOO !*/
-			LOG_ERROR("mem2array: Read @ 0x%08" PRIx32 ", w=%" PRId32 ", cnt=%" PRId32 ", failed",
+			LOG_ERROR("mem2array: Read @ 0x%016" PRIx64 ", w=%" PRId32 ", cnt=%" PRId32 ", failed",
 					  addr,
 					  width,
 					  count);
@@ -4409,7 +4409,7 @@ static int target_array2mem(Jim_Interp *interp, struct target *target,
 	long l;
 	uint32_t width;
 	int len;
-	uint32_t addr;
+	uint64_t addr;
 	uint32_t count;
 	uint32_t v;
 	const char *varname;
@@ -4494,7 +4494,7 @@ static int target_array2mem(Jim_Interp *interp, struct target *target,
 	} else {
 		char buf[100];
 		Jim_SetResult(interp, Jim_NewEmptyStringObj(interp));
-		sprintf(buf, "array2mem address: 0x%08" PRIx32 " is not aligned for %" PRId32 " byte reads",
+		sprintf(buf, "array2mem address: 0x%016" PRIx64 " is not aligned for %" PRId32 " byte reads",
 				addr,
 				width);
 		Jim_AppendStrings(interp, Jim_GetResult(interp), buf, NULL);
@@ -4543,7 +4543,7 @@ static int target_array2mem(Jim_Interp *interp, struct target *target,
 			retval = target_write_memory(target, addr, width, count, buffer);
 		if (retval != ERROR_OK) {
 			/* BOO !*/
-			LOG_ERROR("array2mem: Write @ 0x%08" PRIx32 ", w=%" PRId32 ", cnt=%" PRId32 ", failed",
+			LOG_ERROR("array2mem: Write @ 0x%016" PRIx64 ", w=%" PRId32 ", cnt=%" PRId32 ", failed",
 					  addr,
 					  width,
 					  count);


### PR DESCRIPTION
`mem2array` and `array2mem` are used to read and write memory from
a TCL socket, and the implementation did not support true-64bit
locations (i.e. addr >= 1 << 32) due to uint32_t.  This commit
fixes this.