### PR TITLE
Allow to put breakpoints in memories without 16 bit access

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -818,8 +818,7 @@ static int write_by_any_size(struct target *target, target_addr_t address, uint3
 
 	/* On failure, try other access sizes.
 	   Minimize the number of accesses by trying first the largest size. */
-	for (unsigned access_size = 8; access_size > 0; access_size /= 2)
-	{
+	for (unsigned access_size = 8; access_size > 0; access_size /= 2) {
 		if (access_size == preferred_size)
 			/* Already tried this size. */
 			continue;
@@ -851,8 +850,7 @@ static int read_by_any_size(struct target *target, target_addr_t address, uint32
 
 	/* On failure, try other access sizes.
 	   Minimize the number of accesses by trying first the largest size. */
-	for (unsigned access_size = 8; access_size > 0; access_size /= 2)
-	{
+	for (unsigned access_size = 8; access_size > 0; access_size /= 2) {
 		if (access_size == preferred_size)
 			/* Already tried this size. */
 			continue;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -746,54 +746,58 @@ static int add_trigger(struct target *target, struct trigger *trigger)
 	return ERROR_OK;
 }
 
-static int sw_breakpoint_write_by_any_size(struct target *target,
-		struct breakpoint *breakpoint, uint8_t *buff, int access_size)
+static int write_by_any_size(struct target *target, target_addr_t address,
+		uint32_t size, uint8_t *buffer, uint32_t access_size)
 {
-	assert(breakpoint->length == 4 || breakpoint->length == 2);
+	assert(size == 4 || size == 2);
 	assert(access_size == 1 || access_size == 2 || access_size == 4 || access_size == 8);
 
-	if (access_size < breakpoint->length)
-		/* Can do the memory access directly without helper buffers. */
-		return target_write_memory(target, breakpoint->address, access_size,
-				breakpoint->length / access_size, buff);
+	if (address % size == 0 && target_write_memory(target, address, size, 1, buffer) == ERROR_OK)
+		/* Succeeded with original size. */
+		return ERROR_OK;
 
-	int offset_head = breakpoint->address % access_size;
-	unsigned n_blocks = (offset_head <= (access_size - breakpoint->length)) ? 1 : 2;
+	if (access_size <= size && address % access_size == 0)
+		/* Can do the memory access directly without a helper buffer. */
+		return target_write_memory(target, address, access_size, size / access_size, buffer);
+
+	unsigned offset_head = address % access_size;
+	unsigned n_blocks = ((size + offset_head) <= access_size) ? 1 : 2;
 	uint8_t helper_buf[n_blocks * access_size];
 
 	/* Read from memory */
-	if (target_read_memory(target, breakpoint->address - offset_head,
-			access_size, n_blocks, helper_buf) != ERROR_OK)
+	if (target_read_memory(target, address - offset_head, access_size, n_blocks, helper_buf) != ERROR_OK)
 		return ERROR_FAIL;
 
 	/* Modify and write back */
-	memcpy(helper_buf + offset_head, buff, breakpoint->length);
-	return target_write_memory(target, breakpoint->address - offset_head,
+	memcpy(helper_buf + offset_head, buffer, size);
+	return target_write_memory(target, address - offset_head,
 			access_size, n_blocks, helper_buf);
 }
 
-static int sw_breakpoint_read_by_any_size(struct target *target,
-		struct breakpoint *breakpoint, int access_size)
+static int read_by_any_size(struct target *target, target_addr_t address,
+	uint32_t size, uint8_t *buffer, uint32_t access_size)
 {
-	assert(breakpoint->length == 4 || breakpoint->length == 2);
+	assert(size == 4 || size == 2);
 	assert(access_size == 1 || access_size == 2 || access_size == 4 || access_size == 8);
 
-	if (access_size < breakpoint->length)
-		/* Can do the memory access directly without helper buffers. */
-		return target_read_memory(target, breakpoint->address, access_size,
-				breakpoint->length / access_size, breakpoint->orig_instr);
+	if (address % size == 0 && target_read_memory(target, address, size, 1, buffer) == ERROR_OK)
+		/* Succeeded with original size. */
+		return ERROR_OK;
 
-	int offset_head = breakpoint->address % access_size;
-	unsigned n_blocks = (offset_head <= (access_size - breakpoint->length)) ? 1 : 2;
+	if (access_size <= size && address % access_size == 0)
+		/* Can do the memory access directly without a helper buffer. */
+		return target_read_memory(target, address, access_size, size / access_size, buffer);
+
+	unsigned offset_head = address % access_size;
+	unsigned n_blocks = ((size + offset_head) <= access_size) ? 1 : 2;
 	uint8_t helper_buf[n_blocks * access_size];
 
 	/* Read from memory */
-	if (target_read_memory(target, breakpoint->address - offset_head,
-			access_size, n_blocks, helper_buf) != ERROR_OK)
+	if (target_read_memory(target, address - offset_head, access_size, n_blocks, helper_buf) != ERROR_OK)
 		return ERROR_FAIL;
 
-	/* Pick the original instruction from the buffer */
-	memcpy(breakpoint->orig_instr, helper_buf + offset_head, breakpoint->length);
+	/* Pick the requested portion from the buffer */
+	memcpy(buffer, helper_buf + offset_head, size);
 	return ERROR_OK;
 }
 
@@ -814,28 +818,21 @@ int riscv_add_breakpoint(struct target *target, struct breakpoint *breakpoint)
 		}
 
 		/* Try reading the original instruction using direct 16-bit access. */
-		if (target_read_memory(target, breakpoint->address, 2, breakpoint->length / 2,
-					breakpoint->orig_instr) != ERROR_OK) {
-			/* If failed, retry with a different access size, more natural to the platform (32 or 64 bits) */
-			if (sw_breakpoint_read_by_any_size(
-					target, breakpoint, target_data_bits(target) / 8) != ERROR_OK) {
-				LOG_ERROR("Failed to read original instruction at 0x%" TARGET_PRIxADDR,
-						breakpoint->address);
-				return ERROR_FAIL;
-			}
+		if (read_by_any_size(target, breakpoint->address, breakpoint->length,
+				breakpoint->orig_instr, target_data_bits(target) / 8) != ERROR_OK) {
+			LOG_ERROR("Failed to read original instruction at 0x%" TARGET_PRIxADDR,
+					breakpoint->address);
+			return ERROR_FAIL;
 		}
 
 		uint8_t buff[4] = { 0 };
 		buf_set_u32(buff, 0, breakpoint->length * CHAR_BIT, breakpoint->length == 4 ? ebreak() : ebreak_c());
 		/* Try write the ebreak instruction using direct 16-bit access */
-		if (target_write_memory(target, breakpoint->address, 2, breakpoint->length / 2, buff) != ERROR_OK) {
-			/* If failed, retry with a different access size, more natural to the platform (32 or 64 bits) */
-			if (sw_breakpoint_write_by_any_size(
-					target, breakpoint, buff, target_data_bits(target) / 8) != ERROR_OK) {
-				LOG_ERROR("Failed to write %d-byte breakpoint instruction at 0x%"
-						TARGET_PRIxADDR, breakpoint->length, breakpoint->address);
-				return ERROR_FAIL;
-			}
+		if (write_by_any_size(target, breakpoint->address, breakpoint->length,
+				buff, target_data_bits(target) / 8) != ERROR_OK) {
+			LOG_ERROR("Failed to write %d-byte breakpoint instruction at 0x%"
+					TARGET_PRIxADDR, breakpoint->length, breakpoint->address);
+			return ERROR_FAIL;
 		}
 
 	} else if (breakpoint->type == BKPT_HARD) {
@@ -904,15 +901,11 @@ int riscv_remove_breakpoint(struct target *target,
 {
 	if (breakpoint->type == BKPT_SOFT) {
 		/* Try write the original instruction using direct 16-bit access */
-		if (target_write_memory(target, breakpoint->address, 2, breakpoint->length / 2,
-					breakpoint->orig_instr) != ERROR_OK) {
-			/* If failed, retry with a different access size, more natural to the platform (32 or 64 bits) */
-			if (sw_breakpoint_write_by_any_size(
-					target, breakpoint, breakpoint->orig_instr, target_data_bits(target) / 8) != ERROR_OK) {
-				LOG_ERROR("Failed to restore instruction for %d-byte breakpoint at "
-						"0x%" TARGET_PRIxADDR, breakpoint->length, breakpoint->address);
-				return ERROR_FAIL;
-			}
+		if (write_by_any_size(target, breakpoint->address, breakpoint->length,
+				breakpoint->orig_instr, target_data_bits(target) / 8) != ERROR_OK) {
+			LOG_ERROR("Failed to restore instruction for %d-byte breakpoint at "
+					"0x%" TARGET_PRIxADDR, breakpoint->length, breakpoint->address);
+			return ERROR_FAIL;
 		}
 
 	} else if (breakpoint->type == BKPT_HARD) {


### PR DESCRIPTION
This change allows placing software breakpoints in memories which do not support half-word wide access (16-bit). This can be the case for various special memory regions intended solely for the program (instructions), and not for data. For instance various core-coupled memories for the program storage.

If the breakpoint placement via 16-bit access fails, OpenOCD will retry using 32-bit or 64-bit access (depending on the platform and memory access method used) and will perform read-modify-write operation.

Concrete example of a memory and processor where this is needed: ICCM (instruction closely-coupled memory) in SweRV EH1.