### PR TITLE
riscv-013: Fix comment for register_read()

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1400,7 +1400,7 @@ static int register_write_direct(struct target *target, unsigned number,
 	return exec_out;
 }
 
-/** Return the cached value, or read from the target if necessary. */
+/** Read register value from the target. Also update the cached value. */
 static int register_read(struct target *target, uint64_t *value, uint32_t number)
 {
 	if (number == GDB_REGNO_ZERO) {


### PR DESCRIPTION
Updated comment for `register_read()` to reflect what that function really does.

Signed-off-by: Jan Matyas <matyas@codasip.com>