### PR TITLE
Clear type 6 triggers on connecting.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3791,6 +3791,10 @@ int riscv_enumerate_triggers(struct target *target)
 				if (tdata1 & MCONTROL_DMODE(riscv_xlen(target)))
 					riscv_set_register(target, GDB_REGNO_TDATA1, 0);
 				break;
+			case 6:
+				if (tdata1 & MCONTROL_DMODE(riscv_xlen(target)))
+					riscv_set_register(target, GDB_REGNO_TDATA1, 0);
+				break;
 		}
 	}
 


### PR DESCRIPTION
I missed this when I first add mcontrol6 support.

Change-Id: I1a2706c7ea3a6757ed5083091cd2c764a8b0267c
Signed-off-by: Tim Newsome <tim@sifive.com>