### PR TITLE
Fix: Set proper debug_reason in deassert_reset()

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,6 +1,6 @@
 on: pull_request
 
-name: Check Code Style
+name: Check Code Style (checkpatch)
 
 jobs:
   check:
@@ -16,6 +16,9 @@ jobs:
       - run: sudo apt-get install patchutils
       - name: Run checkpatch
         run: |
-            git diff -U20 HEAD~40 | \
-                    filterdiff -x "a/src/jtag/drivers/libjaylink/*" -x "a/tools/git2cl/*" | \
-                    ./tools/scripts/checkpatch.pl --no-signoff -
+            git diff -U20 HEAD~40 \
+            | filterdiff \
+                -x "a/src/jtag/drivers/libjaylink/*" \
+                -x "a/tools/git2cl/*" \
+                -x "a/.github/*" \
+            | ./tools/scripts/checkpatch.pl --no-signoff -

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,7 +13,10 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 50
-      - run: sudo apt-get install patchutils
+      - name: Install required packages (apt-get)
+        run: |
+            sudo apt-get update
+            sudo apt-get install patchutils
       - name: Run checkpatch
         run: |
             git diff -U20 HEAD~40 \

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2436,6 +2436,7 @@ static int deassert_reset(struct target *target)
 			}
 		}
 		target->state = TARGET_HALTED;
+		target->debug_reason = DBG_REASON_DBGRQ;
 
 		if (get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET)) {
 			/* Ack reset. */


### PR DESCRIPTION
The issue was visible for example when user's .cfg file ended
with "reset halt" command:

In such case, the hart would remain halted but the debug_reason would not be
updated and may retain an incorrect value, e.g. DBG_REASON_NOTHALTED.
As a result, gdb_last_signal() would provide an incorrect reply to GDB.

Change-Id: Ie6f050295fb5cbe9db38b189c4bc385662acf5b4
Signed-off-by: Jan Matyas <matyas@codasip.com>