### PR TITLE
.gitmodules: switch away from repo.or.cz

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
+[submodule "tools/git2cl"]
+	path = tools/git2cl
+	url = https://git.savannah.nongnu.org/git/git2cl.git
 [submodule "jimtcl"]
 	path = jimtcl
 	url = https://github.com/msteveb/jimtcl.git
-[submodule "tools/git2cl"]
-	path = tools/git2cl
-	url = https://repo.or.cz/git2cl.git
 [submodule "src/jtag/drivers/libjaylink"]
 	path = src/jtag/drivers/libjaylink
-	url = https://repo.or.cz/libjaylink.git
+	url = https://gitlab.zapb.de/libjaylink/libjaylink.git


### PR DESCRIPTION
Manually applying https://review.openocd.org/c/openocd/+/6834 (which
hasn't merged yet) since repo.or.cz is down often enough that it's
affecting development.

Change-Id: Idb337c799662f3e0fa72379c59c52a61a048044e
Signed-off-by: Tim Newsome <tim@sifive.com>