### PR TITLE
Remove unused riscv_error_t type

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -111,12 +111,6 @@ typedef enum {
 	DMI_STATUS_BUSY = 3
 } dmi_status_t;
 
-typedef enum {
-	RE_OK,
-	RE_FAIL,
-	RE_AGAIN
-} riscv_error_t;
-
 typedef enum slot {
 	SLOT0,
 	SLOT1,

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -110,12 +110,6 @@ typedef enum {
 #define DBUS_DATA_SIZE				34
 #define DBUS_ADDRESS_START			36
 
-typedef enum {
-	RE_OK,
-	RE_FAIL,
-	RE_AGAIN
-} riscv_error_t;
-
 typedef enum slot {
 	SLOT0,
 	SLOT1,


### PR DESCRIPTION
This seems to be completely unused in these two files. It was probably accidentally copied from `riscv-011.c`, where it is used.