### PR TITLE
flash: redirect gd32vf103 driver to stm32f1x

### DIFF
--- a/src/flash/nor/drivers.c
+++ b/src/flash/nor/drivers.c
@@ -44,6 +44,7 @@ extern const struct flash_driver faux_flash;
 extern const struct flash_driver fm3_flash;
 extern const struct flash_driver fm4_flash;
 extern const struct flash_driver fespi_flash;
+extern const struct flash_driver gd32vf103_flash;
 extern const struct flash_driver jtagspi_flash;
 extern const struct flash_driver kinetis_flash;
 extern const struct flash_driver kinetis_ke_flash;
@@ -119,6 +120,7 @@ static const struct flash_driver * const flash_drivers[] = {
 	&fm3_flash,
 	&fm4_flash,
 	&fespi_flash,
+	&gd32vf103_flash,
 	&jtagspi_flash,
 	&kinetis_flash,
 	&kinetis_ke_flash,

--- a/src/flash/nor/stm32f1x.c
+++ b/src/flash/nor/stm32f1x.c
@@ -1752,11 +1752,36 @@ const struct flash_driver stm32f1x_flash = {
 	.free_driver_priv = default_flash_free_driver_priv,
 };
 
+/* flash bank gd32vf103 <base> <size> 0 0 <target#>
+ */
+FLASH_BANK_COMMAND_HANDLER(gd32vf103_flash_bank_command)
+{
+	struct stm32x_flash_bank *stm32x_info;
+
+	LOG_WARNING("DEPRECATED: The gd32vf103 flash target will be removed in June of 2023, please use stm32f1x instead.");
+	/* The reset code are just copy from stm32x_flash_bank_command function */
+	if (CMD_ARGC < 6)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+
+	stm32x_info = malloc(sizeof(struct stm32x_flash_bank));
+
+	bank->driver_priv = stm32x_info;
+	stm32x_info->probed = false;
+	stm32x_info->has_dual_banks = false;
+	stm32x_info->can_load_options = false;
+	stm32x_info->register_base = FLASH_REG_BASE_B0;
+	stm32x_info->user_bank_size = bank->size;
+
+	/* The flash write must be aligned to a halfword boundary */
+	bank->write_start_alignment = bank->write_end_alignment = 2;
+	return ERROR_OK;
+}
+
 static const struct command_registration gd32vf103_command_handlers[] = {
 	{
 		.name = "gd32vf103",
 		.mode = COMMAND_ANY,
-		.help = "gd32vf103 flash command group(reuse stm32f1x)",
+		.help = "gd32vf103 flash command group (identical to flash commands from stm32f1x)",
 		.usage = "",
 		.chain = stm32f1x_exec_command_handlers,
 	},
@@ -1766,7 +1791,7 @@ static const struct command_registration gd32vf103_command_handlers[] = {
 const struct flash_driver gd32vf103_flash = {
 	.name = "gd32vf103",
 	.commands = gd32vf103_command_handlers,
-	.flash_bank_command = stm32x_flash_bank_command,
+	.flash_bank_command = gd32vf103_flash_bank_command,
 	.erase = stm32x_erase,
 	.protect = stm32x_protect,
 	.write = stm32x_write,

--- a/src/flash/nor/stm32f1x.c
+++ b/src/flash/nor/stm32f1x.c
@@ -1751,3 +1751,30 @@ const struct flash_driver stm32f1x_flash = {
 	.info = get_stm32x_info,
 	.free_driver_priv = default_flash_free_driver_priv,
 };
+
+static const struct command_registration gd32vf103_command_handlers[] = {
+	{
+		.name = "gd32vf103",
+		.mode = COMMAND_ANY,
+		.help = "gd32vf103 flash command group(reuse stm32f1x)",
+		.usage = "",
+		.chain = stm32f1x_exec_command_handlers,
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
+const struct flash_driver gd32vf103_flash = {
+	.name = "gd32vf103",
+	.commands = gd32vf103_command_handlers,
+	.flash_bank_command = stm32x_flash_bank_command,
+	.erase = stm32x_erase,
+	.protect = stm32x_protect,
+	.write = stm32x_write,
+	.read = default_flash_read,
+	.probe = stm32x_probe,
+	.auto_probe = stm32x_auto_probe,
+	.erase_check = default_flash_blank_check,
+	.protect_check = stm32x_protect_check,
+	.info = get_stm32x_info,
+	.free_driver_priv = default_flash_free_driver_priv,
+};


### PR DESCRIPTION
Hi @timsifive , I modify the flash driver like this, is it ok?

Most of the code of stm32f1x are reused, I just add struct of gd32vf103, so `flash gd32vf103` can be still recognized.
