### PR TITLE
Don't cache PC, but do cache DPC.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3014,13 +3014,15 @@ static bool gdb_regno_cacheable(enum gdb_regno regno, bool write)
 	/* GPRs, FPRs, vector registers are just normal data stores. */
 	if (regno <= GDB_REGNO_XPR31 ||
 			(regno >= GDB_REGNO_FPR0 && regno <= GDB_REGNO_FPR31) ||
-			(regno >= GDB_REGNO_V0 && regno <= GDB_REGNO_V31) ||
-			regno == GDB_REGNO_PC)
+			(regno >= GDB_REGNO_V0 && regno <= GDB_REGNO_V31))
 		return true;
 
 	/* Most CSRs won't change value on us, but we can't assume it about rbitrary
 	 * CSRs. */
 	switch (regno) {
+		case GDB_REGNO_DPC:
+			return true;
+
 		case GDB_REGNO_VSTART:
 		case GDB_REGNO_VXSAT:
 		case GDB_REGNO_VXRM:
@@ -3028,7 +3030,6 @@ static bool gdb_regno_cacheable(enum gdb_regno regno, bool write)
 		case GDB_REGNO_VL:
 		case GDB_REGNO_VTYPE:
 		case GDB_REGNO_MISA:
-		case GDB_REGNO_DPC:
 		case GDB_REGNO_DCSR:
 		case GDB_REGNO_DSCRATCH:
 		case GDB_REGNO_MSTATUS:


### PR DESCRIPTION
This fixes a bug where we read PC and marked it cached without actually
updating the cached value. The DPC value was correctly marked as valid
and updated.

Change-Id: Id6d3e94a96b981688b06f7f4a998019f2c02f6f5