### PR TITLE
add callback for target reset

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4263,6 +4263,7 @@ static int riscv013_on_halt(struct target *target)
 static bool riscv013_is_halted(struct target *target)
 {
 	uint32_t dmstatus;
+
 	if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 		return false;
 	if (get_field(dmstatus, DM_DMSTATUS_ANYUNAVAIL))
@@ -4271,7 +4272,10 @@ static bool riscv013_is_halted(struct target *target)
 		LOG_ERROR("Hart %d doesn't exist.", riscv_current_hartid(target));
 	if (get_field(dmstatus, DM_DMSTATUS_ANYHAVERESET)) {
 		int hartid = riscv_current_hartid(target);
-		LOG_INFO("Hart %d unexpectedly reset!", hartid);
+		if (target->state != TARGET_RESET) {
+			/* warn for "unexpected" reset when it is not requested by user */
+			LOG_INFO("Hart %d unexpectedly reset!", hartid);
+		}
 		/* TODO: Can we make this more obvious to eg. a gdb user? */
 		uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE |
 			DM_DMCONTROL_ACKHAVERESET;
@@ -4284,6 +4288,10 @@ static bool riscv013_is_halted(struct target *target)
 		if (target->state == TARGET_HALTED)
 			dmcontrol |= DM_DMCONTROL_HALTREQ;
 		dmi_write(target, DM_DMCONTROL, dmcontrol);
+
+		RISCV_INFO(r);
+		if (r->on_reset)
+			r->on_reset(target);
 	}
 	return get_field(dmstatus, DM_DMSTATUS_ALLHALTED);
 }

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -150,6 +150,10 @@ typedef struct {
 	int (*resume_go)(struct target *target);
 	int (*step_current_hart)(struct target *target);
 	int (*on_halt)(struct target *target);
+
+	/* Indicates that target was reset.*/
+	int (*on_reset)(struct target *target);
+
 	/* Get this target as ready as possible to resume, without actually
 	 * resuming. */
 	int (*resume_prep)(struct target *target);


### PR DESCRIPTION
In this MR  `on_reset` callback function added to inform upper layers when reset happened. 

Reset can be triggered by user request or in an unexpected time. Before displaying an "unexpected reset" warning message, target state checked to inform users correctly.

Change-Id: Ife0244f31db06a93a264e797501d5266243364cd
Signed-off-by: Erhan Kurubas <erhan.kurubas@espressif.com>