### PR TITLE
riscv: Increase batch allocation size to improve transfer speed.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3151,7 +3151,7 @@ static int read_memory_progbuf_inner(struct target *target, target_addr_t addres
 		 * dm_data0 contains[read_addr-size*2]
 		 */
 
-		struct riscv_batch *batch = riscv_batch_alloc(target, 32,
+		struct riscv_batch *batch = riscv_batch_alloc(target, RISCV_BATCH_ALLOC_SIZE,
 				info->dmi_busy_delay + info->ac_busy_delay);
 		if (!batch)
 			return ERROR_FAIL;
@@ -3649,7 +3649,7 @@ static int write_memory_bus_v1(struct target *target, target_addr_t address,
 
 		struct riscv_batch *batch = riscv_batch_alloc(
 				target,
-				32,
+				RISCV_BATCH_ALLOC_SIZE,
 				info->dmi_busy_delay + info->bus_master_write_delay);
 		if (!batch)
 			return ERROR_FAIL;
@@ -3843,7 +3843,7 @@ static int write_memory_progbuf(struct target *target, target_addr_t address,
 
 		struct riscv_batch *batch = riscv_batch_alloc(
 				target,
-				32,
+				RISCV_BATCH_ALLOC_SIZE,
 				info->dmi_busy_delay + info->ac_busy_delay);
 		if (!batch)
 			goto error;

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -29,6 +29,8 @@ struct riscv_program;
 
 #define RISCV_NUM_MEM_ACCESS_METHODS  3
 
+#define RISCV_BATCH_ALLOC_SIZE 128
+
 extern struct target_type riscv011_target;
 extern struct target_type riscv013_target;
 


### PR DESCRIPTION
Hi,

I did a speed test for file transfer, looking at the scope, there was quite some dead time between each batch of commands, so, this PR increase the maximal size of jtag batches in order to improve the speed.

Here is a few test i did based on a FT2232, targetting a core running at 100 Mhz, JTAG at the maximum of the FTDI was able to (probably around 20 Mhz).

Batch size = 32 (as it is currently in upstream)
downloaded 1152044 bytes in 2.192316s (513.176 KiB/s)
dumped 1152044 bytes in 3.017069s (372.893 KiB/s)

Batch size = 128 (as it is in this patch)
downloaded 1152044 bytes in 1.357257s (828.909 KiB/s)
dumped 1152044 bytes in 2.227927s (504.973 KiB/s)

Batch size = 1024
downloaded 1152044 bytes in 1.151690s (976.863 KiB/s)
dumped 1152044 bytes in 2.018675s (557.318 KiB/s)

