### PR TITLE
Ask the RTOS which target to set swbp on.

### DIFF
--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -43,6 +43,8 @@ static int hwthread_read_buffer(struct rtos *rtos, target_addr_t address,
 		uint32_t size, uint8_t *buffer);
 static int hwthread_write_buffer(struct rtos *rtos, target_addr_t address,
 		uint32_t size, const uint8_t *buffer);
+struct target *hwthread_swbp_target(struct rtos *rtos, target_addr_t address,
+				    uint32_t length, enum breakpoint_type type);
 
 #define HW_THREAD_NAME_STR_SIZE (32)
 
@@ -66,6 +68,7 @@ const struct rtos_type hwthread_rtos = {
 	.needs_fake_step = hwthread_needs_fake_step,
 	.read_buffer = hwthread_read_buffer,
 	.write_buffer = hwthread_write_buffer,
+	.swbp_target = hwthread_swbp_target
 };
 
 struct hwthread_params {
@@ -443,4 +446,10 @@ static int hwthread_write_buffer(struct rtos *rtos, target_addr_t address,
 		return ERROR_FAIL;
 
 	return target_write_buffer(curr, address, size, buffer);
+}
+
+struct target *hwthread_swbp_target(struct rtos *rtos, target_addr_t address,
+				    uint32_t length, enum breakpoint_type type)
+{
+	return hwthread_find_thread(rtos->target, rtos->current_thread);
 }

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -836,3 +836,11 @@ int rtos_write_buffer(struct target *target, target_addr_t address,
 		return target->rtos->type->write_buffer(target->rtos, address, size, buffer);
 	return ERROR_NOT_IMPLEMENTED;
 }
+
+struct target *rtos_swbp_target(struct target *target, target_addr_t address,
+				uint32_t length, enum breakpoint_type type)
+{
+	if (target->rtos->type->swbp_target)
+		return target->rtos->type->swbp_target(target->rtos, address, length, type);
+	return target;
+}

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -20,6 +20,7 @@
 #define OPENOCD_RTOS_RTOS_H
 
 #include "server/server.h"
+#include "target/breakpoints.h"
 #include "target/target.h"
 #include <helper/jim-nvp.h>
 
@@ -103,6 +104,12 @@ struct rtos_type {
 			uint8_t *buffer);
 	int (*write_buffer)(struct rtos *rtos, target_addr_t address, uint32_t size,
 			const uint8_t *buffer);
+	/* When a software breakpoint is set, it is set on only one target,
+	 * because we assume memory is shared across them. By default this is the
+	 * first target in the SMP group. Override this function to have
+	 * breakpoint_add() use a different target. */
+	struct target * (*swbp_target)(struct rtos *rtos, target_addr_t address,
+				     uint32_t length, enum breakpoint_type type);
 };
 
 struct stack_register_offset {
@@ -166,5 +173,7 @@ int rtos_read_buffer(struct target *target, target_addr_t address,
 		uint32_t size, uint8_t *buffer);
 int rtos_write_buffer(struct target *target, target_addr_t address,
 		uint32_t size, const uint8_t *buffer);
+struct target *rtos_swbp_target(struct target *target, target_addr_t address,
+				uint32_t length, enum breakpoint_type type);
 
 #endif /* OPENOCD_RTOS_RTOS_H */


### PR DESCRIPTION
This lets the RTOS pick the "current" target, which matters if address
translation differs between threads.

Change-Id: I5b5510ab6a06621589c902f42a91562055817dc4
Signed-off-by: Tim Newsome <tim@sifive.com>