### PR TITLE
riscv: fix remove_trigger return code for unavailable hw bp slot

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -927,7 +927,7 @@ static int remove_trigger(struct target *target, struct trigger *trigger)
 	if (i >= r->trigger_count) {
 		LOG_ERROR("Couldn't find the hardware resources used by hardware "
 				"trigger.");
-		return ERROR_FAIL;
+		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}
 	LOG_DEBUG("[%d] Stop using resource %d for bp %d", target->coreid, i,
 			trigger->unique_id);


### PR DESCRIPTION
If there is no available slot for the hardware breakpoints, it should return with different error code to allow vendors to do specific operation like switching to flash breakpoint's add/remove functions. 

Actually it is working as expected for the `add_trigger`, but not for the `remove_trigger`