### PR TITLE
Look at trigger hit bits to see which trigger was hit.

### DIFF
--- a/src/target/breakpoints.h
+++ b/src/target/breakpoints.h
@@ -56,7 +56,7 @@ struct watchpoint {
 	bool is_set;
 	unsigned int number;
 	struct watchpoint *next;
-	int unique_id;
+	uint32_t unique_id;
 };
 
 void breakpoint_clear_target(struct target *target);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1252,11 +1252,15 @@ int riscv_flush_registers(struct target *target)
 /* Convert: RISC-V hart's halt reason --> OpenOCD's generic debug reason */
 int set_debug_reason(struct target *target, enum riscv_halt_reason halt_reason)
 {
+	RISCV_INFO(r);
+	r->trigger_hit = -1;
 	switch (halt_reason) {
 		case RISCV_HALT_BREAKPOINT:
 			target->debug_reason = DBG_REASON_BREAKPOINT;
 			break;
 		case RISCV_HALT_TRIGGER:
+			if (riscv_hit_trigger_hit_bit(target, &r->trigger_hit) != ERROR_OK)
+				return ERROR_FAIL;
 			target->debug_reason = DBG_REASON_WATCHPOINT;
 			break;
 		case RISCV_HALT_INTERRUPT:

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1159,7 +1159,6 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 	return ERROR_FAIL;
 }
 
-
 static int oldriscv_step(struct target *target, int current, uint32_t address,
 		int handle_breakpoints)
 {

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1262,6 +1262,11 @@ int set_debug_reason(struct target *target, enum riscv_halt_reason halt_reason)
 			if (riscv_hit_trigger_hit_bit(target, &r->trigger_hit) != ERROR_OK)
 				return ERROR_FAIL;
 			target->debug_reason = DBG_REASON_WATCHPOINT;
+			/* Check if we hit a hardware breakpoint. */
+			for (struct breakpoint *bp = target->breakpoints; bp; bp = bp->next) {
+				if (bp->unique_id == r->trigger_hit)
+					target->debug_reason = DBG_REASON_BREAKPOINT;
+			}
 			break;
 		case RISCV_HALT_INTERRUPT:
 		case RISCV_HALT_GROUP:

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1025,8 +1025,6 @@ int riscv_remove_watchpoint(struct target *target,
  * and new value. */
 int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoint)
 {
-	struct watchpoint *wp = target->watchpoints;
-
 	LOG_DEBUG("Current hartid = %d", riscv_current_hartid(target));
 
 	/*TODO instead of disassembling the instruction that we think caused the
@@ -1081,6 +1079,7 @@ int riscv_hit_watchpoint(struct target *target, struct watchpoint **hit_watchpoi
 		return ERROR_FAIL;
 	}
 
+	struct watchpoint *wp = target->watchpoints;
 	while (wp) {
 		/*TODO support length/mask */
 		if (wp->address == mem_addr) {

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -216,7 +216,7 @@ typedef struct {
 	struct reg_data_type_union vector_union;
 	struct reg_data_type type_vector;
 
-	/* Set when trigger registers are changed by the user. This indicates we eed
+	/* Set when trigger registers are changed by the user. This indicates we need
 	 * to beware that we may hit a trigger that we didn't realize had been set. */
 	bool manual_hwbp_set;
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -124,6 +124,10 @@ typedef struct {
 	 * target controls, while otherwise only a single hart is controlled. */
 	int trigger_unique_id[RISCV_MAX_HWBPS];
 
+	/* The unique id of the trigger that caused the most recent halt. If the
+	 * most recent halt was not caused by a trigger, then this is -1. */
+	uint32_t trigger_hit;
+
 	/* The number of entries in the debug buffer. */
 	int debug_buffer_size;
 


### PR DESCRIPTION
If that doesn't work (the hit bit is optional), then disassemble as we used to do.