### PR TITLE
rename and cleanup, add tiny-h-cjtag

### DIFF
--- a/tcl/interface/ftdi/olimex-arm-usb-ocd-h-cjtag.cfg
+++ b/tcl/interface/ftdi/olimex-arm-usb-ocd-h-cjtag.cfg
@@ -1,0 +1,22 @@
+#
+# Olimex ARM-USB-OCD-H (using cJTAG)
+#
+# http://www.olimex.com/dev/arm-usb-ocd-h.html
+#
+
+interface ftdi
+ftdi_oscan1_mode on
+ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-OCD-H"
+ftdi_vid_pid 0x15ba 0x002b
+
+ftdi_layout_init 0x0808 0x0a1b
+ftdi_layout_signal nSRST -oe 0x0200
+# oscan1_ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
+ftdi_layout_signal LED -data 0x0800
+
+# These signals are used for cJTAG escape sequence on initialization only
+ftdi_layout_signal TCK -data 0x0001
+ftdi_layout_signal TDI -data 0x0002
+ftdi_layout_signal TDO -input 0x0004
+ftdi_layout_signal TMS -data 0x0008
+ftdi_layout_signal JTAG_SEL -data 0x0100 -oe 0x0100

--- a/tcl/interface/ftdi/olimex-arm-usb-tiny-h-cjtag.cfg
+++ b/tcl/interface/ftdi/olimex-arm-usb-tiny-h-cjtag.cfg
@@ -4,15 +4,15 @@
 #
 
 #
-# Olimex ARM-USB-TINY-H
+# Olimex ARM-USB-TINY-H (using cJTAG)
 #
 # http://www.olimex.com/dev/arm-usb-tiny-h.html
 #
 
 interface ftdi
 ftdi_oscan1_mode on
-ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-OCD-H"
-ftdi_vid_pid 0x15ba 0x002b
+ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi_vid_pid 0x15ba 0x002a
 
 ftdi_layout_init 0x0808 0x0a1b
 ftdi_layout_signal nSRST -oe 0x0200


### PR DESCRIPTION
- rename and cleanup to arm-usb-ocd-h-cjtag file to be consistent
- add copy of olimex-arm-jtag-cjtag.cfg as arm-usb-tiny-h-cjtag.cfg
- did not remove olimex-arm-jtag-cjtag.cfg (should be deprecated)