### PR TITLE
Add before/after timestamps to memory sampling.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2207,7 +2207,7 @@ static int sample_memory_bus_v1(struct target *target,
 		for (unsigned n = 0; n < repeat; n++) {
 			for (unsigned i = 0; i < DIM(config->bucket); i++) {
 				if (config->bucket[i].enabled) {
-					assert(i < RISCV_SAMPLE_BUF_TIMESTAMP);
+					assert(i < RISCV_SAMPLE_BUF_TIMESTAMP_BEFORE);
 					uint64_t value = 0;
 					if (config->bucket[i].size_bytes > 4)
 						value = ((uint64_t) riscv_batch_get_dmi_read_data(batch, read++)) << 32;

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -60,12 +60,12 @@ typedef struct {
 	unsigned custom_number;
 } riscv_reg_info_t;
 
-#define RISCV_SAMPLE_BUF_TIMESTAMP	0x80
+#define RISCV_SAMPLE_BUF_TIMESTAMP_BEFORE	0x80
+#define RISCV_SAMPLE_BUF_TIMESTAMP_AFTER	0x81
 typedef struct {
 	uint8_t *buf;
 	unsigned used;
 	unsigned size;
-	uint32_t last_timestamp;
 } riscv_sample_buf_t;
 
 typedef struct {


### PR DESCRIPTION
This lets a user see exactly what period of time was sampled, without
having to guess how much time the target was ignored in between bursts.

Change-Id: I5c0639528636bf1a88f249be3ba59bec28c001e2
Signed-off-by: Tim Newsome <tim@sifive.com>