### PR TITLE
Further deprecate `-rtos riscv`.

### DIFF
--- a/src/rtos/riscv_debug.c
+++ b/src/rtos/riscv_debug.c
@@ -18,16 +18,29 @@ static bool riscv_detect_rtos(struct target *target)
 	return -1;
 }
 
+extern bool enable_rtos_riscv;
+
 static int riscv_create_rtos(struct target *target)
 {
 	LOG_DEBUG("RISC-V Debug 'RTOS' created: this doesn't mean you're running an RTOS, just that you have multi-hart support on RISC-V");
-	LOG_WARNING("`-rtos riscv` is deprecated! Please change your configuration to use `-rtos");
-	LOG_WARNING("hwthread` instead. To do that, you will have to explicitly list every hart in");
-	LOG_WARNING("the system as a separate target. See");
-	LOG_WARNING("https://github.com/riscv/riscv-tests/blob/ec6537fc4a527ca88be2f045e01c460e640ab9c5/debug/targets/SiFive/HiFiveUnleashed.cfg#L11");
-	LOG_WARNING("for an example.");
-	LOG_WARNING("You will have to change your configuration file in any OpenOCD newer than June");
-	LOG_WARNING("2020.");
+
+	if (enable_rtos_riscv) {
+		LOG_WARNING("`-rtos riscv` is deprecated and will be removed at the end of 2020! Please");
+		LOG_WARNING("change your configuration to use `-rtos hwthread` instead. To do that, you");
+		LOG_WARNING("will have to explicitly list every hart in the system as a separate target. See");
+		LOG_WARNING("https://github.com/riscv/riscv-tests/blob/ec6537fc4a527ca88be2f045e01c460e640ab9c5/debug/targets/SiFive/HiFiveUnleashed.cfg#L11");
+		LOG_WARNING("for an example.");
+	} else {
+		LOG_ERROR("`-rtos riscv` is deprecated and will be removed at the end of 2020! Until");
+		LOG_ERROR("then, you can still use it by adding `enable_rtos_riscv` to your");
+		LOG_ERROR("configuration.");
+		LOG_ERROR("Please change your configuration to use `-rtos hwthread` instead. To do ");
+		LOG_ERROR("that, you will have to explicitly list every hart in the system as a separate ");
+		LOG_ERROR("target. See");
+		LOG_ERROR("https://github.com/riscv/riscv-tests/blob/ec6537fc4a527ca88be2f045e01c460e640ab9c5/debug/targets/SiFive/HiFiveUnleashed.cfg#L11");
+		LOG_ERROR("for an example.");
+		return ERROR_FAIL;
+	}
 
 	struct riscv_rtos *r = calloc(1, sizeof(*r));
 	target->rtos->rtos_specific_params = r;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -5948,6 +5948,17 @@ COMMAND_HANDLER(handle_fast_load_command)
 	return retval;
 }
 
+bool enable_rtos_riscv = false;
+COMMAND_HANDLER(handle_enable_rtos_riscv_command)
+{
+	if (CMD_ARGC != 0) {
+		LOG_ERROR("Command takes no arguments");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	enable_rtos_riscv = true;
+	return ERROR_OK;
+}
+
 static const struct command_registration target_command_handlers[] = {
 	{
 		.name = "targets",
@@ -5963,6 +5974,14 @@ static const struct command_registration target_command_handlers[] = {
 		.help = "configure target",
 		.chain = target_subcommand_handlers,
 		.usage = "",
+	},
+	{
+		.name = "enable_rtos_riscv",
+		.handler = handle_enable_rtos_riscv_command,
+		.mode = COMMAND_CONFIG,
+		.usage = "enable_rtos_riscv",
+		.help = "Allow the use of `-rtos riscv` for just a little longer, "
+			"until it will be completely removed at the end of 2020."
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -5948,7 +5948,7 @@ COMMAND_HANDLER(handle_fast_load_command)
 	return retval;
 }
 
-bool enable_rtos_riscv = false;
+bool enable_rtos_riscv;
 COMMAND_HANDLER(handle_enable_rtos_riscv_command)
 {
 	if (CMD_ARGC != 0) {


### PR DESCRIPTION
Now using `-rtos riscv` will result in a failure, which you can (until
the end of this year) bypass by adding `enable_rtos_riscv` to the
configuration.

Change-Id: Ic714c303dc1b00c19e8956609730c0f83c845cb6