### PR TITLE
Update gd32vf103.cfg

### DIFF
--- a/tcl/target/gd32vf103.cfg
+++ b/tcl/target/gd32vf103.cfg
@@ -1,3 +1,6 @@
+adapter speed 1000
+transport select jtag
+
 reset_config srst_nogate
 
 set _CHIPNAME gd32vf103


### PR DESCRIPTION
After compiling OpenOCD from source (commit: 6edf98db7), OpenOCD could not connect with the target board which is a GD32VF103T_START development board,
when I used the command: openocd -f "interface/cmsis-dap.cfg" -f "target/gd32vf103.cfg"

Issue 1: The clock speed hasn't been set, the error message given is:
Error: CMSIS-DAP command CMD_DAP_SWJ_CLOCK failed.
Which can be solved by adding a clock speed setting to the gd32vf103.cfg file:
adapter speed 1000

Issue 2: The default transport is not set to jtag, which it requires, the error shown is:
Open On-Chip Debugger 0.11.0+dev-01861-g6edf98db7-dirty (2021-08-25-10:18)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
embedded:startup.tcl:128: Error: session transport is "swd" but your config requires JTAG
in procedure 'script' 
at file "embedded:startup.tcl", line 26
in procedure 'jtag' called at file "/home/user/riscv-openocd-tool/usr/local/bin/../share/openocd/scripts/target/gd32vf103.cfg", line 9
in procedure 'default_to_jtag' called at file "embedded:startup.tcl", line 133
at file "embedded:startup.tcl", line 128
This issue can be solved by adding the line:
transport select jtag

After adding these two lines, OpenOCD could connect to the development board successfully. Programming the flash also works.