### PR TITLE
Fix allowed mode for set_mem_access

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2286,6 +2286,11 @@ COMMAND_HANDLER(riscv_test_compliance) {
 
 COMMAND_HANDLER(riscv_set_prefer_sba)
 {
+	if (CMD_CTX->mode != COMMAND_EXEC) {
+		LOG_ERROR("Cannot use `riscv set_prefer_sba` in the config phase. "
+				"Please call it only in OpenOCD execution phase (after `init`).");
+		return ERROR_FAIL;
+	}
 	struct target *target = get_current_target(CMD_CTX);
 	RISCV_INFO(r);
 	bool prefer_sba;
@@ -2816,7 +2821,7 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 	{
 		.name = "set_mem_access",
 		.handler = riscv_set_mem_access,
-		.mode = COMMAND_ANY,
+		.mode = COMMAND_EXEC,
 		.usage = "method1 [method2] [method3]",
 		.help = "Set which memory access methods shall be used and in which order "
 			"of priority. Method can be one of: 'progbuf', 'sysbus' or 'abstract'."


### PR DESCRIPTION
OpenOCD fails with segfault when using newly introduced command `riscv set_mem_access` before calling init. 

This is caused by the option being set per target. To fix it, `set_mem_access` is to be allowed only after init; `set_prefer_sba`, which calls the same functions, will fail and warn the user to only call it after init.

This also relates to https://github.com/riscv/riscv-openocd/issues/527 