### PR TITLE
Dynamically allocate memory for RTOS registers.

### DIFF
--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -510,16 +510,33 @@ int rtos_get_gdb_reg(struct connection *connection, int reg_num)
 										target->rtos->current_thread);
 
 		int retval;
-		if (target->rtos->type->get_thread_reg) {
-			reg_list = calloc(1, sizeof(*reg_list));
-			reg_list[0].number = reg_num;
-			num_regs = 1;
-			retval = target->rtos->type->get_thread_reg(target->rtos,
-					current_threadid, reg_num, &reg_list[0]);
+		if (target->rtos->type->get_thread_reg_value) {
+			uint32_t reg_size;
+			uint8_t *reg_value;
+			retval = target->rtos->type->get_thread_reg_value(target->rtos,
+					current_threadid, reg_num, &reg_size, &reg_value);
 			if (retval != ERROR_OK) {
 				LOG_ERROR("RTOS: failed to get register %d", reg_num);
 				return retval;
 			}
+
+			/* Create a reg_list with one register that can
+			 * accommodate the full size of the one we just got the
+			 * value for. To do that we allocate extra space off the
+			 * end of the struct, relying on the fact that
+			 * rtos_reg.value is the last element in the struct. */
+			reg_list = calloc(1, sizeof(*reg_list) + DIV_ROUND_UP(reg_size, 8));
+			if (!reg_list) {
+				free(reg_value);
+				LOG_ERROR("Failed to allocated reg_list for %d-byte register.",
+					  reg_size);
+				return ERROR_FAIL;
+			}
+			reg_list[0].number = reg_num;
+			reg_list[0].size = reg_size;
+			memcpy(&reg_list[0].value, reg_value, DIV_ROUND_UP(reg_size, 8));
+			free(reg_value);
+			num_regs = 1;
 		} else {
 			retval = target->rtos->type->get_thread_reg_list(target->rtos,
 					current_threadid,

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -68,6 +68,8 @@ struct rtos_reg {
 	uint32_t number;
 	uint32_t size;
 	uint8_t value[16];
+	/* WARNING: rtos_get_gdb_reg() relies on the fact that value is the last
+	 * element of this struct. Any new fields should be added *before* value. */
 };
 
 struct rtos_type {
@@ -79,8 +81,10 @@ struct rtos_type {
 	/** Return a list of general registers, with their values filled out. */
 	int (*get_thread_reg_list)(struct rtos *rtos, threadid_t thread_id,
 			struct rtos_reg **reg_list, int *num_regs);
-	int (*get_thread_reg)(struct rtos *rtos, threadid_t thread_id,
-			uint32_t reg_num, struct rtos_reg *reg);
+	/** Return the size and value of the specified reg_num. The value is
+	 * allocated by the callee and freed by the caller. */
+	int (*get_thread_reg_value)(struct rtos *rtos, threadid_t thread_id,
+			uint32_t reg_num, uint32_t *size, uint8_t **value);
 	int (*get_symbol_list_to_lookup)(struct symbol_table_elem *symbol_list[]);
 	int (*clean)(struct target *target);
 	char * (*ps_command)(struct target *target);


### PR DESCRIPTION
This makes things work on RISC-V cores with large vector registers
(which can be up to kilobytes in size).

Change-Id: Ie53cb43a88e2a475f695cd5c1e28605569926817
Signed-off-by: Tim Newsome <tim@sifive.com>