### PR TITLE
riscv: Add a option to specify the JTAG TAP tunnel IR 

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10494,7 +10494,7 @@ tunneled DR scan consists of:
 
 @deffn {Command} {riscv set_bscan_tunnel_ir} value
 Allows the use_bscan_tunnel feature to target non Xilinx device by
-specifing the JTAG TAP IR used to access the bscan tunnel.
+specifying the JTAG TAP IR used to access the bscan tunnel.
 @end deffn
 
 @deffn {Command} {riscv set_maskisr} [@option{off}|@option{steponly}]

--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10492,6 +10492,11 @@ tunneled DR scan consists of:
 
 @end deffn
 
+@deffn {Command} {riscv set_bscan_tunnel_ir} value
+Allows the use_bscan_tunnel feature to target non Xilinx device by
+specifing the JTAG TAP IR used to access the bscan tunnel.
+@end deffn
+
 @deffn {Command} {riscv set_maskisr} [@option{off}|@option{steponly}]
 Selects whether interrupts will be disabled when single stepping. The default configuration is @option{off}.
 This feature is only useful on hardware that always steps into interrupts and doesn't support dcsr.stepie=0.

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -451,8 +451,12 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 	select_idcode.num_bits = target->tap->ir_length;
 
 	if (bscan_tunnel_ir_width != 0) {
-		assert(target->tap->ir_length >= 6);
-		uint32_t ir_user4_raw = bscan_tunnel_ir_id != 0 ? bscan_tunnel_ir_id : 0x23 << (target->tap->ir_length - 6);
+		uint32_t ir_user4_raw = bscan_tunnel_ir_id;
+		/* Provide a default value which target some Xilinx FPGA USER4 IR */
+		if (ir_user4_raw == 0) {
+			assert(target->tap->ir_length >= 6);
+			ir_user4_raw = 0x23 << (target->tap->ir_length - 6);
+		}
 		ir_user4[0] = (uint8_t)ir_user4_raw;
 		ir_user4[1] = (uint8_t)(ir_user4_raw >>= 8);
 		ir_user4[2] = (uint8_t)(ir_user4_raw >>= 8);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -129,6 +129,7 @@ struct scan_field select_idcode = {
 
 bscan_tunnel_type_t bscan_tunnel_type;
 int bscan_tunnel_ir_width; /* if zero, then tunneling is not present/active */
+int bscan_tunnel_ir_id; /* IR ID of the JTAG TAP to access the tunnel. Valid when not 0 */
 
 static const uint8_t bscan_zero[4] = {0};
 static const uint8_t bscan_one[4] = {1};
@@ -451,7 +452,7 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 
 	if (bscan_tunnel_ir_width != 0) {
 		assert(target->tap->ir_length >= 6);
-		uint32_t ir_user4_raw = 0x23 << (target->tap->ir_length - 6);
+		uint32_t ir_user4_raw = bscan_tunnel_ir_id != 0 ? bscan_tunnel_ir_id : 0x23 << (target->tap->ir_length - 6);
 		ir_user4[0] = (uint8_t)ir_user4_raw;
 		ir_user4[1] = (uint8_t)(ir_user4_raw >>= 8);
 		ir_user4[2] = (uint8_t)(ir_user4_raw >>= 8);
@@ -2913,6 +2914,24 @@ COMMAND_HANDLER(riscv_use_bscan_tunnel)
 	return ERROR_OK;
 }
 
+COMMAND_HANDLER(riscv_set_bscan_tunnel_ir)
+{
+	int ir_id = 0;
+
+	if (CMD_ARGC > 1) {
+		LOG_ERROR("Command takes at most one arguments");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	} else if (CMD_ARGC == 1) {
+		COMMAND_PARSE_NUMBER(int, CMD_ARGV[0], ir_id);
+	}
+
+	LOG_INFO("Bscan tunnel IR 0x%x selected", ir_id);
+
+	bscan_tunnel_ir_id = ir_id;
+	return ERROR_OK;
+}
+
+
 COMMAND_HANDLER(riscv_set_maskisr)
 {
 	struct target *target = get_current_target(CMD_CTX);
@@ -3346,6 +3365,15 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 			"enable.  Supply a value of 0 to disable. Pass A second argument "
 			"(optional) to indicate Bscan Tunnel Type {0:(default) NESTED_TAP , "
 			"1: DATA_REGISTER}"
+	},
+	{
+		.name = "set_bscan_tunnel_ir",
+		.handler = riscv_set_bscan_tunnel_ir,
+		.mode = COMMAND_ANY,
+		.usage = "value",
+		.help = "Specify the JTAG TAP IR used to access the bscan tunnel. "
+			"By default it is 0x23 << (ir_length - 6), which map some "
+			"Xilinx FPGA (IR USER4)"
 	},
 	{
 		.name = "set_maskisr",

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -129,7 +129,7 @@ struct scan_field select_idcode = {
 
 bscan_tunnel_type_t bscan_tunnel_type;
 int bscan_tunnel_ir_width; /* if zero, then tunneling is not present/active */
-int bscan_tunnel_ir_id; /* IR ID of the JTAG TAP to access the tunnel. Valid when not 0 */
+static int bscan_tunnel_ir_id; /* IR ID of the JTAG TAP to access the tunnel. Valid when not 0 */
 
 static const uint8_t bscan_zero[4] = {0};
 static const uint8_t bscan_one[4] = {1};


### PR DESCRIPTION
Hi,

This patch fix :
https://github.com/riscv/riscv-openocd/blob/0a70e59cb86deed71fd92ceffdd233478e237ebb/src/target/riscv/riscv.c#L454

The TAP IR used when tunneling was hardcoded to 0x23 << IR_WIDTH-6, which refer to some Xilinx FPGA USER4 BSCANE.

This PR allows to select which IR is used in the TAP to access the tunnel entry, allowing targetting other FPGA vendors / device families.

This PR It is backward compatible.

TCL Usage example : 
riscv set_bscan_tunnel_ir 0x23    

