### PR TITLE
Support RV32/RV64 mainline/metal stackings

### DIFF
--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -279,8 +279,7 @@ static int FreeRTOS_read_struct_value(
 }
 
 typedef struct {
-	enum
-	{
+	enum {
 		TYPE_POINTER,
 		TYPE_UBASE,
 		TYPE_TICKTYPE,
@@ -327,8 +326,7 @@ static unsigned populate_offset_size(struct FreeRTOS *freertos,
 
 		largest = MAX(largest, align);
 
-		if (offset & (align - 1))
-		{
+		if (offset & (align - 1)) {
 			offset = offset & ~(align - 1);
 			offset += align;
 		}
@@ -853,32 +851,11 @@ static int FreeRTOS_create(struct target *target)
 	freertos->ubasetype_size = DIV_ROUND_UP(target_data_bits(target), 8);
 
 	/*
-	 * Simplified, from FreeRTOS source:
-	 * struct xLIST_ITEM
-	 * {
-	 *     TickType_t xItemValue; // 16 or 32 bits depending on configUSE_16_BIT_TICKS
-	 *     struct xLIST_ITEM *pxNext;
-	 *     struct xLIST_ITEM *pxPrevious;
-	 *     void *pvOwner;
-	 *     struct xLIST *pxContainer;
-	 * };
-	 * struct xMINI_LIST_ITEM
-	 * {
-	 *     TickType_t xItemValue; // 16 or 32 bits depending on configUSE_16_BIT_TICKS
-	 *     struct xLIST_ITEM *pxNext;
-	 *     struct xLIST_ITEM *pxPrevious;
-	 * };
-	 * typedef struct xLIST
-	 * {
-	 *     UBaseType_t uxNumberOfItems;
-	 *     struct xMINI_LIST_ITEM *pxIndex;
-	 *     MiniListItem_t xListEnd;
-	 * } List_t;
-	 * 
 	 * FreeRTOS can be compiled with configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES
 	 * in which case extra data is inserted and OpenOCD won't work right.
 	 */
 
+	/* struct xLIST */
 	type_offset_size_t struct_list_info[] = {
 		{TYPE_UBASE, 0, 0},		/* uxNumberOfItems */
 		{TYPE_POINTER, 0, 0},	/* ListItem_t *pxIndex */
@@ -887,6 +864,7 @@ static int FreeRTOS_create(struct target *target)
 		{TYPE_POINTER, 0, 0},	/* ListItem_t *pxPrevious */
 	};
 
+	/* struct xLIST_ITEM */
 	type_offset_size_t struct_list_item_info[] = {
 		{TYPE_TICKTYPE, 0, 0},	/* xItemValue */
 		{TYPE_POINTER, 0, 0},	/* ListItem_t *pxNext */
@@ -895,6 +873,7 @@ static int FreeRTOS_create(struct target *target)
 		{TYPE_POINTER, 0, 0},	/* List_t *pvContainer */
 	};
 
+	/* struct tskTaskControlBlock */
 	type_offset_size_t task_control_block_info[] = {
 		{TYPE_POINTER, 0, 0},		/* StackType_t *pxTopOfStack */
 		{TYPE_LIST_ITEM, 0, 0},		/* ListItem_t xStateListItem */

--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -887,19 +887,22 @@ static int FreeRTOS_create(struct target *target)
 		/* Lots of more optional stuff, but is is irrelevant to us. */
 	};
 
-	freertos->list_width = populate_offset_size(freertos, struct_list_info, ARRAY_SIZE(struct_list_info));
+	freertos->list_width = populate_offset_size(
+		freertos, struct_list_info, ARRAY_SIZE(struct_list_info));
 	freertos->list_uxNumberOfItems_offset = struct_list_info[0].offset;
 	freertos->list_uxNumberOfItems_size = struct_list_info[0].size;
 	freertos->list_next_offset = struct_list_info[3].offset;
 	freertos->list_next_size = struct_list_info[3].size;
 
-	freertos->list_item_width = populate_offset_size(freertos, struct_list_item_info, ARRAY_SIZE(struct_list_item_info));
+	freertos->list_item_width = populate_offset_size(
+		freertos, struct_list_item_info, ARRAY_SIZE(struct_list_item_info));
 	freertos->list_elem_next_offset = struct_list_item_info[1].offset;
 	freertos->list_elem_next_size = struct_list_item_info[1].size;
 	freertos->list_elem_content_offset = struct_list_item_info[3].offset;
 	freertos->list_elem_content_size = struct_list_item_info[3].size;
 
-	populate_offset_size(freertos, task_control_block_info, ARRAY_SIZE(task_control_block_info));
+	populate_offset_size(
+		freertos, task_control_block_info, ARRAY_SIZE(task_control_block_info));
 	freertos->thread_stack_offset = task_control_block_info[0].offset;
 	freertos->thread_stack_size = task_control_block_info[0].size;
 	freertos->thread_name_offset = task_control_block_info[5].offset;

--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -126,7 +126,12 @@ static int nds32_stacking(struct rtos *rtos, const struct rtos_register_stacking
 static int riscv_stacking(struct rtos *rtos, const struct rtos_register_stacking **stacking,
 							 target_addr_t stack_ptr)
 {
+	/* Use the next line to debug programs compiled from
+	 * https://github.com/FreeRTOS/FreeRTOS-Kernel */
 	*stacking = &rtos_standard_RV32_stacking;
+	/* Use the next line to debug programs compiled from
+	 * https://github.com/sifive/FreeRTOS-metal */
+	/* *stacking = &rtos_metal_RV32_stacking; */
 	return ERROR_OK;
 }
 

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -612,7 +612,7 @@ int rtos_generic_stack_read(struct target *target,
 		LOG_OUTPUT("\r\n");
 #endif
 
-	int64_t new_stack_ptr;
+	target_addr_t new_stack_ptr;
 	if (stacking->calculate_process_stack != NULL) {
 		new_stack_ptr = stacking->calculate_process_stack(target,
 				stack_data, stacking, stack_ptr);

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -79,7 +79,8 @@ static int rtos_target_for_threadid(struct connection *connection,
 	return ERROR_OK;
 }
 
-static int os_alloc(struct target *target, struct rtos_type *ostype)
+static int os_alloc(struct target *target, struct rtos_type *ostype,
+					struct command_context *cmd_ctx)
 {
 	struct rtos *os = target->rtos = calloc(1, sizeof(struct rtos));
 
@@ -96,6 +97,7 @@ static int os_alloc(struct target *target, struct rtos_type *ostype)
 	os->gdb_thread_packet = rtos_thread_packet;
 	os->gdb_v_packet = NULL;
 	os->gdb_target_for_threadid = rtos_target_for_threadid;
+	os->cmd_ctx = cmd_ctx;
 
 	return JIM_OK;
 }
@@ -110,9 +112,10 @@ static void os_free(struct target *target)
 	target->rtos = NULL;
 }
 
-static int os_alloc_create(struct target *target, struct rtos_type *ostype)
+static int os_alloc_create(struct target *target, struct rtos_type *ostype,
+						   struct command_context *cmd_ctx)
 {
-	int ret = os_alloc(target, ostype);
+	int ret = os_alloc(target, ostype, cmd_ctx);
 
 	if (JIM_OK == ret) {
 		ret = target->rtos->type->create(target);
@@ -135,6 +138,8 @@ int rtos_create(Jim_GetOptInfo *goi, struct target *target)
 		return JIM_ERR;
 	}
 
+	struct command_context *cmd_ctx = current_command_context(goi->interp);
+
 	os_free(target);
 
 	e = Jim_GetOpt_String(goi, &cp, NULL);
@@ -149,12 +154,12 @@ int rtos_create(Jim_GetOptInfo *goi, struct target *target)
 
 		/* rtos_qsymbol() will iterate over all RTOSes. Allocate
 		 * target->rtos here, and set it to the first RTOS type. */
-		return os_alloc(target, rtos_types[0]);
+		return os_alloc(target, rtos_types[0], cmd_ctx);
 	}
 
 	for (x = 0; rtos_types[x]; x++)
 		if (0 == strcmp(cp, rtos_types[x]->name))
-			return os_alloc_create(target, rtos_types[x]);
+			return os_alloc_create(target, rtos_types[x], cmd_ctx);
 
 	Jim_SetResultFormatted(goi->interp, "Unknown RTOS type %s, try one of: ", cp);
 	res = Jim_GetResult(goi->interp);

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -60,6 +60,8 @@ struct rtos {
 	int (*gdb_v_packet)(struct connection *connection, char const *packet, int packet_size);
 	int (*gdb_target_for_threadid)(struct connection *connection, threadid_t thread_id, struct target **p_target);
 	void *rtos_specific_params;
+	/* Populated in rtos.c, so that individual RTOSes can register commands. */
+	struct command_context *cmd_ctx;
 };
 
 struct rtos_reg {

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -110,8 +110,8 @@ struct stack_register_offset {
 };
 
 struct rtos_register_stacking {
-	unsigned char stack_registers_size;
-	signed char stack_growth_direction;
+	unsigned stack_registers_size;
+	int stack_growth_direction;
 	/* The number of gdb general registers, in order. */
 	unsigned char num_output_registers;
 	/* Some targets require evaluating the stack to determine the
@@ -119,10 +119,10 @@ struct rtos_register_stacking {
 	 * just use stacking->stack_registers_size * stack_growth_direction
 	 * to calculate adjustment.
 	 */
-	int64_t (*calculate_process_stack)(struct target *target,
+	target_addr_t (*calculate_process_stack)(struct target *target,
 		const uint8_t *stack_data,
 		const struct rtos_register_stacking *stacking,
-		int64_t stack_ptr);
+		target_addr_t stack_ptr);
 	const struct stack_register_offset *register_offsets;
 	/* Total number of registers on the stack, including the general ones. This
 	 * may be 0 if there are no additional registers on the stack beyond the

--- a/src/rtos/rtos_riot_stackings.c
+++ b/src/rtos/rtos_riot_stackings.c
@@ -27,9 +27,9 @@
 /* This works for the M0 and M34 stackings as xPSR is in a fixed
  * location
  */
-static int64_t rtos_riot_cortex_m_stack_align(struct target *target,
+static target_addr_t rtos_riot_cortex_m_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr)
+	target_addr_t stack_ptr)
 {
 	const int XPSR_OFFSET = 0x40;
 	return rtos_Cortex_M_stack_align(target, stack_data, stacking,

--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -153,7 +153,7 @@ static const struct stack_register_offset rtos_standard_NDS32_N1068_stack_offset
 	{ 35, 0x10, 32 },		/* IFC_LP */
 };
 
-static const struct stack_register_offset rtos_standard_RV32_stack_offsets[] = {
+static const struct stack_register_offset rtos_metal_RV32_stack_offsets[] = {
 	/* zero isn't on the stack. By making its offset -1 we leave the value at 0
 	 * inside rtos_generic_stack_read(). */
 	{ GDB_REGNO_ZERO,  -1, 32 },
@@ -192,6 +192,47 @@ static const struct stack_register_offset rtos_standard_RV32_stack_offsets[] = {
 	/* Registers below are on the stack, but not what gdb expects to return from
 	 * a 'g' packet so are only accessible through get_reg. */
 	{ GDB_REGNO_MSTATUS, 0x84, 32 },
+};
+
+static const struct stack_register_offset rtos_standard_RV32_stack_offsets[] = {
+	/* zero isn't on the stack. By making its offset -1 we leave the value at 0
+	 * inside rtos_generic_stack_read(). */
+	{ GDB_REGNO_ZERO,  -1, 32 },
+	{ GDB_REGNO_RA,  0x04, 32 },
+	{ GDB_REGNO_SP,  -2, 32 },
+	{ GDB_REGNO_GP,  -2, 32 },
+	{ GDB_REGNO_TP,  -2, 32 },
+	{ GDB_REGNO_T0,  0x08, 32 },
+	{ GDB_REGNO_T1,  0x0c, 32 },
+	{ GDB_REGNO_T2,  0x10, 32 },
+	{ GDB_REGNO_FP,  0x14, 32 },
+	{ GDB_REGNO_S1,  0x18, 32 },
+	{ GDB_REGNO_A0, 0x1c, 32 },
+	{ GDB_REGNO_A1, 0x20, 32 },
+	{ GDB_REGNO_A2, 0x24, 32 },
+	{ GDB_REGNO_A3, 0x28, 32 },
+	{ GDB_REGNO_A4, 0x2c, 32 },
+	{ GDB_REGNO_A5, 0x30, 32 },
+	{ GDB_REGNO_A6, 0x34, 32 },
+	{ GDB_REGNO_A7, 0x38, 32 },
+	{ GDB_REGNO_S2, 0x3c, 32 },
+	{ GDB_REGNO_S3, 0x40, 32 },
+	{ GDB_REGNO_S4, 0x44, 32 },
+	{ GDB_REGNO_S5, 0x48, 32 },
+	{ GDB_REGNO_S6, 0x4c, 32 },
+	{ GDB_REGNO_S7, 0x50, 32 },
+	{ GDB_REGNO_S8, 0x54, 32 },
+	{ GDB_REGNO_S9, 0x58, 32 },
+	{ GDB_REGNO_S10, 0x5c, 32 },
+	{ GDB_REGNO_S11, 0x60, 32 },
+	{ GDB_REGNO_T3, 0x64, 32 },
+	{ GDB_REGNO_T4, 0x68, 32 },
+	{ GDB_REGNO_T5, 0x6c, 32 },
+	{ GDB_REGNO_T6, 0x70, 32 },
+	{ GDB_REGNO_PC, 0, 32 },
+	/* Registers below are on the stack, but not what gdb expects to return from
+	 * a 'g' packet so are only accessible through get_reg. */
+	{ GDB_REGNO_MSTATUS, 29 * 4, 32 },
 };
 
 static int64_t rtos_generic_stack_align(struct target *target,
@@ -328,6 +369,15 @@ const struct rtos_register_stacking rtos_standard_NDS32_N1068_stacking = {
 	.num_output_registers = 32,
 	.calculate_process_stack = rtos_generic_stack_align8,
 	.register_offsets = rtos_standard_NDS32_N1068_stack_offsets
+};
+
+const struct rtos_register_stacking rtos_metal_RV32_stacking = {
+	.stack_registers_size = (32 + 2) * 4,
+	.stack_growth_direction = -1,
+	.num_output_registers = 33,
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = rtos_metal_RV32_stack_offsets,
+	.total_register_count = ARRAY_SIZE(rtos_metal_RV32_stack_offsets)
 };
 
 const struct rtos_register_stacking rtos_standard_RV32_stacking = {

--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -194,6 +194,47 @@ static const struct stack_register_offset rtos_metal_RV32_stack_offsets[] = {
 	{ GDB_REGNO_MSTATUS, 0x84, 32 },
 };
 
+static const struct stack_register_offset rtos_metal_RV64_stack_offsets[] = {
+	/* zero isn't on the stack. By making its offset -1 we leave the value at 0
+	 * inside rtos_generic_stack_read(). */
+	{ GDB_REGNO_ZERO,  -1, 64 },
+	{ GDB_REGNO_RA, 2 * 0x04, 64 },
+	{ GDB_REGNO_SP, 2 * 0x08, 64 },
+	{ GDB_REGNO_GP, 2 * 0x0c, 64 },
+	{ GDB_REGNO_TP, 2 * 0x10, 64 },
+	{ GDB_REGNO_T0, 2 * 0x14, 64 },
+	{ GDB_REGNO_T1, 2 * 0x18, 64 },
+	{ GDB_REGNO_T2, 2 * 0x1c, 64 },
+	{ GDB_REGNO_FP, 2 * 0x20, 64 },
+	{ GDB_REGNO_S1, 2 * 0x24, 64 },
+	{ GDB_REGNO_A0, 2 * 0x28, 64 },
+	{ GDB_REGNO_A1, 2 * 0x2c, 64 },
+	{ GDB_REGNO_A2, 2 * 0x30, 64 },
+	{ GDB_REGNO_A3, 2 * 0x34, 64 },
+	{ GDB_REGNO_A4, 2 * 0x38, 64 },
+	{ GDB_REGNO_A5, 2 * 0x3c, 64 },
+	{ GDB_REGNO_A6, 2 * 0x40, 64 },
+	{ GDB_REGNO_A7, 2 * 0x44, 64 },
+	{ GDB_REGNO_S2, 2 * 0x48, 64 },
+	{ GDB_REGNO_S3, 2 * 0x4c, 64 },
+	{ GDB_REGNO_S4, 2 * 0x50, 64 },
+	{ GDB_REGNO_S5, 2 * 0x54, 64 },
+	{ GDB_REGNO_S6, 2 * 0x58, 64 },
+	{ GDB_REGNO_S7, 2 * 0x5c, 64 },
+	{ GDB_REGNO_S8, 2 * 0x60, 64 },
+	{ GDB_REGNO_S9, 2 * 0x64, 64 },
+	{ GDB_REGNO_S10, 2 * 0x68, 64 },
+	{ GDB_REGNO_S11, 2 * 0x6c, 64 },
+	{ GDB_REGNO_T3, 2 * 0x70, 64 },
+	{ GDB_REGNO_T4, 2 * 0x74, 64 },
+	{ GDB_REGNO_T5, 2 * 0x78, 64 },
+	{ GDB_REGNO_T6, 2 * 0x7c, 64 },
+	{ GDB_REGNO_PC, 2 * 0x80, 64 },
+	/* Registers below are on the stack, but not what gdb expects to return from
+	 * a 'g' packet so are only accessible through get_reg. */
+	{ GDB_REGNO_MSTATUS, 2 * 0x84, 64 },
+};
+
 static const struct stack_register_offset rtos_standard_RV32_stack_offsets[] = {
 	/* zero isn't on the stack. By making its offset -1 we leave the value at 0
 	 * inside rtos_generic_stack_read(). */
@@ -235,15 +276,57 @@ static const struct stack_register_offset rtos_standard_RV32_stack_offsets[] = {
 	{ GDB_REGNO_MSTATUS, 29 * 4, 32 },
 };
 
-static int64_t rtos_generic_stack_align(struct target *target,
+static const struct stack_register_offset rtos_standard_RV64_stack_offsets[] = {
+	/* zero isn't on the stack. By making its offset -1 we leave the value at 0
+	 * inside rtos_generic_stack_read(). */
+	{ GDB_REGNO_ZERO,  -1, 64 },
+	{ GDB_REGNO_RA, 2 * 0x04, 64 },
+	{ GDB_REGNO_SP, -2, 64 },
+	{ GDB_REGNO_GP, -2, 64 },
+	{ GDB_REGNO_TP, -2, 64 },
+	{ GDB_REGNO_T0, 2 * 0x08, 64 },
+	{ GDB_REGNO_T1, 2 * 0x0c, 64 },
+	{ GDB_REGNO_T2, 2 * 0x10, 64 },
+	{ GDB_REGNO_FP, 2 * 0x14, 64 },
+	{ GDB_REGNO_S1, 2 * 0x18, 64 },
+	{ GDB_REGNO_A0, 2 * 0x1c, 64 },
+	{ GDB_REGNO_A1, 2 * 0x20, 64 },
+	{ GDB_REGNO_A2, 2 * 0x24, 64 },
+	{ GDB_REGNO_A3, 2 * 0x28, 64 },
+	{ GDB_REGNO_A4, 2 * 0x2c, 64 },
+	{ GDB_REGNO_A5, 2 * 0x30, 64 },
+	{ GDB_REGNO_A6, 2 * 0x34, 64 },
+	{ GDB_REGNO_A7, 2 * 0x38, 64 },
+	{ GDB_REGNO_S2, 2 * 0x3c, 64 },
+	{ GDB_REGNO_S3, 2 * 0x40, 64 },
+	{ GDB_REGNO_S4, 2 * 0x44, 64 },
+	{ GDB_REGNO_S5, 2 * 0x48, 64 },
+	{ GDB_REGNO_S6, 2 * 0x4c, 64 },
+	{ GDB_REGNO_S7, 2 * 0x50, 64 },
+	{ GDB_REGNO_S8, 2 * 0x54, 64 },
+	{ GDB_REGNO_S9, 2 * 0x58, 64 },
+	{ GDB_REGNO_S10, 2 * 0x5c, 64 },
+	{ GDB_REGNO_S11, 2 * 0x60, 64 },
+	{ GDB_REGNO_T3, 2 * 0x64, 64 },
+	{ GDB_REGNO_T4, 2 * 0x68, 64 },
+	{ GDB_REGNO_T5, 2 * 0x6c, 64 },
+	{ GDB_REGNO_T6, 2 * 0x70, 64 },
+	{ GDB_REGNO_PC, 0, 64 },
+	/* Registers below are on the stack, but not what gdb expects to return from
+	 * a 'g' packet so are only accessible through get_reg. */
+	{ GDB_REGNO_MSTATUS, 2 * 29 * 4, 64 },
+};
+
+static target_addr_t rtos_generic_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr, int align)
+	target_addr_t stack_ptr, int align)
 {
-	int64_t new_stack_ptr;
-	int64_t aligned_stack_ptr;
-	new_stack_ptr = stack_ptr - stacking->stack_growth_direction *
-		stacking->stack_registers_size;
-	aligned_stack_ptr = new_stack_ptr & ~((int64_t)align - 1);
+	target_addr_t new_stack_ptr = stack_ptr;
+	if (stacking->stack_growth_direction > 0)
+		new_stack_ptr -= stacking->stack_registers_size;
+	else
+		new_stack_ptr += stacking->stack_registers_size;
+	target_addr_t aligned_stack_ptr = new_stack_ptr & ~((int64_t)align - 1);
 	if (aligned_stack_ptr != new_stack_ptr &&
 		stacking->stack_growth_direction == -1) {
 		/* If we have a downward growing stack, the simple alignment code
@@ -255,9 +338,9 @@ static int64_t rtos_generic_stack_align(struct target *target,
 	return aligned_stack_ptr;
 }
 
-int64_t rtos_generic_stack_align8(struct target *target,
+target_addr_t rtos_generic_stack_align8(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr)
+	target_addr_t stack_ptr)
 {
 	return rtos_generic_stack_align(target, stack_data,
 			stacking, stack_ptr, 8);
@@ -303,27 +386,27 @@ int64_t rtos_Cortex_M_stack_align(struct target *target,
 	return new_stack_ptr;
 }
 
-static int64_t rtos_standard_Cortex_M3_stack_align(struct target *target,
+static target_addr_t rtos_standard_Cortex_M3_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr)
+	target_addr_t stack_ptr)
 {
 	const int XPSR_OFFSET = 0x3c;
 	return rtos_Cortex_M_stack_align(target, stack_data, stacking,
 		stack_ptr, XPSR_OFFSET);
 }
 
-static int64_t rtos_standard_Cortex_M4F_stack_align(struct target *target,
+static target_addr_t rtos_standard_Cortex_M4F_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr)
+	target_addr_t stack_ptr)
 {
 	const int XPSR_OFFSET = 0x40;
 	return rtos_Cortex_M_stack_align(target, stack_data, stacking,
 		stack_ptr, XPSR_OFFSET);
 }
 
-static int64_t rtos_standard_Cortex_M4F_FPU_stack_align(struct target *target,
+static target_addr_t rtos_standard_Cortex_M4F_FPU_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr)
+	target_addr_t stack_ptr)
 {
 	const int XPSR_OFFSET = 0x80;
 	return rtos_Cortex_M_stack_align(target, stack_data, stacking,
@@ -387,4 +470,22 @@ const struct rtos_register_stacking rtos_standard_RV32_stacking = {
 	.calculate_process_stack = rtos_generic_stack_align8,
 	.register_offsets = rtos_standard_RV32_stack_offsets,
 	.total_register_count = ARRAY_SIZE(rtos_standard_RV32_stack_offsets)
+};
+
+const struct rtos_register_stacking rtos_metal_RV64_stacking = {
+	.stack_registers_size = (32 + 2) * 8,
+	.stack_growth_direction = -1,
+	.num_output_registers = 33,
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = rtos_metal_RV64_stack_offsets,
+	.total_register_count = ARRAY_SIZE(rtos_metal_RV64_stack_offsets)
+};
+
+const struct rtos_register_stacking rtos_standard_RV64_stacking = {
+	.stack_registers_size = (32 + 2) * 8,
+	.stack_growth_direction = -1,
+	.num_output_registers = 33,
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = rtos_standard_RV64_stack_offsets,
+	.total_register_count = ARRAY_SIZE(rtos_standard_RV64_stack_offsets)
 };

--- a/src/rtos/rtos_standard_stackings.h
+++ b/src/rtos/rtos_standard_stackings.h
@@ -30,14 +30,16 @@ extern const struct rtos_register_stacking rtos_standard_Cortex_M4F_stacking;
 extern const struct rtos_register_stacking rtos_standard_Cortex_M4F_FPU_stacking;
 extern const struct rtos_register_stacking rtos_standard_Cortex_R4_stacking;
 extern const struct rtos_register_stacking rtos_standard_NDS32_N1068_stacking;
-int64_t rtos_generic_stack_align8(struct target *target,
+target_addr_t rtos_generic_stack_align8(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr);
-int64_t rtos_Cortex_M_stack_align(struct target *target,
+	target_addr_t stack_ptr);
+target_addr_t rtos_Cortex_M_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
-	int64_t stack_ptr, size_t xpsr_offset);
+	target_addr_t stack_ptr, size_t xpsr_offset);
 
 extern const struct rtos_register_stacking rtos_standard_RV32_stacking;
+extern const struct rtos_register_stacking rtos_standard_RV64_stacking;
 extern const struct rtos_register_stacking rtos_metal_RV32_stacking;
+extern const struct rtos_register_stacking rtos_metal_RV64_stacking;
 
 #endif /* OPENOCD_RTOS_RTOS_STANDARD_STACKINGS_H */

--- a/src/rtos/rtos_standard_stackings.h
+++ b/src/rtos/rtos_standard_stackings.h
@@ -38,5 +38,6 @@ int64_t rtos_Cortex_M_stack_align(struct target *target,
 	int64_t stack_ptr, size_t xpsr_offset);
 
 extern const struct rtos_register_stacking rtos_standard_RV32_stacking;
+extern const struct rtos_register_stacking rtos_metal_RV32_stacking;
 
 #endif /* OPENOCD_RTOS_RTOS_STANDARD_STACKINGS_H */


### PR DESCRIPTION
Add an option that lets a user choose between metal and mainline FreeRTOS stackings (defaults to mainline).

Add support for RV64.