### PR TITLE
Select current hart before accessing vector regs.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1930,6 +1930,9 @@ static int riscv013_get_register_buf(struct target *target,
 {
 	assert(regno >= GDB_REGNO_V0 && regno <= GDB_REGNO_V31);
 
+	if (riscv_select_current_hart(target) != ERROR_OK)
+		return ERROR_FAIL;
+
 	riscv_reg_t s0;
 	if (register_read(target, &s0, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1985,6 +1988,9 @@ static int riscv013_set_register_buf(struct target *target,
 		int regno, const uint8_t *value)
 {
 	assert(regno >= GDB_REGNO_V0 && regno <= GDB_REGNO_V31);
+
+	if (riscv_select_current_hart(target) != ERROR_OK)
+		return ERROR_FAIL;
 
 	riscv_reg_t s0;
 	if (register_read(target, &s0, GDB_REGNO_S0) != ERROR_OK)
@@ -4018,7 +4024,8 @@ static int riscv013_get_register(struct target *target,
 	LOG_DEBUG("[%s] reading register %s", target_name(target),
 			gdb_regno_name(rid));
 
-	riscv_select_current_hart(target);
+	if (riscv_select_current_hart(target) != ERROR_OK)
+		return ERROR_FAIL;
 
 	int result = ERROR_OK;
 	if (rid == GDB_REGNO_PC) {


### PR DESCRIPTION
I don't know how this worked before. Possibly caused by overzealous
removal of `-rtos riscv`.

Change-Id: I7259267b861ef45655f469ab39cc463d608fe149
Signed-off-by: Tim Newsome <tim@sifive.com>