### PR TITLE
Don't propagate failure to read satp in riscv_mmu()

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1382,10 +1382,11 @@ static int riscv_mmu(struct target *target, int *enabled)
 		riscv_set_current_hartid(target, target->rtos->current_thread - 1);
 
 	riscv_reg_t value;
-	int result = riscv_get_register(target, &value, GDB_REGNO_SATP);
-	if (result != ERROR_OK) {
+	if (riscv_get_register(target, &value, GDB_REGNO_SATP) != ERROR_OK) {
 		LOG_DEBUG("Couldn't read SATP.");
-		return result;
+		/* If we can't read SATP, then there must not be an MMU. */
+		*enabled = 0;
+		return ERROR_OK;
 	}
 
 	if (get_field(value, RISCV_SATP_MODE(riscv_xlen(target))) == SATP_MODE_OFF) {


### PR DESCRIPTION
If we return failure, then the caller will think something's wrong. But
it could very well be that the hardware doesn't have SATP, in which case
we should just report that the MMU is disabled.

This fixes a bug where flashing wasn't using the target algorithm
because allocating a work area failed.

Change-Id: I16e8e660036d3f8584c0b17e842c4ec8961a8410