### PR TITLE
Enable remote_bitbang by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,7 @@ AC_MSG_RESULT([$build_zy1000])
 
 AC_ARG_ENABLE([remote-bitbang],
   AS_HELP_STRING([--enable-remote-bitbang], [Enable building support for the Remote Bitbang jtag driver]),
-  [build_remote_bitbang=$enableval], [build_remote_bitbang=no])
+  [build_remote_bitbang=$enableval], [build_remote_bitbang=yes])
 
 AC_MSG_CHECKING([whether to enable dummy minidriver])
 AS_IF([test "x$build_minidriver_dummy" = "xyes"], [


### PR DESCRIPTION
RBB is the protocol supported by [spike](https://github.com/riscv/riscv-isa-sim#readme) so it would make sense to include it by default.

> To get remote bitbang support in OpenOCD, you need to run configure with `--enable-remote-bitbang` before building.
> I'd accept a change https://github.com/riscv/riscv-openocd that makes that the default.

_Originally posted by @timsifive in https://github.com/riscv/riscv-isa-sim/issues/102#issuecomment-656910235_