### PR TITLE
Add authdata_read/authdata_write support to 0.11.

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10129,12 +10129,14 @@ set challenge [riscv authdata_read]
 riscv authdata_write [expr $challenge + 1]
 @end example
 
-@deffn Command {riscv authdata_read}
-Return the 32-bit value read from authdata.
+@deffn Command {riscv authdata_read} [index=0]
+Return the 32-bit value read from authdata or authdata0 (index=0), or
+authdata1 (index=1).
 @end deffn
 
-@deffn Command {riscv authdata_write} value
-Write the 32-bit value to authdata.
+@deffn Command {riscv authdata_write} [index=0] value
+Write the 32-bit value to authdata or authdata0 (index=0), or authdata1
+(index=1).
 @end deffn
 
 @subsection RISC-V DMI Commands

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -171,8 +171,8 @@ typedef struct {
 	void (*fill_dmi_read_u64)(struct target *target, char *buf, int a);
 	void (*fill_dmi_nop_u64)(struct target *target, char *buf);
 
-	int (*authdata_read)(struct target *target, uint32_t *value);
-	int (*authdata_write)(struct target *target, uint32_t value);
+	int (*authdata_read)(struct target *target, uint32_t *value, unsigned index);
+	int (*authdata_write)(struct target *target, uint32_t value, unsigned index);
 
 	int (*dmi_read)(struct target *target, uint32_t *value, uint32_t address);
 	int (*dmi_write)(struct target *target, uint32_t address, uint32_t value);


### PR DESCRIPTION
AFAIK there is no hardware that implements this, but it should be a
close-to-done starting point in case it is ever required.

Also adds `dm.authenticated` entry to `riscv info` output.

Change-Id: I49e3082e8629b1d70b12e8a847c2848e75b04508
Signed-off-by: Tim Newsome <tim@sifive.com>