### PR TITLE
Don't write to zero.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4165,6 +4165,11 @@ static int register_set(struct reg *reg, uint8_t *buf)
 			riscv_current_hartid(target), str, reg->name, reg->valid);
 	free(str);
 
+	/* Exit early for writing x0, which on the hardware would be ignored, and we
+	 * don't want to update our cache. */
+	if (reg->number == GDB_REGNO_ZERO)
+		return ERROR_OK;
+
 	memcpy(reg->value, buf, DIV_ROUND_UP(reg->size, 8));
 	reg->valid = gdb_regno_cacheable(reg->number, true);
 


### PR DESCRIPTION
It doesn't have any effect on real hardware, and by caching the value we
pretended it did.

Fixes #564

Change-Id: I9f4e2cc8abddee61435bbd8d992cbff971a0c28d
Signed-off-by: Tim Newsome <tim@sifive.com>