### PR TITLE
fix for missing thread ID in stop reply when smp-configured harts other than hart 0 single-stepped

### DIFF
--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -789,10 +789,34 @@ static int rtos_try_next(struct target *target)
 	return 1;
 }
 
-int rtos_update_threads(struct target *target)
+static struct rtos * rtos_of_target(struct target *target)
 {
 	if ((target->rtos) && (target->rtos->type))
+	{
+	   return target->rtos;
+	}
+	else if (target->smp)
+	{
+	   // find target in SMP group that has ->rtos and ->rtos->type non-zero
+	   struct target_list *cur = target->head;
+	   while (cur) {
+	      if (cur->target->rtos && cur->target->rtos->type)
+		 return cur->target->rtos;
+	      cur = cur->next;
+	   }
+	}
+	return NULL;
+}
+
+int rtos_update_threads(struct target *target)
+{
+/*   
+	if ((target->rtos) && (target->rtos->type))
 		target->rtos->type->update_threads(target->rtos);
+*/
+	struct rtos *rtos = rtos_of_target(target);
+	if (rtos)
+		rtos->type->update_threads(rtos);	   
 	return ERROR_OK;
 }
 

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -789,7 +789,7 @@ static int rtos_try_next(struct target *target)
 	return 1;
 }
 
-struct rtos * rtos_of_target(struct target *target)
+struct rtos *rtos_of_target(struct target *target)
 {
 	if ((target->rtos) && (target->rtos->type))
 	{

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -797,7 +797,7 @@ struct rtos *rtos_of_target(struct target *target)
 		Otherwise NULL return means that no associated non-zero rtos field could be found. */
 
 	struct target_list *pos;
-   
+
 	if ((target->rtos) && (target->rtos->type))
 		return target->rtos;
 
@@ -812,7 +812,7 @@ int rtos_update_threads(struct target *target)
 {
 	struct rtos *rtos = rtos_of_target(target);
 	if (rtos)
-		rtos->type->update_threads(rtos);	   
+		rtos->type->update_threads(rtos);
 	return ERROR_OK;
 }
 

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -789,7 +789,7 @@ static int rtos_try_next(struct target *target)
 	return 1;
 }
 
-static struct rtos * rtos_of_target(struct target *target)
+struct rtos * rtos_of_target(struct target *target)
 {
 	if ((target->rtos) && (target->rtos->type))
 	{

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -793,8 +793,8 @@ static int rtos_try_next(struct target *target)
 struct rtos *rtos_of_target(struct target *target)
 {
 	/* Primarily consider the rtos field of the target itself, secondarily consider
-		rtos field SMP leader target, then consider rtos field of any other target in the SMP group.
-		Otherwise NULL return means that no associated non-zero rtos field could be found. */
+	 * rtos field SMP leader target, then consider rtos field of any other target in the SMP group.
+	 * Otherwise NULL return means that no associated non-zero rtos field could be found. */
 
 	struct target_list *pos;
 

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -795,8 +795,8 @@ struct rtos *rtos_of_target(struct target *target)
 	/* Primarily consider the rtos field of the target itself, secondarily consider
 		rtos field SMP leader target, then consider rtos field of any other target in the SMP group.
 		Otherwise NULL return means that no associated non-zero rtos field could be found. */
-   
-	struct target_list *pos;   
+
+	struct target_list *pos;
    
 	if ((target->rtos) && (target->rtos->type))
 		return target->rtos;

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -810,10 +810,6 @@ struct rtos *rtos_of_target(struct target *target)
 
 int rtos_update_threads(struct target *target)
 {
-/*   
-	if ((target->rtos) && (target->rtos->type))
-		target->rtos->type->update_threads(target->rtos);
-*/
 	struct rtos *rtos = rtos_of_target(target);
 	if (rtos)
 		rtos->type->update_threads(rtos);	   

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -791,20 +791,15 @@ static int rtos_try_next(struct target *target)
 
 struct rtos *rtos_of_target(struct target *target)
 {
+	/* Primarily consider the rtos field of the target itself, and secondarily consider
+		rtos field of SMP leader target (if present) */
+   
 	if ((target->rtos) && (target->rtos->type))
-	{
-	   return target->rtos;
-	}
-	else if (target->smp)
-	{
-	   // find target in SMP group that has ->rtos and ->rtos->type non-zero
-	   struct target_list *cur = target->head;
-	   while (cur) {
-	      if (cur->target->rtos && cur->target->rtos->type)
-		 return cur->target->rtos;
-	      cur = cur->next;
-	   }
-	}
+		return target->rtos;
+
+	if ((target->smp) && (target->head) && (target->head->target->rtos) && (target->head->target->rtos->type))
+		return target->head->target->rtos;
+
 	return NULL;
 }
 

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -176,4 +176,6 @@ int rtos_write_buffer(struct target *target, target_addr_t address,
 struct target *rtos_swbp_target(struct target *target, target_addr_t address,
 				uint32_t length, enum breakpoint_type type);
 
+struct rtos * rtos_of_target(struct target *target);
+
 #endif /* OPENOCD_RTOS_RTOS_H */

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -175,7 +175,6 @@ int rtos_write_buffer(struct target *target, target_addr_t address,
 		uint32_t size, const uint8_t *buffer);
 struct target *rtos_swbp_target(struct target *target, target_addr_t address,
 				uint32_t length, enum breakpoint_type type);
-
-struct rtos * rtos_of_target(struct target *target);
+struct rtos *rtos_of_target(struct target *target);
 
 #endif /* OPENOCD_RTOS_RTOS_H */

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -778,9 +778,12 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		sig_reply_len = snprintf(sig_reply, sizeof(sig_reply), "W00");
 	} else {
 		struct target *ct;
-		if (target->rtos) {
-			target->rtos->current_threadid = target->rtos->current_thread;
-			target->rtos->gdb_target_for_threadid(connection, target->rtos->current_threadid, &ct);
+		struct rtos *rtos;
+
+		rtos = rtos_of_target(target);		
+		if (rtos) {
+			rtos->current_threadid = rtos->current_thread;
+			rtos->gdb_target_for_threadid(connection, rtos->current_threadid, &ct);
 		} else {
 			ct = target;
 		}
@@ -817,9 +820,9 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		}
 
 		current_thread[0] = '\0';
-		if (target->rtos)
+		if (rtos)
 			snprintf(current_thread, sizeof(current_thread), "thread:%" PRIx64 ";",
-					target->rtos->current_thread);
+					rtos->current_thread);
 
 		sig_reply_len = snprintf(sig_reply, sizeof(sig_reply), "T%2.2x%s%s",
 				signal_var, stop_reason, current_thread);

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -780,7 +780,7 @@ static void gdb_signal_reply(struct target *target, struct connection *connectio
 		struct target *ct;
 		struct rtos *rtos;
 
-		rtos = rtos_of_target(target);		
+		rtos = rtos_of_target(target);
 		if (rtos) {
 			rtos->current_threadid = rtos->current_thread;
 			rtos->gdb_target_for_threadid(connection, rtos->current_threadid, &ct);


### PR DESCRIPTION
To replicate the issue that this fixes:

1) checkout the riscv branch, build, connect to a multi-hart target configured as an SMP group.  
2) Start a GDB instance against the running OpenOCD.  
3) Observe that GDB might display "warning: multi-threaded target stopped without sending a thread-id, using first non-exited thread."
4) Set a breakpoint in code that any non-hart-0 hart is expected to reach (but hart 0 is not expected to reach).
5)  Allow a non-hart-0 hart to reach the breakpoint.
6) Remove the breakpoint.
7) Do a few sequential "stepi" commands in GDB.
8) Observe that GDB displays "Switching to Thread 1" even though the thread that was just single stepped was not Thread 1 in GDB.  Also observe that the register values in GDB correspond to the thread that was single-stepped, not Thread 1.  Basically GDB erroneously starts to consider thread 1 to be current, when in fact the thread that was single-stepped is still current.

The changes in this pull request are intended to avoid the erroneous "Switching to Thread 1" described in (8) above.

What was happening was that, in a couple areas of code, non-hart-0 harts weren't seen as belonging to an rtos module, and this had the effect of (1) bypassing hwthread_update_threads() being called after a halt; (2) omitting a thread ID in a stop reply over GDB remote protocol connection (requiring GDB to take an arbitrary guess of current thread id, a guess that is wrong unless the current thread happens to be hart 0).