### PR TITLE
Added 'apt-get update' to snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,9 @@ jobs:
       BUILD_DIR: ../build
     steps:
       - name: Install needed packages
-        run: sudo apt-get install autotools-dev autoconf automake libtool pkg-config cmake texinfo texlive g++-mingw-w64-i686
+        run: |
+          sudo apt-get update
+          sudo apt-get install autotools-dev autoconf automake libtool pkg-config cmake texinfo texlive g++-mingw-w64-i686
       - name: Checkout Code
         uses: actions/checkout@v1
       - run: ./bootstrap


### PR DESCRIPTION
This change fixes the snapshot workflow by adding 'apt-get update':

Before installing any packages via apt-get, the local package database needs to be updated.