### PR TITLE
batch: Not retrieving DR value when writing to DMI

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -119,9 +119,8 @@ void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint
 	struct scan_field *field = batch->fields + batch->used_scans;
 	field->num_bits = riscv_dmi_write_u64_bits(batch->target);
 	field->out_value = (void *)(batch->data_out + batch->used_scans * DMI_SCAN_BUF_SIZE);
-	field->in_value  = (void *)(batch->data_in  + batch->used_scans * DMI_SCAN_BUF_SIZE);
+	field->in_value = NULL;
 	riscv_fill_dmi_write_u64(batch->target, (char *)field->out_value, address, data);
-	riscv_fill_dmi_nop_u64(batch->target, (char *)field->in_value);
 	batch->last_scan = RISCV_SCAN_TYPE_WRITE;
 	batch->used_scans++;
 }


### PR DESCRIPTION
Indicate to the JTAG driver that it does not need
to read and return the DR register value after scanning the
JTAG chain.

riscv_batch_run(), calls jtag_add_dr_scan() to schedule a
DR scan operation. Eventually, this will result in the JTAG
driver performing a JTAG scan to write to or read from DR.
The decision on whether to write to and/or read from DR
register is determined by the second parameter to
jtag_add_dr_scan(), i.e. a "struct scan_field".
Of particular interest here is if
batch->fields[i]->in_value is not NULL, the JTAG developer
must return the DR value collected from the JTAG  scan
operation.

When creating the DR scan operation instruction with
riscv_batch_add_dmi_write(), batch->fields[i]->in_value points
to a location in batch->data_in buffer,
meaning batch->field[i]->in_value is not NULL, and the JTAG
developer must therefore read and return the DR value collected.
The returning of the DR value is redundant in a write
operation.

This patch set batch->fields[i]->in_value to NULL to indicate
the DR value need not be returned. This allows the JTAG
developer to optimize away any code associated with returning
the DR value.

Normally, the extra work to return the DR value is negligible.
However, in one usecase it introduces significant delays
In this use case a JTAG driver forwards
all JTAG scan to a server on a network. If the server has to
return the DR value, it has to perform the JTAG scan before
replying to the JTAG driver, and only then the JTAG driver
can send the next JTAG scan operation. However, if there is
no need to return the DR value, the server can
acknowledge the JTAG operation request immediately,thus
signalling  to the JTAG driver that it is free to send the next
JTAG scan operation. At the same time of receiving the second
JTAG operation the server will process the original JTAG scan.
This saves time and mitigates network delay. Also, not having
to include the DR value in resulting in smaller reply packet
from server to JTAG driver and save on network traffic.

Signed-off-by: Ooi, Cinly <cinly.ooi@intel.com>