### PR TITLE
Add memory access while running to `riscv info`

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -2298,6 +2298,18 @@ static int arch_state(struct target *target)
 
 COMMAND_HELPER(riscv011_print_info, struct target *target)
 {
+	/* Abstract description. */
+	riscv_print_info_line(CMD, "target", "memory.read_while_running8", 0);
+	riscv_print_info_line(CMD, "target", "memory.write_while_running8", 0);
+	riscv_print_info_line(CMD, "target", "memory.read_while_running16", 0);
+	riscv_print_info_line(CMD, "target", "memory.write_while_running16", 0);
+	riscv_print_info_line(CMD, "target", "memory.read_while_running32", 0);
+	riscv_print_info_line(CMD, "target", "memory.write_while_running32", 0);
+	riscv_print_info_line(CMD, "target", "memory.read_while_running64", 0);
+	riscv_print_info_line(CMD, "target", "memory.write_while_running64", 0);
+	riscv_print_info_line(CMD, "target", "memory.read_while_running128", 0);
+	riscv_print_info_line(CMD, "target", "memory.write_while_running128", 0);
+
 	uint32_t dminfo = dbus_read(target, DMINFO);
 	riscv_print_info_line(CMD, "dm", "authenticated", get_field(dminfo, DMINFO_AUTHENTICATED));
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1878,6 +1878,19 @@ COMMAND_HELPER(riscv013_print_info, struct target *target)
 {
 	RISCV013_INFO(info);
 
+	/* Abstract description. */
+	riscv_print_info_line(CMD, "target", "memory.read_while_running8", get_field(info->sbcs, DM_SBCS_SBACCESS8));
+	riscv_print_info_line(CMD, "target", "memory.write_while_running8", get_field(info->sbcs, DM_SBCS_SBACCESS8));
+	riscv_print_info_line(CMD, "target", "memory.read_while_running16", get_field(info->sbcs, DM_SBCS_SBACCESS16));
+	riscv_print_info_line(CMD, "target", "memory.write_while_running16", get_field(info->sbcs, DM_SBCS_SBACCESS16));
+	riscv_print_info_line(CMD, "target", "memory.read_while_running32", get_field(info->sbcs, DM_SBCS_SBACCESS32));
+	riscv_print_info_line(CMD, "target", "memory.write_while_running32", get_field(info->sbcs, DM_SBCS_SBACCESS32));
+	riscv_print_info_line(CMD, "target", "memory.read_while_running64", get_field(info->sbcs, DM_SBCS_SBACCESS64));
+	riscv_print_info_line(CMD, "target", "memory.write_while_running64", get_field(info->sbcs, DM_SBCS_SBACCESS64));
+	riscv_print_info_line(CMD, "target", "memory.read_while_running128", get_field(info->sbcs, DM_SBCS_SBACCESS128));
+	riscv_print_info_line(CMD, "target", "memory.write_while_running128", get_field(info->sbcs, DM_SBCS_SBACCESS128));
+
+	/* Lower level description. */
 	riscv_print_info_line(CMD, "dm", "abits", info->abits);
 	riscv_print_info_line(CMD, "dm", "progbufsize", info->progbufsize);
 	riscv_print_info_line(CMD, "dm", "sbversion", get_field(info->sbcs, DM_SBCS_SBVERSION));


### PR DESCRIPTION
This way people can write TCL scripts that rely on these more abstract
properties instead of having to check for the existence of sbaccess,
which is not part of 0.11. (There is a similar feature but things are
named differently.)

Change-Id: I5c95a29ef43cb40c3a73b904f11fa7ca38d87b21
Signed-off-by: Tim Newsome <tim@sifive.com>