### PR TITLE
Fix write_memory_bus_v1: incorrect getting sbcs state.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3701,7 +3701,7 @@ static int write_memory_bus_v1(struct target *target, target_addr_t address,
 
 		bool dmi_busy_encountered;
 		if (dmi_op(target, &sbcs, &dmi_busy_encountered, DMI_OP_READ,
-				DM_SBCS, 0, false, false) != ERROR_OK)
+				DM_SBCS, 0, false, true) != ERROR_OK)
 			return ERROR_FAIL;
 
 		time_t start = time(NULL);


### PR DESCRIPTION
Function dmi_op with given "ensure_success == false" does not read back the result of DMI read operation. Thus data_in variable won't be updated and actual register's value won't be loaded. It will cause false positive decision and result to write failure without detection of an error.
Over here it causes false positive decision and results to write failure when DM_SBCS_SBBUSY occurs. Using dmi_op with "ensure_success == false" leads to outdated sbcs state.
And further "get_field(sbcs, DM_SBCS_SBBUSY) || dmi_busy" will result wrong decision.