### PR TITLE
fix: semihosting_fileio display the unsupported info

### DIFF
--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -155,16 +155,16 @@ semihosting_result_t riscv_semihosting(struct target *target, int *retval)
 		}
 	}
 
+	/* Resume right after the EBREAK 4 bytes instruction. */
+	*retval = riscv_set_register(target, GDB_REGNO_PC, pc + 4);
+	if (*retval != ERROR_OK)
+		return SEMI_ERROR;
+
 	/*
 	 * Resume target if we are not waiting on a fileio
 	 * operation to complete.
 	 */
 	if (semihosting->is_resumable && !semihosting->hit_fileio) {
-		/* Resume right after the EBREAK 4 bytes instruction. */
-		*retval = riscv_set_register(target, GDB_REGNO_PC, pc + 4);
-		if (*retval != ERROR_OK)
-			return SEMI_ERROR;
-
 		LOG_DEBUG("   -> HANDLED");
 		return SEMI_HANDLED;
 	}


### PR DESCRIPTION
the abnormal info display below:
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0
semihosting: unsupported call 0

the PC did not plus 4 before resume, which cause this
abnormal info popup.

Change-Id: I15c1e7426f1925e78f607c566976f9352216506f
Signed-off-by: Wu Zhigang <zhigang.wu@starfivetech.com>