### PR TITLE
Do not throw error if RISC-V tselect unimplemented

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3623,8 +3623,11 @@ int riscv_enumerate_triggers(struct target *target)
 		riscv_reg_t tselect;
 		int result = riscv_get_register_on_hart(target, &tselect, hartid,
 				GDB_REGNO_TSELECT);
+		/* If tselect is not readable, the trigger module is likely not
+		 * implemented. There are no triggers to enumerate then and no error
+		 * should be thrown. */
 		if (result != ERROR_OK)
-			return result;
+			return ERROR_OK;
 
 		for (unsigned t = 0; t < RISCV_MAX_TRIGGERS; ++t) {
 			r->trigger_count[hartid] = t;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3626,8 +3626,11 @@ int riscv_enumerate_triggers(struct target *target)
 		/* If tselect is not readable, the trigger module is likely not
 		 * implemented. There are no triggers to enumerate then and no error
 		 * should be thrown. */
-		if (result != ERROR_OK)
+		if (result != ERROR_OK) {
+			LOG_DEBUG("Cannot access tselect register on hart %d. "
+					"Assuming that triggers are not implemented.", hartid);
 			return ERROR_OK;
+		}
 
 		for (unsigned t = 0; t < RISCV_MAX_TRIGGERS; ++t) {
 			r->trigger_count[hartid] = t;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3629,7 +3629,7 @@ int riscv_enumerate_triggers(struct target *target)
 		if (result != ERROR_OK) {
 			LOG_DEBUG("Cannot access tselect register on hart %d. "
 					"Assuming that triggers are not implemented.", hartid);
-			return ERROR_OK;
+			continue;
 		}
 
 		for (unsigned t = 0; t < RISCV_MAX_TRIGGERS; ++t) {


### PR DESCRIPTION
A RISC-V hart without Trigger Module may not implement any of the
associated CSRs such as tselect according to the specification.
riscv_enumerate_triggers previously threw an error in this case, but
only on the first invocation due to r->triggers_enumerated being set
regardless of this. Due to the propagation of this error condition to
disable_triggers and riscv_openocd_step, such a hart would remain
halted after the first 'step' (or 'continue') of a debug session.

This problem can be reproduced with the Ibex RISC-V CPU when
the DbgTriggerEn parameter is set to zero.

This commit changes the behavior of riscv_enumerate_triggers to
return ERROR_OK when tselect was not readable. This fixes the
described malfunction.