### PR TITLE
Fix: Prevent segfault for non-examined targets during reg. cache invalidate

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3490,7 +3490,6 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 {
 	memset(r, 0, sizeof(*r));
 	r->dtm_version = 1;
-	r->registers_initialized = false;
 	r->current_hartid = target->coreid;
 	r->version_specific = NULL;
 
@@ -3635,7 +3634,10 @@ int riscv_set_current_hartid(struct target *target, int hartid)
 
 void riscv_invalidate_register_cache(struct target *target)
 {
-	RISCV_INFO(r);
+	/* Do not invalidate the register cache if it is not yet set up
+	 * (e.g. when the target failed to get examined). */
+	if (!target->reg_cache)
+		return;
 
 	LOG_DEBUG("[%d]", target->coreid);
 	register_cache_invalidate(target->reg_cache);
@@ -3643,8 +3645,6 @@ void riscv_invalidate_register_cache(struct target *target)
 		struct reg *reg = &target->reg_cache->reg_list[i];
 		reg->valid = false;
 	}
-
-	r->registers_initialized = true;
 }
 
 int riscv_current_hartid(const struct target *target)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -125,9 +125,6 @@ typedef struct {
 	/* The number of entries in the debug buffer. */
 	int debug_buffer_size;
 
-	/* This avoids invalidating the register cache too often. */
-	bool registers_initialized;
-
 	/* This hart contains an implicit ebreak at the end of the program buffer. */
 	bool impebreak;
 


### PR DESCRIPTION
The segfault could be triggered if:

- At least one target failed to get examined (therefore does not have the
  register cache set up yet),

- and "reset" TCL command was issued, which internally tries to
  invalidate the register cache.

Minor cleanup: "registers_initialized" member removed from riscv_info_t
because it is not used anywhere.

Change-Id: I6288c0d4343ef6a330fb2a6b49d388e7eafa32a2
Signed-off-by: Jan Matyas <matyas@codasip.com>