### PR TITLE
Fix comment in read_memory_progbuf

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3451,8 +3451,8 @@ static int read_memory_progbuf(struct target *target, target_addr_t address,
 	if (modify_privilege(target, &mstatus, &mstatus_old) != ERROR_OK)
 		return ERROR_FAIL;
 
-	/* s0 holds the next address to write to
-	 * s1 holds the next data value to write
+	/* s0 holds the next address to read from
+	 * s1 holds the next data value read
 	 * s2 is a counter in case increment is 0
 	 */
 	uint64_t s0, s1, s2;


### PR DESCRIPTION
The comment should refer to reading rather than writing.

Change-Id: I72937bb48053233ab5e48d343c4bd1e394f77bda
Signed-off-by: Craig Blackmore <craig.blackmore@embecosm.com>