### PR TITLE
Improve support for GD32VF103 MCU

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2172,16 +2172,7 @@ static int deassert_reset(struct target *target)
 			index = r->current_hartid;
 		}
 
-		char *operation;
-		uint32_t expected_field;
-		if (target->reset_halt) {
-			operation = "halt";
-			expected_field = DM_DMSTATUS_ALLHALTED;
-		} else {
-			operation = "run";
-			expected_field = DM_DMSTATUS_ALLRUNNING;
-		}
-		LOG_DEBUG("Waiting for hart %d to %s out of reset.", index, operation);
+		LOG_DEBUG("Waiting for hart %d to come out of reset.", index);
 		while (1) {
 			int result = dmstatus_read_timeout(target, &dmstatus, true,
 					riscv_reset_timeout_sec);
@@ -2192,13 +2183,20 @@ static int deassert_reset(struct target *target)
 						index, riscv_reset_timeout_sec);
 			if (result != ERROR_OK)
 				return result;
-			if (get_field(dmstatus, expected_field))
+			/* Certain debug modules, like the one in GD32VF103
+			 * MCUs, violate the specification's requirement that
+			 * each hart is in "exactly one of four states" and,
+			 * during reset, report harts as both unavailable and
+			 * halted/running. To work around this, we check for
+			 * the absence of the unavailable state rather than
+			 * the presence of any other state. */
+			if (!get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL))
 				break;
 			if (time(NULL) - start > riscv_reset_timeout_sec) {
-				LOG_ERROR("Hart %d didn't %s coming out of reset in %ds; "
+				LOG_ERROR("Hart %d didn't leave reset in %ds; "
 						"dmstatus=0x%x; "
 						"Increase the timeout with riscv set_reset_timeout_sec.",
-						index, operation, riscv_reset_timeout_sec, dmstatus);
+						index, riscv_reset_timeout_sec, dmstatus);
 				return ERROR_FAIL;
 			}
 		}

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2100,7 +2100,10 @@ static int assert_reset(struct target *target)
 
 	uint32_t control_base = set_field(0, DM_DMCONTROL_DMACTIVE, 1);
 
-	if (target->rtos) {
+	if (target_has_event_action(target, TARGET_EVENT_RESET_ASSERT)) {
+		/* Run the user-supplied script if there is one. */
+		target_handle_event(target, TARGET_EVENT_RESET_ASSERT);
+	} else if (target->rtos) {
 		/* There's only one target, and OpenOCD thinks each hart is a thread.
 		 * We must reset them all. */
 

--- a/tcl/target/gd32vf103.cfg
+++ b/tcl/target/gd32vf103.cfg
@@ -21,6 +21,14 @@ $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size 0x1000 -work-a
 set _FLASHNAME $_CHIPNAME.flash
 flash bank $_FLASHNAME gd32vf103 0x08000000 0 0 0 $_TARGETNAME
 
+# Address 0 is only aliased to main flash when the chip is not running its
+# built-in bootloader. When it is, it's instead aliased to a read only section
+# of flash at 0x1fffb000. However, we can't detect or dynamically switch this,
+# so just pretend it's always aliased to main flash. We need to tell OpenOCD
+# about this alias because otherwise we'll try to use software breakpoints on
+# code in flash, which don't work because flash mappings are read-only.
+flash bank $_CHIPNAME.flashalias virtual 0x0 0 0 0 $_TARGETNAME $_FLASHNAME
+
 # On this chip, ndmreset (the debug module bit that triggers a software reset)
 # doesn't work. So for JTAG connections without an SRST, we need to trigger a
 # reset manually. This is an undocumented reset sequence that's used by the

--- a/tcl/target/gd32vf103.cfg
+++ b/tcl/target/gd32vf103.cfg
@@ -1,0 +1,88 @@
+reset_config srst_nogate
+
+set _CHIPNAME gd32vf103
+# The vendor's configuration expects an ID of 0x1e200a6d, but this one is what
+# I have on my board (Sipeed Longan Nano, GD32VF103CBT6).
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x1000563d
+jtag newtap $_CHIPNAME bs -irlen 5 -expected-id 0x790007a3
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+$_TARGETNAME riscv set_enable_virt2phys off
+
+proc default_mem_access {} {
+	riscv set_mem_access progbuf
+}
+
+default_mem_access
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size 0x1000 -work-area-backup 1
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME gd32vf103 0x08000000 0 0 0 $_TARGETNAME
+
+# On this chip, ndmreset (the debug module bit that triggers a software reset)
+# doesn't work. So for JTAG connections without an SRST, we need to trigger a
+# reset manually. This is an undocumented reset sequence that's used by the
+# JTAG flashing script in the vendor-supplied GD32VF103 PlatformIO plugin:
+#
+#   https://github.com/sipeed/platform-gd32v/commit/f9cbb44819bc05dd2010cc815c32be0486800cc2
+#
+$_TARGETNAME configure -event reset-assert {
+	set dmcontrol 		0x10
+	set dmcontrol_dmactive	[expr 1 << 0]
+	set dmcontrol_haltreq	[expr 1 << 31]
+
+	global _RESETMODE
+	global _TARGETNAME
+
+	# Halt the core so that we can write to memory. We do this first so
+	# that it doesn't clobber our dmcontrol configuration.
+	halt
+
+	# Set haltreq appropriately for the type of reset we're doing. This
+	# replicates what the generic RISC-V reset_assert() function would
+	# do if we weren't overriding it. The $_RESETMODE hack sucks, but
+	# it's the least invasive way to determine whether we need to halt,
+	# and psoc6.cfg already uses the same trick. (reset_deassert(), which
+	# does run, also does this, but at that point it may be too late: the
+	# reset has already been triggered, so there's a race between it and
+	# the haltreq write.)
+	#
+	# If we didn't override the generic handler, we'd actually still have
+	# to do this: the default handler sets ndmreset, which prevents memory
+	# access even though it doesn't actually trigger a reset on this chip.
+	# So we'd need to unset it here, which involves a write to dmcontrol,
+	# Since haltreq is write-only and there's no way to leave it unchanged,
+	# we'd have to figure out its proper value anyway.
+	set val $dmcontrol_dmactive
+	if {$_RESETMODE ne "run"} {
+		set val [expr $val | $dmcontrol_haltreq]
+	}
+	$_TARGETNAME riscv dmi_write $dmcontrol $val
+
+	# Unlock 0xe0042008 so that the next write triggers a reset
+	$_TARGETNAME mww 0xe004200c 0x4b5a6978
+
+	# We need to trigger the reset using abstract memory access, since
+	# progbuf access tries to read a status code out of a core register
+	# after the write happens, which fails when the core is in reset.
+	riscv set_mem_access abstract
+
+	# Go!
+	$_TARGETNAME mww 0xe0042008 0x1
+
+	# Put the memory access mode back to what it was.
+	default_mem_access
+}
+
+# Capture the mode of a given reset so that we can use it later in the
+# reset-assert handler.
+proc init_reset { mode } {
+	global _RESETMODE
+	set _RESETMODE $mode
+
+	if {[using_jtag]} {
+		jtag arp_init-reset
+	}
+}


### PR DESCRIPTION
The GD32VF103 is a low-cost 32-bit RISC-V microcontroller with peripherals that are more-or-less compatible with the STM32F103 ARM microcontroller. It is available on several low-cost dev boards, such as the Sipeed Longan Nano. Unfortunately, its debug module has a number of quirks, including spec-violating reset behavior and an `ndmreset` line that doesn't seem to be hooked up to the core at all. Teach OpenOCD how to work around these quirks.

Tested working
 - Halt/resume
 - Register access
 - Single step
 - Hardware breakpoints
 - Reset (both `reset halt` and `reset run`)
 - Memory operations (both abstract and progbuf, SBA not supported by chip)
 - Flash read/write/erase