### PR TITLE
Handle changed `ftdi` syntax.

### DIFF
--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -1337,7 +1337,7 @@ static const struct command_registration ftdi_subcommand_handlers[] = {
 	},
 #if BUILD_FTDI_OSCAN1 == 1
 	{
-		.name = "ftdi_oscan1_mode",
+		.name = "oscan1_mode",
 		.handler = &ftdi_handle_oscan1_mode_command,
 		.mode = COMMAND_ANY,
 		.help = "set to 'on' to use OSCAN1 mode for signaling, otherwise 'off' (default is 'off')",

--- a/tcl/interface/ftdi/arty-onboard-ftdi.cfg
+++ b/tcl/interface/ftdi/arty-onboard-ftdi.cfg
@@ -1,7 +1,7 @@
 interface ftdi
 # ftdi_device_desc "Arty On-board FTDI interface"
-ftdi_vid_pid 0x0403 0x6010
-ftdi_channel 0
-ftdi_layout_init 0x0088 0x008b
+ftdi vid_pid 0x0403 0x6010
+ftdi channel 0
+ftdi layout_init 0x0088 0x008b
 reset_config none
 

--- a/tcl/interface/ftdi/lambdaconcept_ecpix-5.cfg
+++ b/tcl/interface/ftdi/lambdaconcept_ecpix-5.cfg
@@ -7,8 +7,8 @@
 
 adapter driver ftdi
 adapter speed 10000
-ftdi_device_desc "Dual RS232-HS"
-ftdi_vid_pid 0x0403 0x6010
+ftdi device_desc "Dual RS232-HS"
+ftdi vid_pid 0x0403 0x6010
 
-ftdi_layout_init 0xfff8 0xfffb
+ftdi layout_init 0xfff8 0xfffb
 transport select jtag

--- a/tcl/interface/ftdi/olimex-arm-jtag-cjtag.cfg
+++ b/tcl/interface/ftdi/olimex-arm-jtag-cjtag.cfg
@@ -10,18 +10,18 @@
 #
 
 interface ftdi
-ftdi_oscan1_mode on
-ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
-ftdi_vid_pid 0x15ba 0x002a
+ftdi oscan1_mode on
+ftdi device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi vid_pid 0x15ba 0x002a
 
-ftdi_layout_init 0x0808 0x0a1b
-ftdi_layout_signal nSRST -oe 0x0200
+ftdi layout_init 0x0808 0x0a1b
+ftdi layout_signal nSRST -oe 0x0200
 # oscan1_ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
-ftdi_layout_signal LED -data 0x0800
+ftdi layout_signal LED -data 0x0800
 
 # These signals are used for cJTAG escape sequence on initialization only
-ftdi_layout_signal TCK -data 0x0001
-ftdi_layout_signal TDI -data 0x0002
-ftdi_layout_signal TDO -input 0x0004
-ftdi_layout_signal TMS -data 0x0008
-ftdi_layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ftdi layout_signal TCK -data 0x0001
+ftdi layout_signal TDI -data 0x0002
+ftdi layout_signal TDO -input 0x0004
+ftdi layout_signal TMS -data 0x0008
+ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100

--- a/tcl/interface/ftdi/olimex-arm-usb-ocd-h-cjtag.cfg
+++ b/tcl/interface/ftdi/olimex-arm-usb-ocd-h-cjtag.cfg
@@ -5,18 +5,18 @@
 #
 
 interface ftdi
-ftdi_oscan1_mode on
-ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-OCD-H"
-ftdi_vid_pid 0x15ba 0x002b
+ftdi oscan1_mode on
+ftdi device_desc "Olimex OpenOCD JTAG ARM-USB-OCD-H"
+ftdi vid_pid 0x15ba 0x002b
 
-ftdi_layout_init 0x0808 0x0a1b
-ftdi_layout_signal nSRST -oe 0x0200
+ftdi layout_init 0x0808 0x0a1b
+ftdi layout_signal nSRST -oe 0x0200
 # oscan1_ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
-ftdi_layout_signal LED -data 0x0800
+ftdi layout_signal LED -data 0x0800
 
 # These signals are used for cJTAG escape sequence on initialization only
-ftdi_layout_signal TCK -data 0x0001
-ftdi_layout_signal TDI -data 0x0002
-ftdi_layout_signal TDO -input 0x0004
-ftdi_layout_signal TMS -data 0x0008
-ftdi_layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ftdi layout_signal TCK -data 0x0001
+ftdi layout_signal TDI -data 0x0002
+ftdi layout_signal TDO -input 0x0004
+ftdi layout_signal TMS -data 0x0008
+ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100

--- a/tcl/interface/ftdi/olimex-arm-usb-tiny-h-cjtag.cfg
+++ b/tcl/interface/ftdi/olimex-arm-usb-tiny-h-cjtag.cfg
@@ -10,18 +10,18 @@
 #
 
 interface ftdi
-ftdi_oscan1_mode on
-ftdi_device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
-ftdi_vid_pid 0x15ba 0x002a
+ftdi oscan1_mode on
+ftdi device_desc "Olimex OpenOCD JTAG ARM-USB-TINY-H"
+ftdi vid_pid 0x15ba 0x002a
 
-ftdi_layout_init 0x0808 0x0a1b
-ftdi_layout_signal nSRST -oe 0x0200
+ftdi layout_init 0x0808 0x0a1b
+ftdi layout_signal nSRST -oe 0x0200
 # oscan1_ftdi_layout_signal nTRST -data 0x0100 -oe 0x0100
-ftdi_layout_signal LED -data 0x0800
+ftdi layout_signal LED -data 0x0800
 
 # These signals are used for cJTAG escape sequence on initialization only
-ftdi_layout_signal TCK -data 0x0001
-ftdi_layout_signal TDI -data 0x0002
-ftdi_layout_signal TDO -input 0x0004
-ftdi_layout_signal TMS -data 0x0008
-ftdi_layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ftdi layout_signal TCK -data 0x0001
+ftdi layout_signal TDI -data 0x0002
+ftdi layout_signal TDO -input 0x0004
+ftdi layout_signal TMS -data 0x0008
+ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100


### PR DESCRIPTION
Also rename ftdi_oscan1_mode command which only exists in our branch.

Change-Id: Ie9b28f228b1fd984244edb8162d552104d28e462
Signed-off-by: Tim Newsome <tim@sifive.com>