### PR TITLE
Remote bitbang buf

### DIFF
--- a/src/jtag/drivers/remote_bitbang.c
+++ b/src/jtag/drivers/remote_bitbang.c
@@ -181,6 +181,10 @@ static int remote_bitbang_sample(void)
 
 static bb_value_t remote_bitbang_read_sample(void)
 {
+	if (remote_bitbang_start == remote_bitbang_end) {
+		if (remote_bitbang_fill_buf() != ERROR_OK)
+			return ERROR_FAIL;
+	}
 	if (remote_bitbang_start != remote_bitbang_end) {
 		int c = remote_bitbang_buf[remote_bitbang_start];
 		remote_bitbang_start =

--- a/src/jtag/drivers/remote_bitbang.c
+++ b/src/jtag/drivers/remote_bitbang.c
@@ -352,8 +352,19 @@ static const struct command_registration remote_bitbang_command_handlers[] = {
 	COMMAND_REGISTRATION_DONE,
 };
 
+static int remote_bitbang_execute_queue(void)
+{
+	/* process the JTAG command queue */
+	int ret = bitbang_execute_queue();
+	if (ret != ERROR_OK)
+		return ret;
+
+	/* flush not-yet-sent characters, if any */
+	return remote_bitbang_flush();
+}
+
 static struct jtag_interface remote_bitbang_interface = {
-	.execute_queue = &bitbang_execute_queue,
+	.execute_queue = &remote_bitbang_execute_queue,
 };
 
 struct adapter_driver remote_bitbang_adapter_driver = {


### PR DESCRIPTION
Implement a write buffer in remote_bitbang.c. This restores most of the performance that was lost when the file was changed to add Windows support.

My testcase has been the ChecKMisa test against dual-hart spike64. Before the Windows change this took 2.2s. After it became 5.78s. With this change the time is down to 2.92s again. I'd like to get all the performance back but don't want to spend the time right now.