### PR TITLE
Fix semihosting for multicore targets

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -267,7 +267,7 @@ static int riscv_gdb_v_packet(struct connection *connection, const char *packet,
 		target_call_event_callbacks(target, TARGET_EVENT_GDB_START);
 		target_call_event_callbacks(target, TARGET_EVENT_RESUME_START);
 		riscv_set_all_rtos_harts(target);
-		riscv_resume(target, 1, 0, 0, 0);
+		riscv_resume(target, 1, 0, 0, 0, false);
 		target->state = TARGET_RUNNING;
 		gdb_set_frontend_state_running(connection);
 		target_call_event_callbacks(target, TARGET_EVENT_RESUMED);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3599,7 +3599,6 @@ struct target_type riscv013_target = {
 
 	.poll = &riscv_openocd_poll,
 	.halt = &riscv_halt,
-	.resume = &riscv_resume,
 	.step = &riscv_openocd_step,
 
 	.assert_reset = assert_reset,
@@ -4493,7 +4492,7 @@ int riscv013_test_compliance(struct target *target)
 
 	/* resumereq */
 	/* This bit is not actually readable according to the spec, so nothing to check.*/
-	COMPLIANCE_MUST_PASS(riscv_resume(target, true, 0, false, false));
+	COMPLIANCE_MUST_PASS(riscv_resume(target, true, 0, false, false, false));
 
 	/* Halt all harts again so the test can continue.*/
 	COMPLIANCE_MUST_PASS(riscv_halt(target));

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1995,7 +1995,7 @@ int riscv_openocd_poll(struct target *target)
 	} else if (target->smp) {
 		unsigned halts_discovered = 0;
 		unsigned total_targets = 0;
-		bool newly_halted[128] = {0};	// TODO: remove
+		bool newly_halted[128] = {0};
 		unsigned should_remain_halted = 0;
 		unsigned should_resume = 0;
 		unsigned i = 0;
@@ -2006,8 +2006,7 @@ int riscv_openocd_poll(struct target *target)
 			riscv_info_t *r = riscv_info(t);
 			assert(i < DIM(newly_halted));
 			enum riscv_poll_hart out = riscv_poll_hart(t, r->current_hartid);
-			switch (out)
-			{
+			switch (out) {
 			case RPH_NO_CHANGE:
 				if (t->state == TARGET_HALTED)
 					should_remain_halted++;
@@ -2025,11 +2024,9 @@ int riscv_openocd_poll(struct target *target)
 				if (set_debug_reason(t, halt_reason) != ERROR_OK)
 					return ERROR_FAIL;
 
-				if (halt_reason == RISCV_HALT_BREAKPOINT)
-				{
+				if (halt_reason == RISCV_HALT_BREAKPOINT) {
 					int retval;
-					switch (riscv_semihosting(t, &retval))
-					{
+					switch (riscv_semihosting(t, &retval)) {
 					case SEMI_NONE:
 					case SEMI_WAITING:
 						/* This hart should remain halted. */
@@ -2043,9 +2040,7 @@ int riscv_openocd_poll(struct target *target)
 					case SEMI_ERROR:
 						return retval;
 					}
-				}
-				else if (halt_reason != RISCV_HALT_GROUP)
-				{
+				} else if (halt_reason != RISCV_HALT_GROUP) {
 					should_remain_halted++;
 				}
 				break;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2087,13 +2087,12 @@ int riscv_openocd_poll(struct target *target)
 		target->state = TARGET_HALTED;
 	}
 
-	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
-
 	if (target->debug_reason == DBG_REASON_BREAKPOINT) {
 		int retval;
 		switch (riscv_semihosting(target, &retval)) {
 			case SEMI_NONE:
 			case SEMI_WAITING:
+				target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 				break;
 			case SEMI_HANDLED:
 				if (riscv_resume(target, true, 0, 0, 0, false) != ERROR_OK)
@@ -2102,6 +2101,8 @@ int riscv_openocd_poll(struct target *target)
 			case SEMI_ERROR:
 				return retval;
 		}
+	} else {
+		target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 	}
 
 	return ERROR_OK;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2043,9 +2043,9 @@ int riscv_openocd_poll(struct target *target)
 						case SEMI_ERROR:
 							return ERROR_FAIL;
 						}
+					} else {
+						halt_all = true;
 					}
-				} else {
-					halt_all = true;
 				}
 			}
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -339,9 +339,10 @@ int riscv_init_registers(struct target *target);
 
 void riscv_semihosting_init(struct target *target);
 typedef enum {
-	SEMI_NONE,	/* Not halted for a semihosting call. */
+	SEMI_NONE,		/* Not halted for a semihosting call. */
 	SEMI_HANDLED,	/* Call handled, and target was resumed. */
 	SEMI_WAITING,	/* Call handled, target is halted waiting until we can resume. */
+	SEMI_ERROR		/* Something went wrong. */
 } semihosting_result_t;
 semihosting_result_t riscv_semihosting(struct target *target, int *retval);
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -239,7 +239,8 @@ int riscv_resume(
 	int current,
 	target_addr_t address,
 	int handle_breakpoints,
-	int debug_execution
+	int debug_execution,
+	bool single_hart
 );
 
 int riscv_openocd_step(
@@ -337,7 +338,12 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_wp_addre
 int riscv_init_registers(struct target *target);
 
 void riscv_semihosting_init(struct target *target);
-int riscv_semihosting(struct target *target, int *retval);
+typedef enum {
+	SEMI_NONE,	/* Not halted for a semihosting call. */
+	SEMI_HANDLED,	/* Call handled, and target was resumed. */
+	SEMI_WAITING,	/* Call handled, target is halted waiting until we can resume. */
+} semihosting_result_t;
+semihosting_result_t riscv_semihosting(struct target *target, int *retval);
 
 void riscv_add_bscan_tunneled_scan(struct target *target, struct scan_field *field,
 		riscv_bscan_tunneled_scan_context_t *ctxt);

--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -60,35 +60,35 @@ void riscv_semihosting_init(struct target *target)
 /**
  * Check for and process a semihosting request using the ARM protocol). This
  * is meant to be called when the target is stopped due to a debug mode entry.
- * If the value 0 is returned then there was nothing to process. A non-zero
- * return value signifies that a request was processed and the target resumed,
- * or an error was encountered, in which case the caller must return
- * immediately.
  *
  * @param target Pointer to the target to process.
  * @param retval Pointer to a location where the return code will be stored
  * @return non-zero value if a request was processed or an error encountered
  */
-int riscv_semihosting(struct target *target, int *retval)
+semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 {
 	struct semihosting *semihosting = target->semihosting;
-	if (!semihosting)
-		return 0;
+	if (!semihosting) {
+		LOG_DEBUG("   -> 0 (!semihosting)");
+		return SEMI_NONE;
+	}
 
-	if (!semihosting->is_active)
-		return 0;
+	if (!semihosting->is_active) {
+		LOG_DEBUG("   -> 0 (!semihosting->is_active)");
+		return SEMI_NONE;
+	}
 
-	riscv_reg_t dpc;
-	int result = riscv_get_register(target, &dpc, GDB_REGNO_DPC);
+	riscv_reg_t pc;
+	int result = riscv_get_register(target, &pc, GDB_REGNO_PC);
 	if (result != ERROR_OK)
-		return 0;
+		return SEMI_ERROR;
 
 	uint8_t tmp[12];
 
 	/* Read the current instruction, including the bracketing */
-	*retval = target_read_memory(target, dpc - 4, 2, 6, tmp);
+	*retval = target_read_memory(target, pc - 4, 2, 6, tmp);
 	if (*retval != ERROR_OK)
-		return 0;
+		return SEMI_ERROR;
 
 	/*
 	 * The instructions that trigger a semihosting call,
@@ -101,12 +101,12 @@ int riscv_semihosting(struct target *target, int *retval)
 	uint32_t pre = target_buffer_get_u32(target, tmp);
 	uint32_t ebreak = target_buffer_get_u32(target, tmp + 4);
 	uint32_t post = target_buffer_get_u32(target, tmp + 8);
-	LOG_DEBUG("check %08x %08x %08x from 0x%" PRIx64 "-4", pre, ebreak, post, dpc);
+	LOG_DEBUG("check %08x %08x %08x from 0x%" PRIx64 "-4", pre, ebreak, post, pc);
 
 	if (pre != 0x01f01013 || ebreak != 0x00100073 || post != 0x40705013) {
-
 		/* Not the magic sequence defining semihosting. */
-		return 0;
+		LOG_DEBUG("   -> 0 (no magic)");
+		return SEMI_NONE;
 	}
 
 	/*
@@ -114,18 +114,21 @@ int riscv_semihosting(struct target *target, int *retval)
 	 * operation to complete.
 	 */
 	if (!semihosting->hit_fileio) {
-
 		/* RISC-V uses A0 and A1 to pass function arguments */
 		riscv_reg_t r0;
 		riscv_reg_t r1;
 
 		result = riscv_get_register(target, &r0, GDB_REGNO_A0);
-		if (result != ERROR_OK)
-			return 0;
+		if (result != ERROR_OK) {
+			LOG_DEBUG("   -> 0 (couldn't read a0)");
+			return SEMI_ERROR;
+		}
 
 		result = riscv_get_register(target, &r1, GDB_REGNO_A1);
-		if (result != ERROR_OK)
-			return 0;
+		if (result != ERROR_OK) {
+			LOG_DEBUG("   -> 0 (couldn't read a1)");
+			return SEMI_ERROR;
+		}
 
 		semihosting->op = r0;
 		semihosting->param = r1;
@@ -136,11 +139,12 @@ int riscv_semihosting(struct target *target, int *retval)
 			*retval = semihosting_common(target);
 			if (*retval != ERROR_OK) {
 				LOG_ERROR("Failed semihosting operation");
-				return 0;
+				return SEMI_ERROR;
 			}
 		} else {
 			/* Unknown operation number, not a semihosting call. */
-			return 0;
+			LOG_DEBUG("   -> 0 (unknown operation number)");
+			return SEMI_NONE;
 		}
 	}
 
@@ -150,16 +154,18 @@ int riscv_semihosting(struct target *target, int *retval)
 	 */
 	if (semihosting->is_resumable && !semihosting->hit_fileio) {
 		/* Resume right after the EBREAK 4 bytes instruction. */
-		*retval = target_resume(target, 0, dpc+4, 0, 0);
+		*retval = riscv_resume(target, 0, pc+4, 0, 0, true);
 		if (*retval != ERROR_OK) {
-			LOG_ERROR("Failed to resume target");
-			return 0;
+			LOG_ERROR("Failed to resume %s", target_name(target));
+			return SEMI_ERROR;
 		}
 
-		return 1;
+		LOG_DEBUG("   -> 1");
+		return SEMI_HANDLED;
 	}
 
-	return 0;
+	LOG_DEBUG("   -> 0");
+	return SEMI_WAITING;
 }
 
 /* -------------------------------------------------------------------------
@@ -171,7 +177,7 @@ int riscv_semihosting(struct target *target, int *retval)
  */
 static int riscv_semihosting_setup(struct target *target, int enable)
 {
-	LOG_DEBUG("enable=%d", enable);
+	LOG_DEBUG("[%s] enable=%d", target_name(target), enable);
 
 	struct semihosting *semihosting = target->semihosting;
 	if (semihosting)

--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -69,12 +69,12 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 {
 	struct semihosting *semihosting = target->semihosting;
 	if (!semihosting) {
-		LOG_DEBUG("   -> 0 (!semihosting)");
+		LOG_DEBUG("   -> NONE (!semihosting)");
 		return SEMI_NONE;
 	}
 
 	if (!semihosting->is_active) {
-		LOG_DEBUG("   -> 0 (!semihosting->is_active)");
+		LOG_DEBUG("   -> NONE (!semihosting->is_active)");
 		return SEMI_NONE;
 	}
 
@@ -105,7 +105,7 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 
 	if (pre != 0x01f01013 || ebreak != 0x00100073 || post != 0x40705013) {
 		/* Not the magic sequence defining semihosting. */
-		LOG_DEBUG("   -> 0 (no magic)");
+		LOG_DEBUG("   -> NONE (no magic)");
 		return SEMI_NONE;
 	}
 
@@ -120,13 +120,13 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 
 		result = riscv_get_register(target, &r0, GDB_REGNO_A0);
 		if (result != ERROR_OK) {
-			LOG_DEBUG("   -> 0 (couldn't read a0)");
+			LOG_DEBUG("   -> ERROR (couldn't read a0)");
 			return SEMI_ERROR;
 		}
 
 		result = riscv_get_register(target, &r1, GDB_REGNO_A1);
 		if (result != ERROR_OK) {
-			LOG_DEBUG("   -> 0 (couldn't read a1)");
+			LOG_DEBUG("   -> ERROR (couldn't read a1)");
 			return SEMI_ERROR;
 		}
 
@@ -143,7 +143,7 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 			}
 		} else {
 			/* Unknown operation number, not a semihosting call. */
-			LOG_DEBUG("   -> 0 (unknown operation number)");
+			LOG_DEBUG("   -> NONE (unknown operation number)");
 			return SEMI_NONE;
 		}
 	}
@@ -160,11 +160,11 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 			return SEMI_ERROR;
 		}
 
-		LOG_DEBUG("   -> 1");
+		LOG_DEBUG("   -> HANDLED");
 		return SEMI_HANDLED;
 	}
 
-	LOG_DEBUG("   -> 0");
+	LOG_DEBUG("   -> WAITING");
 	return SEMI_WAITING;
 }
 

--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -154,11 +154,9 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 	 */
 	if (semihosting->is_resumable && !semihosting->hit_fileio) {
 		/* Resume right after the EBREAK 4 bytes instruction. */
-		*retval = riscv_resume(target, 0, pc+4, 0, 0, true);
-		if (*retval != ERROR_OK) {
-			LOG_ERROR("Failed to resume %s", target_name(target));
+		*retval = riscv_set_register(target, GDB_REGNO_PC, pc + 4);
+		if (*retval != ERROR_OK)
 			return SEMI_ERROR;
-		}
 
 		LOG_DEBUG("   -> HANDLED");
 		return SEMI_HANDLED;


### PR DESCRIPTION
Now it works in multiple gdb scenarios, as well as with `-rtos hwthread`. It does not work with `-rtos riscv`, which is deprecated in any case.

Moved the automatic resume out of riscv_semihosting, because when multiple harts are halted we sometimes want to resume them all (when they're all part of a halt group halted because of a semihosting breakpoint) and sometimes now (when one hart hit a semihosting breakpoint and another hit a regular breakpoint).