### PR TITLE
Correctly set target->smp.

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -6471,7 +6471,6 @@ static int jim_target_smp(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 	foreach_smp_target(head, lh) {
 		target = head->target;
 		target->smp = smp_group;
-		target->smp = 1;
 		target->smp_targets = lh;
 	}
 	smp_group++;


### PR DESCRIPTION
This was broken by #684. Thanks to Jan for noticing.

Change-Id: I6ce115a6a333b93d7edb3ee44daae3f618d092e6
Signed-off-by: Tim Newsome <tim@sifive.com>