### PR TITLE
Fixed halt reason after single-step

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2227,6 +2227,8 @@ int riscv_openocd_poll(struct target *target)
 int riscv_openocd_step(struct target *target, int current,
 		target_addr_t address, int handle_breakpoints)
 {
+	RISCV_INFO(r);
+
 	LOG_DEBUG("stepping rtos hart");
 
 	if (!current)
@@ -2249,8 +2251,11 @@ int riscv_openocd_step(struct target *target, int current,
 
 	target->state = TARGET_RUNNING;
 	target_call_event_callbacks(target, TARGET_EVENT_RESUMED);
+
 	target->state = TARGET_HALTED;
-	target->debug_reason = DBG_REASON_SINGLESTEP;
+	/* Read real debug reason from the target. Do not presume the target halted due
+	 * to the single-step. There may be a higher-priority halt cause, e.g. a breakpoint. */
+	set_debug_reason(target, r->current_hartid);
 	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 	return out;
 }


### PR DESCRIPTION
After single step operation, we should not assume that the halt
reason is single-step. There can be a higher-priority halt cause,
e.g. a breakpoint.

The real halt reason should be obtained from the target (dcsr.cause).