### PR TITLE
Don't invalidate register cache of halted target.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1163,6 +1163,8 @@ int riscv_flush_registers(struct target *target)
 	if (!target->reg_cache)
 		return ERROR_OK;
 
+	LOG_DEBUG("[%s]", target_name(target));
+
 	for (uint32_t number = 0; number < target->reg_cache->num_regs; number++) {
 		struct reg *reg = &target->reg_cache->reg_list[number];
 		if (reg->valid && reg->dirty) {
@@ -1210,9 +1212,9 @@ int riscv_halt_go_all_harts(struct target *target)
 	} else {
 		if (r->halt_go(target) != ERROR_OK)
 			return ERROR_FAIL;
-	}
 
-	riscv_invalidate_register_cache(target);
+		riscv_invalidate_register_cache(target);
+	}
 
 	return ERROR_OK;
 }


### PR DESCRIPTION
This causes trouble if you disconnect/reconnect gdb, because in that
case a halt is issued again. (It probably would be possible to run into
this problem in other ways as well.)

Change-Id: Id5815f9d1dc2c2dd627770e001c03874a307c279
Signed-off-by: Tim Newsome <tim@sifive.com>