### PR TITLE
riscv: Add assert for debug buffer

### DIFF
--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -23,6 +23,7 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 	for (size_t i = 0; i < RISCV_REGISTER_COUNT; ++i)
 		p->writes_xreg[i] = 0;
 
+	assert(RISCV_MAX_DEBUG_BUFFER_SIZE >= riscv_debug_buffer_size(target));
 	for (size_t i = 0; i < RISCV_MAX_DEBUG_BUFFER_SIZE; ++i)
 		p->debug_buffer[i] = -1;
 


### PR DESCRIPTION
The current debug buffer uses a fixed maximum length, and the new version of
the debugging protocol may be changed in the future. Here, add assert for
error detection.

Change-Id: I7187b489173b8b74e8483a892dbc9a46edf46157
Signed-off-by: Xiang W <wxjstz@126.com>