### PR TITLE
Add non-functional gd32vf103 driver.

### DIFF
--- a/src/flash/nor/drivers.c
+++ b/src/flash/nor/drivers.c
@@ -44,6 +44,16 @@ extern const struct flash_driver faux_flash;
 extern const struct flash_driver fm3_flash;
 extern const struct flash_driver fm4_flash;
 extern const struct flash_driver fespi_flash;
+FLASH_BANK_COMMAND_HANDLER(gd32vf103_flash_bank_command)
+{
+	LOG_ERROR("The gd32vf103 was removed. use stm32f1x instead.");
+	return ERROR_FAIL;
+}
+const struct flash_driver gd32vf103_flash = {
+	.name = "gd32vf103",
+	.usage = "This driver was removed. Use stm32f1x instead.",
+	.flash_bank_command = gd32vf103_flash_bank_command
+};
 extern const struct flash_driver jtagspi_flash;
 extern const struct flash_driver kinetis_flash;
 extern const struct flash_driver kinetis_ke_flash;
@@ -119,6 +129,7 @@ static const struct flash_driver * const flash_drivers[] = {
 	&fm3_flash,
 	&fm4_flash,
 	&fespi_flash,
+	&gd32vf103_flash,
 	&jtagspi_flash,
 	&kinetis_flash,
 	&kinetis_ke_flash,


### PR DESCRIPTION
Now users of the old driver will get an error message that points them
in the right direction.

Change-Id: I1654db1a36c7b7cca8a496a272717decd948672e
Signed-off-by: Tim Newsome <tim@sifive.com>