### PR TITLE
riscv: implement maskisr steponly command

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10425,8 +10425,10 @@ tunneled DR scan consists of:
 @end deffn
 
 @deffn {Command} {riscv set_maskisr} [@option{off}|@option{steponly}]
-Selects whether interrupts will be disabled when single stepping. The default configuration is
-@option{off}.
+Selects whether interrupts will be disabled when single stepping. The default configuration is @option{off}.
+This feature is only useful on hardware that always steps into interrupts and doesn't support dcsr.stepie=0.
+Keep in mind, disabling the option does not guarantee that single stepping will go into interrupt handlers.
+To make that happen, dcsr.stepie would have to be written to 1 as well.
 @end deffn
 
 @deffn {Command} {riscv set_ebreakm} on|off

--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10424,6 +10424,11 @@ tunneled DR scan consists of:
 
 @end deffn
 
+@deffn {Command} {riscv set_maskisr} [@option{off}|@option{steponly}]
+Selects whether interrupts will be disabled when single stepping. The default configuration is
+@option{off}.
+@end deffn
+
 @deffn {Command} {riscv set_ebreakm} on|off
 Control dcsr.ebreakm. When on (default), M-mode ebreak instructions trap to
 OpenOCD. When off, they generate a breakpoint exception handled internally.

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1953,26 +1953,11 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 		}
 	}
 
-
 	/* Disable Interrupts before attempting to run the algorithm. */
 	uint64_t current_mstatus;
-	uint8_t mstatus_bytes[8] = { 0 };
-
-	LOG_DEBUG("Disabling Interrupts");
-	struct reg *reg_mstatus = register_get_by_name(target->reg_cache,
-			"mstatus", true);
-	if (!reg_mstatus) {
-		LOG_ERROR("Couldn't find mstatus!");
+	uint64_t irq_disabled_mask = MSTATUS_MIE | MSTATUS_HIE | MSTATUS_SIE | MSTATUS_UIE;
+	if (riscv_interrupts_disable(target, irq_disabled_mask, &current_mstatus) != ERROR_OK)
 		return ERROR_FAIL;
-	}
-
-	reg_mstatus->type->get(reg_mstatus);
-	current_mstatus = buf_get_u64(reg_mstatus->value, 0, reg_mstatus->size);
-	uint64_t ie_mask = MSTATUS_MIE | MSTATUS_HIE | MSTATUS_SIE | MSTATUS_UIE;
-	buf_set_u64(mstatus_bytes, 0, info->xlen, set_field(current_mstatus,
-				ie_mask, 0));
-
-	reg_mstatus->type->set(reg_mstatus, mstatus_bytes);
 
 	/* Run algorithm */
 	LOG_DEBUG("resume at 0x%" TARGET_PRIxADDR, entry_point);
@@ -2028,9 +2013,8 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 	}
 
 	/* Restore Interrupts */
-	LOG_DEBUG("Restoring Interrupts");
-	buf_set_u64(mstatus_bytes, 0, info->xlen, current_mstatus);
-	reg_mstatus->type->set(reg_mstatus, mstatus_bytes);
+	if (riscv_interrupts_restore(target, current_mstatus) != ERROR_OK)
+		return ERROR_FAIL;
 
 	/* Restore registers */
 	uint8_t buf[8] = { 0 };
@@ -2377,10 +2361,24 @@ int riscv_openocd_step(struct target *target, int current,
 	if (disable_triggers(target, trigger_state) != ERROR_OK)
 		return ERROR_FAIL;
 
+	uint64_t current_mstatus;
+	RISCV_INFO(info);
+	if (info->isrmask_mode == RISCV_ISRMASK_STEPONLY) {
+		/* Disable Interrupts before stepping. */
+		uint64_t irq_disabled_mask = MSTATUS_MIE | MSTATUS_HIE | MSTATUS_SIE | MSTATUS_UIE;
+		if (riscv_interrupts_disable(target, irq_disabled_mask, &current_mstatus) != ERROR_OK)
+			return ERROR_FAIL;
+	}
+
 	int out = riscv_step_rtos_hart(target);
 	if (out != ERROR_OK) {
 		LOG_ERROR("unable to step rtos hart");
 		return out;
+	}
+
+	if (info->isrmask_mode == RISCV_ISRMASK_STEPONLY) {
+		if (riscv_interrupts_restore(target, current_mstatus) != ERROR_OK)
+			return ERROR_FAIL;
 	}
 
 	register_cache_invalidate(target->reg_cache);
@@ -2393,6 +2391,7 @@ int riscv_openocd_step(struct target *target, int current,
 	target->state = TARGET_HALTED;
 	target->debug_reason = DBG_REASON_SINGLESTEP;
 	target_call_event_callbacks(target, TARGET_EVENT_HALTED);
+
 	return out;
 }
 
@@ -2936,6 +2935,31 @@ COMMAND_HANDLER(riscv_use_bscan_tunnel)
 	return ERROR_OK;
 }
 
+COMMAND_HANDLER(riscv_set_maskisr)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	RISCV_INFO(info);
+
+	static const struct jim_nvp nvp_maskisr_modes[] = {
+		{ .name = "off", .value = RISCV_ISRMASK_OFF },
+		{ .name = "steponly", .value = RISCV_ISRMASK_STEPONLY },
+		{ .name = NULL, .value = -1 },
+	};
+	const struct jim_nvp *n;
+
+	if (CMD_ARGC > 0) {
+		n = jim_nvp_name2value_simple(nvp_maskisr_modes, CMD_ARGV[0]);
+		if (!n->name)
+			return ERROR_COMMAND_SYNTAX_ERROR;
+		info->isrmask_mode = n->value;
+	} else {
+		n = jim_nvp_value2name_simple(nvp_maskisr_modes, info->isrmask_mode);
+		command_print(CMD, "riscv interrupt mask %s", n->name);
+	}
+	
+	return ERROR_OK;
+}
+
 COMMAND_HANDLER(riscv_set_enable_virt2phys)
 {
 	if (CMD_ARGC != 1) {
@@ -3346,6 +3370,13 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 			"1: DATA_REGISTER}"
 	},
 	{
+		.name = "set_maskisr",
+		.handler = riscv_set_maskisr,
+		.mode = COMMAND_EXEC,
+		.help = "mask riscv interrupts",
+		.usage = "['off'|'steponly']",
+	},
+	{
 		.name = "set_enable_virt2phys",
 		.handler = riscv_set_enable_virt2phys,
 		.mode = COMMAND_ANY,
@@ -3489,6 +3520,8 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 
 	r->xlen = -1;
 
+	r->isrmask_mode = RISCV_ISRMASK_OFF;
+
 	r->mem_access_methods[0] = RISCV_MEM_ACCESS_PROGBUF;
 	r->mem_access_methods[1] = RISCV_MEM_ACCESS_SYSBUS;
 	r->mem_access_methods[2] = RISCV_MEM_ACCESS_ABSTRACT;
@@ -3518,6 +3551,52 @@ static int riscv_resume_go_all_harts(struct target *target)
 
 	riscv_invalidate_register_cache(target);
 	return ERROR_OK;
+}
+
+int riscv_interrupts_disable(struct target *target, uint64_t irq_mask, uint64_t *old_mstatus)
+{
+	LOG_DEBUG("Disabling Interrupts");
+	struct reg *reg_mstatus = register_get_by_name(target->reg_cache,
+			"mstatus", true);
+	if (!reg_mstatus) {
+		LOG_ERROR("Couldn't find mstatus!");
+		return ERROR_FAIL;
+	}
+
+	int retval = reg_mstatus->type->get(reg_mstatus);
+	if (retval != ERROR_OK)
+		return retval;
+
+	RISCV_INFO(info);
+	uint8_t mstatus_bytes[8] = { 0 };
+	uint64_t current_mstatus = buf_get_u64(reg_mstatus->value, 0, reg_mstatus->size);
+	buf_set_u64(mstatus_bytes, 0, info->xlen, set_field(current_mstatus,
+				irq_mask, 0));
+
+	retval = reg_mstatus->type->set(reg_mstatus, mstatus_bytes);
+	if (retval != ERROR_OK)
+		return retval;
+
+	if (old_mstatus)
+		*old_mstatus = current_mstatus;
+
+	return ERROR_OK;
+}
+
+int riscv_interrupts_restore(struct target *target, uint64_t old_mstatus)
+{
+	LOG_DEBUG("Restore Interrupts");
+	struct reg *reg_mstatus = register_get_by_name(target->reg_cache,
+			"mstatus", true);
+	if (!reg_mstatus) {
+		LOG_ERROR("Couldn't find mstatus!");
+		return ERROR_FAIL;
+	}
+
+	RISCV_INFO(info);
+	uint8_t mstatus_bytes[8];
+	buf_set_u64(mstatus_bytes, 0, info->xlen, old_mstatus);
+	return reg_mstatus->type->set(reg_mstatus, mstatus_bytes);
 }
 
 int riscv_step_rtos_hart(struct target *target)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -56,6 +56,13 @@ enum riscv_halt_reason {
 	RISCV_HALT_ERROR
 };
 
+enum riscv_isrmasking_mode {
+	/* RISCV_ISRMASK_AUTO,	*/ /* not supported yet */
+	RISCV_ISRMASK_OFF,
+	/* RISCV_ISRMASK_ON,	*/ /* not supported yet */
+	RISCV_ISRMASK_STEPONLY,
+};
+
 typedef struct {
 	struct target *target;
 	unsigned custom_number;
@@ -134,6 +141,8 @@ typedef struct {
 	bool prepped;
 	/* This target was selected using hasel. */
 	bool selected;
+
+	enum riscv_isrmasking_mode isrmask_mode;
 
 	/* Helper functions that target the various RISC-V debug spec
 	 * implementations. */
@@ -402,5 +411,8 @@ void riscv_add_bscan_tunneled_scan(struct target *target, struct scan_field *fie
 
 int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
 int riscv_write_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
+
+int riscv_interrupts_disable(struct target *target, uint64_t ie_mask, uint64_t *old_mstatus);
+int riscv_interrupts_restore(struct target *target, uint64_t old_mstatus);
 
 #endif


### PR DESCRIPTION
With this PR,  `riscv maskisr <off | steponly>` command implemented. Now it will be possible to disable/restore interrupts within the step function.  

ARM implementation of this command has also `auto and on` option but it is not ready for the riscv yet.  

I will also run and share the test results to make sure at least nothing broken. 

Change-Id: I1a3b666d466b064460c3acc307a36485ce165601
Signed-off-by: Erhan Kurubas <erhan.kurubas@espressif.com>