### PR TITLE
Minor improvement to `riscv expose_custom` docs.

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10001,7 +10001,10 @@ The RISC-V Debug Specification allows targets to expose custom registers
 through abstract commands. (See Section 3.5.1.1 in that document.) This command
 configures individual registers or register ranges (inclusive) that shall be exposed.
 Number 0 indicates the first custom register, whose abstract command number is 0xc000.
-For individually listed registers, a human-readable name can be optionally provided.
+For individually listed registers, a human-readable name can be optionally provided,
+which will get custom_ prepended to it. If no name is provided, the register will
+be named custom<n>.
+
 This command must be executed before `init`.
 @end deffn
 

--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -9987,7 +9987,10 @@ external tools can gather the data efficiently.
 @deffn Command {riscv expose_csrs} n[-m|=name] [...]
 Configure which CSRs to expose in addition to the standard ones. The CSRs to expose
 can be specified as individual register numbers or register ranges (inclusive). For the
-individually listed CSRs, a human-readable name can optionally be set.
+individually listed CSRs, a human-readable name can optionally be set, which
+will get csr_ prepended to it. If no name is provided, the register will be
+named csr<n>.
+
 This command must be executed before `init`.
 
 By default OpenOCD attempts to expose only CSRs that are mentioned in a spec,


### PR DESCRIPTION
Change-Id: Idba63368a147111af7b0a8b15aab5d9d653b9a6d
Signed-off-by: Tim Newsome <tim@sifive.com>