### PR TITLE
Update to version 1.0 of the vector spec.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1875,7 +1875,7 @@ static int prep_for_vector_access(struct target *target, uint64_t *vtype,
 	if (register_read(target, vl, GDB_REGNO_VL) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (register_write_direct(target, GDB_REGNO_VTYPE, encoded_vsew << 2) != ERROR_OK)
+	if (register_write_direct(target, GDB_REGNO_VTYPE, encoded_vsew << 3) != ERROR_OK)
 		return ERROR_FAIL;
 	*debug_vl = DIV_ROUND_UP(r->vlenb[r->current_hartid] * 8,
 			riscv_xlen(target));


### PR DESCRIPTION
Accessing registers on targets that implement 0.9 or earlier will no
longer work. If you need that we can talk about making it a config
option.

Change-Id: I953b639cf9a92ee9b0422e035da57c1d07504237