### PR TITLE
Allocate RISC-V arch_info during target creation

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -228,6 +228,8 @@ static int get_register(struct target *target, riscv_reg_t *value, int hartid,
 static riscv011_info_t *get_info(const struct target *target)
 {
 	riscv_info_t *info = (riscv_info_t *) target->arch_info;
+	assert(info);
+	assert(info->version_specific);
 	return (riscv011_info_t *) info->version_specific;
 }
 
@@ -2300,7 +2302,7 @@ static int init_target(struct command_context *cmd_ctx,
 		struct target *target)
 {
 	LOG_DEBUG("init");
-	riscv_info_t *generic_info = (riscv_info_t *)target->arch_info;
+	RISCV_INFO(generic_info);
 	generic_info->get_register = get_register;
 	generic_info->set_register = set_register;
 	generic_info->read_memory = read_memory;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -239,6 +239,8 @@ LIST_HEAD(dm_list);
 static riscv013_info_t *get_info(const struct target *target)
 {
 	riscv_info_t *info = (riscv_info_t *) target->arch_info;
+	assert(info);
+	assert(info->version_specific);
 	return (riscv013_info_t *) info->version_specific;
 }
 
@@ -2031,7 +2033,7 @@ static int init_target(struct command_context *cmd_ctx,
 		struct target *target)
 {
 	LOG_DEBUG("init");
-	riscv_info_t *generic_info = (riscv_info_t *) target->arch_info;
+	RISCV_INFO(generic_info);
 
 	generic_info->get_register = &riscv013_get_register;
 	generic_info->set_register = &riscv013_set_register;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -468,15 +468,23 @@ static struct target_type *get_target_type(struct target *target)
 	}
 }
 
+static int riscv_create_target(struct target *target, Jim_Interp *interp)
+{
+	LOG_DEBUG("riscv_create_target()");
+	target->arch_info = calloc(1, sizeof(riscv_info_t));
+	if (!target->arch_info)
+		return ERROR_FAIL;
+	/* TODO: Explicitly initialize all arch_info members in riscv_info_init().
+	   Don't misuse calloc/memset for that. */
+	riscv_info_init(target, target->arch_info);
+	return ERROR_OK;
+}
+
 static int riscv_init_target(struct command_context *cmd_ctx,
 		struct target *target)
 {
 	LOG_DEBUG("riscv_init_target()");
-	target->arch_info = calloc(1, sizeof(riscv_info_t));
-	if (!target->arch_info)
-		return ERROR_FAIL;
-	riscv_info_t *info = (riscv_info_t *) target->arch_info;
-	riscv_info_init(target, info);
+	RISCV_INFO(info);
 	info->cmd_ctx = cmd_ctx;
 
 	select_dtmcontrol.num_bits = target->tap->ir_length;
@@ -1024,7 +1032,7 @@ static int riscv_examine(struct target *target)
 
 	/* Don't need to select dbus, since the first thing we do is read dtmcontrol. */
 
-	riscv_info_t *info = (riscv_info_t *) target->arch_info;
+	RISCV_INFO(info);
 	uint32_t dtmcontrol = dtmcontrol_scan(target, 0);
 	LOG_DEBUG("dtmcontrol=0x%x", dtmcontrol);
 	info->dtm_version = get_field(dtmcontrol, DTMCONTROL_VERSION);
@@ -1746,7 +1754,7 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 		struct reg_param *reg_params, target_addr_t entry_point,
 		target_addr_t exit_point, int timeout_ms, void *arch_info)
 {
-	riscv_info_t *info = (riscv_info_t *) target->arch_info;
+	RISCV_INFO(info);
 	int hartid = riscv_current_hartid(target);
 
 	if (num_mem_params > 0) {
@@ -3010,6 +3018,7 @@ static unsigned riscv_data_bits(struct target *target)
 struct target_type riscv_target = {
 	.name = "riscv",
 
+	.target_create = riscv_create_target,
 	.init_target = riscv_init_target,
 	.deinit_target = riscv_deinit_target,
 	.examine = riscv_examine,
@@ -3062,6 +3071,7 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 	r->dtm_version = 1;
 	r->registers_initialized = false;
 	r->current_hartid = target->coreid;
+	r->version_specific = NULL;
 
 	memset(r->trigger_unique_id, 0xff, sizeof(r->trigger_unique_id));
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -474,8 +474,6 @@ static int riscv_create_target(struct target *target, Jim_Interp *interp)
 	target->arch_info = calloc(1, sizeof(riscv_info_t));
 	if (!target->arch_info)
 		return ERROR_FAIL;
-	/* TODO: Explicitly initialize all arch_info members in riscv_info_init().
-	   Don't misuse calloc/memset for that. */
 	riscv_info_init(target, target->arch_info);
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -232,7 +232,10 @@ extern bool riscv_ebreaku;
  * that provides that. */
 static inline riscv_info_t *riscv_info(const struct target *target) __attribute__((unused));
 static inline riscv_info_t *riscv_info(const struct target *target)
-{ return target->arch_info; }
+{
+	assert(target->arch_info);
+	return target->arch_info;
+}
 #define RISCV_INFO(R) riscv_info_t *R = riscv_info(target);
 
 extern uint8_t ir_dtmcontrol[4];


### PR DESCRIPTION
* Ensured that target->arch_info is allocated as soon as the
  target is created. Needed so that per-target config commands
  (e.g. "riscv set_mem_access") can be executed also in the
  OpenOCD's config phase (before calling "init").

* Added several assert()'s for safety.

Signed-off-by: Jan Matyas <matyas@codasip.com>