### PR TITLE
Fix build on systems without usb.h

### DIFF
--- a/src/jtag/drivers/arm-jtag-ew.c
+++ b/src/jtag/drivers/arm-jtag-ew.c
@@ -23,7 +23,6 @@
 #include <jtag/interface.h>
 #include <jtag/commands.h>
 #include "helper/system.h"
-#include <usb.h>
 #include "libusb_helper.h"
 
 #define USB_VID						0x15ba


### PR DESCRIPTION
This include seems to have been left over from a merge
commit (7420382).

Fixes #598.

Change-Id: I930f53fe943654d23fe915a50856512546d4f10d
Signed-off-by: Rupert Swarbrick <rswarbrick@gmail.com>