### PR TITLE
Properly cache s0/s1

### DIFF
--- a/src/flash/nor/stm32lx.c
+++ b/src/flash/nor/stm32lx.c
@@ -884,11 +884,10 @@ static int stm32lx_get_info(struct flash_bank *bank, struct command_invocation *
 		if (rev_id == info->revs[i].rev)
 			rev_str = info->revs[i].str;
 
-	if (rev_str) {
+	if (rev_str)
 		command_print_sameline(cmd, "%s - Rev: %s", info->device_str, rev_str);
-	} else {
+	else
 		command_print_sameline(cmd, "%s - Rev: unknown (0x%04x)", info->device_str, rev_id);
-	}
 
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1346,9 +1346,6 @@ static int register_write_direct(struct target *target, unsigned number,
 		riscv_program_insert(&program, vsetvli(ZERO, S0, value));
 
 	} else {
-		if (register_write_direct(target, GDB_REGNO_S0, value) != ERROR_OK)
-			return ERROR_FAIL;
-
 		if (number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31) {
 			if (riscv_supports_extension(target, 'D'))
 				riscv_program_insert(&program, fmv_d_x(number - GDB_REGNO_FPR0, S0));
@@ -1369,6 +1366,8 @@ static int register_write_direct(struct target *target, unsigned number,
 			LOG_ERROR("Unsupported register (enum gdb_regno)(%d)", number);
 			return ERROR_FAIL;
 		}
+		if (register_write_direct(target, GDB_REGNO_S0, value) != ERROR_OK)
+			return ERROR_FAIL;
 	}
 
 	int exec_out = riscv_program_exec(&program, target);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4769,7 +4769,8 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 		return ERROR_FAIL;
 	}
 
-	riscv_flush_registers(target);
+	if (riscv_flush_registers(target) != ERROR_OK)
+		return ERROR_FAIL;
 
 	/* Issue the resume command, and then wait for the current hart to resume. */
 	uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE | DM_DMCONTROL_RESUMEREQ;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3644,7 +3644,7 @@ int riscv_save_register(struct target *target, enum gdb_regno regid)
 {
 	riscv_reg_t value;
 	if (!target->reg_cache) {
-		LOG_ERROR("TODO: Properly save %s", gdb_regno_name(regid));
+		assert(!target_was_examined(target));
 		return ERROR_OK;
 	}
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -350,6 +350,9 @@ int riscv_set_register(struct target *target, enum gdb_regno i, riscv_reg_t v);
 /** Get register, from the cache if it's in there. */
 int riscv_get_register(struct target *target, riscv_reg_t *value,
 		enum gdb_regno r);
+/** Read the register into the cache, and mark it dirty so it will be restored
+ * before resuming. */
+int riscv_save_register(struct target *target, enum gdb_regno regid);
 
 /* Checks the state of the current hart -- "is_halted" checks the actual
  * on-device register. */

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -353,6 +353,8 @@ int riscv_get_register(struct target *target, riscv_reg_t *value,
 /** Read the register into the cache, and mark it dirty so it will be restored
  * before resuming. */
 int riscv_save_register(struct target *target, enum gdb_regno regid);
+/** Write all dirty registers to the target. */
+int riscv_flush_registers(struct target *target);
 
 /* Checks the state of the current hart -- "is_halted" checks the actual
  * on-device register. */


### PR DESCRIPTION
Read those registers when we're about to use them for scratch, and then don't write them back until we resume the target. This saves a lot of needless saving/restoring of s0/s1. It only makes my tests run a few percent faster, though. I'm not sure why the difference isn't more clear there.