### PR TITLE
Properly handle held-in-reset targets.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -863,8 +863,8 @@ static uint32_t access_register_command(struct target *target, uint32_t number,
 			command = set_field(command, AC_ACCESS_REGISTER_AARSIZE, 3);
 			break;
 		default:
-			LOG_ERROR("%d-bit register %s not supported.", size,
-					gdb_regno_name(number));
+			LOG_ERROR("[%s] %d-bit register %s not supported.",
+					target_name(target), size, gdb_regno_name(number));
 			assert(0);
 	}
 
@@ -1546,8 +1546,8 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 	}
 	if (get_field(dtmcontrol, DTM_DTMCS_VERSION) != 1) {
-		LOG_ERROR("Unsupported DTM version %d. (dtmcontrol=0x%x)",
-				get_field(dtmcontrol, DTM_DTMCS_VERSION), dtmcontrol);
+		LOG_ERROR("[%s] Unsupported DTM version %d. (dtmcontrol=0x%x)",
+				target_name(target), get_field(dtmcontrol, DTM_DTMCS_VERSION), dtmcontrol);
 		return ERROR_FAIL;
 	}
 
@@ -1685,7 +1685,8 @@ static int examine(struct target *target)
 	bool halted = riscv_is_halted(target);
 	if (!halted) {
 		if (riscv013_halt_go(target) != ERROR_OK) {
-			LOG_ERROR("Fatal: Hart %d failed to halt during examine()", r->current_hartid);
+			LOG_ERROR("[%s] Fatal: Hart %d failed to halt during examine()",
+					target_name(target), r->current_hartid);
 			return ERROR_FAIL;
 		}
 	}
@@ -4193,9 +4194,9 @@ static int riscv013_halt_go(struct target *target)
 		if (dmi_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
 			return ERROR_FAIL;
 
-		LOG_ERROR("unable to halt hart %d", r->current_hartid);
-		LOG_ERROR("  dmcontrol=0x%08x", dmcontrol);
-		LOG_ERROR("  dmstatus =0x%08x", dmstatus);
+		LOG_ERROR("[%s] unable to halt hart %d", target_name(target), r->current_hartid);
+		LOG_ERROR("[%s]   dmcontrol=0x%08x", target_name(target), dmcontrol);
+		LOG_ERROR("[%s]   dmstatus =0x%08x", target_name(target), dmstatus);
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4195,9 +4195,8 @@ static int riscv013_halt_go(struct target *target)
 		if (dmi_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
 			return ERROR_FAIL;
 
-		LOG_ERROR("[%s] unable to halt hart %d", target_name(target), r->current_hartid);
-		LOG_ERROR("[%s]   dmcontrol=0x%08x", target_name(target), dmcontrol);
-		LOG_ERROR("[%s]   dmstatus =0x%08x", target_name(target), dmstatus);
+		LOG_ERROR("[%s] Unable to halt hart %d. dmcontrol=0x%08x, dmstatus=0x%08x",
+				  target_name(target), r->current_hartid, dmcontrol, dmstatus);
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -652,10 +652,10 @@ static int dmi_op(struct target *target, uint32_t *data_in,
 	int result = dmi_op_timeout(target, data_in, dmi_busy_encountered, dmi_op,
 			address, data_out, riscv_command_timeout_sec, exec, ensure_success);
 	if (result == ERROR_TIMEOUT_REACHED) {
-		LOG_ERROR("DMI operation didn't complete in %d seconds. The target is "
+		LOG_ERROR("[%s] DMI operation didn't complete in %d seconds. The target is "
 				"either really slow or broken. You could increase the "
 				"timeout with riscv set_command_timeout_sec.",
-				riscv_command_timeout_sec);
+				target_name(target), riscv_command_timeout_sec);
 		return ERROR_FAIL;
 	}
 	return result;
@@ -1628,7 +1628,8 @@ static int examine(struct target *target)
 	info->datacount = get_field(abstractcs, DM_ABSTRACTCS_DATACOUNT);
 	info->progbufsize = get_field(abstractcs, DM_ABSTRACTCS_PROGBUFSIZE);
 
-	LOG_INFO("datacount=%d progbufsize=%d", info->datacount, info->progbufsize);
+	LOG_INFO("[%s] datacount=%d progbufsize=%d", target_name(target),
+			info->datacount, info->progbufsize);
 
 	RISCV_INFO(r);
 	r->impebreak = get_field(dmstatus, DM_DMSTATUS_IMPEBREAK);
@@ -1728,7 +1729,7 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 
 	/* Display this as early as possible to help people who are using
-		* really slow simulators. */
+	 * really slow simulators. */
 	LOG_DEBUG(" hart %d: XLEN=%d, misa=0x%" PRIx64, r->current_hartid, r->xlen,
 			r->misa);
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -418,7 +418,8 @@ static struct target_type *get_target_type(struct target *target)
 		case 1:
 			return &riscv013_target;
 		default:
-			LOG_ERROR("Unsupported DTM version: %d", info->dtm_version);
+			LOG_ERROR("[%s] Unsupported DTM version: %d",
+					target_name(target), info->dtm_version);
 			return NULL;
 	}
 }
@@ -1108,10 +1109,9 @@ static int old_or_new_riscv_step(struct target *target, int current,
 		return riscv_openocd_step(target, current, address, handle_breakpoints);
 }
 
-
 static int riscv_examine(struct target *target)
 {
-	LOG_DEBUG("riscv_examine()");
+	LOG_DEBUG("[%s]", target_name(target));
 	if (target_was_examined(target)) {
 		LOG_DEBUG("Target was already examined.");
 		return ERROR_OK;
@@ -2079,7 +2079,8 @@ static enum riscv_poll_hart riscv_poll_hart(struct target *target, int hartid)
 	if (riscv_set_current_hartid(target, hartid) != ERROR_OK)
 		return RPH_ERROR;
 
-	LOG_DEBUG("polling hart %d, target->state=%d", hartid, target->state);
+	LOG_DEBUG("[%s] polling hart %d, target->state=%d", target_name(target),
+			hartid, target->state);
 
 	/* If OpenOCD thinks we're running but this hart is halted then it's time
 	 * to raise an event. */
@@ -2185,6 +2186,8 @@ int riscv_openocd_poll(struct target *target)
 		for (struct target_list *list = target->head; list;
 				list = list->next, i++) {
 			struct target *t = list->target;
+			if (!target_was_examined(t))
+				continue;
 			riscv_info_t *r = riscv_info(t);
 			enum riscv_poll_hart out = riscv_poll_hart(t, r->current_hartid);
 			switch (out) {
@@ -4099,8 +4102,8 @@ int riscv_init_registers(struct target *target)
 			target->reg_cache->num_regs += entry->high - entry->low + 1;
 	}
 
-	LOG_DEBUG("create register cache for %d registers",
-			target->reg_cache->num_regs);
+	LOG_DEBUG("[%s] create register cache for %d registers",
+			target_name(target), target->reg_cache->num_regs);
 
 	target->reg_cache->reg_list =
 		calloc(target->reg_cache->num_regs, sizeof(struct reg));

--- a/tools/filter_openocd_log.py
+++ b/tools/filter_openocd_log.py
@@ -106,7 +106,7 @@ def main(args):
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('file', nargs='*', help='input file')
     parser.add_argument('-o', '--output', help='output file', default=sys.stdout)
-    parser.add_argument('-w', '--window', type=int, default=100,
+    parser.add_argument('-w', '--window', type=int, default=400,
             help='number of lines to consider when looking for repetitions')
     args = parser.parse_args(args)
 


### PR DESCRIPTION
1. Let OpenOCD continue into some pre-existing code that will periodically
   call examine() until it passes.
2. Fix crash in riscv_openocd_poll()
   When SMP is configured, it's not guaranteed that all targets have been
   examine()d when poll is called on one of them.

Change-Id: Ic6c1d217dc766ea69b67bb2e9a4898e37ee94927
Signed-off-by: Tim Newsome <tim@sifive.com>