### PR TITLE
Call keep_alive() more often.

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -82,8 +82,6 @@ int riscv_batch_run(struct riscv_batch *batch)
 		return ERROR_OK;
 	}
 
-	keep_alive();
-
 	riscv_batch_add_nop(batch);
 
 	for (size_t i = 0; i < batch->used_scans; ++i) {
@@ -96,10 +94,14 @@ int riscv_batch_run(struct riscv_batch *batch)
 			jtag_add_runtest(batch->idle_count, TAP_IDLE);
 	}
 
+	keep_alive();
+
 	if (jtag_execute_queue() != ERROR_OK) {
 		LOG_ERROR("Unable to execute JTAG queue");
 		return ERROR_FAIL;
 	}
+
+	keep_alive();
 
 	if (bscan_tunnel_ir_width != 0) {
 		/* need to right-shift "in" by one bit, because of clock skew between BSCAN TAP and DM TAP */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -591,6 +591,8 @@ static int dmi_op_timeout(struct target *target, uint32_t *data_in,
 			return ERROR_FAIL;
 	}
 
+	keep_alive();
+
 	time_t start = time(NULL);
 	/* This first loop performs the request.  Note that if for some reason this
 	 * stays busy, it is actually due to the previous access. */
@@ -1306,8 +1308,6 @@ static int register_write_direct(struct target *target, unsigned number,
 {
 	LOG_DEBUG("{%d} %s <- 0x%" PRIx64, riscv_current_hartid(target),
 			gdb_regno_name(number), value);
-
-	keep_alive();
 
 	int result = register_write_abstract(target, number, value,
 			register_size(target, number));
@@ -2730,6 +2730,7 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 								  next_read);
 						return ERROR_FAIL;
 					}
+					keep_alive();
 					dmi_status_t status = dmi_scan(target, NULL, &value,
 												   DMI_OP_READ, sbdata[j], 0, false);
 					if (status == DMI_STATUS_BUSY)
@@ -2745,7 +2746,6 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 				}
 				next_read = address + i * size + j * 4;
 			}
-			keep_alive();
 		}
 
 		uint32_t sbcs_read = 0;
@@ -3507,7 +3507,6 @@ static int read_memory_progbuf(struct target *target, target_addr_t address,
 		uint8_t *buffer_i = buffer;
 
 		for (uint32_t i = 0; i < count; i++, address_i += increment, buffer_i += size) {
-			keep_alive();
 			/* TODO: This is much slower than it needs to be because we end up
 			 * writing the address to read for every word we read. */
 			result = read_memory_progbuf_inner(target, address_i, size, count_i, buffer_i, increment);


### PR DESCRIPTION
When it doesn't do anything (most of the time) it has negligible
performance impact. With slower remote bitbang, and multiple spike
instances being tested in a single chain, things are sufficiently slow
that if a computer is busy then this is required to pass
riscv-tests/debug.

Change-Id: I8816efedaa0cc3b25734ba8fdc979ee4502284a1
Signed-off-by: Tim Newsome <tim@sifive.com>