### PR TITLE
Fix handeling of ebreak

### DIFF
--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -159,9 +159,6 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 	 */
 	if (semihosting->is_resumable && !semihosting->hit_fileio) {
 		/* Resume right after the EBREAK 4 bytes instruction. */
-		*retval = riscv_set_register(target, GDB_REGNO_PC, pc + 4);
-		if (*retval != ERROR_OK)
-			return SEMI_ERROR;
 
 		LOG_DEBUG("   -> HANDLED");
 		return SEMI_HANDLED;


### PR DESCRIPTION
According to RISC-V Spec 0.13 - 4.8.2, value of `dpc `when debug cause is an `ebreak` is the address of the `ebreak`.
Actually when an `ebreak` cause a debug halt the `dpc` is not modified so when execution is resumed the `ebreak` cause again a debug halt. ( Except when semihosting without semihosting_fileio activated ) 
So in order to continue execution after an `ebreak`, `dpc` need to be set to the next instruction.

This patch set `dpc` for the next instruction when the debug cause is `ebreak` and remove it from the semihosting special case.

This also fix #433 in a more general and cleaner way.
Concerning semi-hosting the issue is not detected by riscv-test because `semihosting_fileio` is not enabled.
