### PR TITLE
tcl: add Espressif riscv targets (ESP32-C2 & ESP32-C3)

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -4714,6 +4714,8 @@ compact Thumb2 instruction set. Supports also ARMv6-M and ARMv8-M cores
 @item @code{dsp5680xx} -- implements Freescale's 5680x DSP.
 @item @code{esirisc} -- this is an EnSilica eSi-RISC core.
 The current implementation supports eSi-32xx cores.
+@item @code{esp32c2} -- this is an Espressif SoC with single RISC-V core.
+@item @code{esp32c3} -- this is an Espressif SoC with single RISC-V core.
 @item @code{fa526} -- resembles arm920 (w/o Thumb).
 @item @code{feroceon} -- resembles arm926.
 @item @code{hla_target} -- a Cortex-M alternative to work with HL adapters like ST-Link.

--- a/tcl/board/esp32c2-ftdi.cfg
+++ b/tcl/board/esp32c2-ftdi.cfg
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-C2 connected via ESP-Prog.
+#
+# For example, OpenOCD can be started for ESP32-C2 debugging on
+#
+#   openocd -f board/esp32c2-ftdi.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+# Source the ESP32-C2 configuration file
+source [find target/esp32c2.cfg]
+
+# The speed of the JTAG interface, in kHz. If you get DSR/DIR errors (and they
+# do not relate to OpenOCD trying to read from a memory range without physical
+# memory being present there), you can try lowering this.
+#
+# On DevKit-J, this can go as high as 20MHz if CPU frequency is 80MHz, or 26MHz
+# if CPU frequency is 160MHz or 240MHz.
+adapter speed 20000

--- a/tcl/board/esp32c3-ftdi.cfg
+++ b/tcl/board/esp32c3-ftdi.cfg
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-C3 connected via ESP-Prog.
+#
+# For example, OpenOCD can be started for ESP32-C3 debugging on
+#
+#   openocd -f board/esp32c3-ftdi.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+# Source the ESP32-C3 configuration file
+source [find target/esp32c3.cfg]
+
+# The speed of the JTAG interface, in kHz. If you get DSR/DIR errors (and they
+# do not relate to OpenOCD trying to read from a memory range without physical
+# memory being present there), you can try lowering this.
+#
+# On DevKit-J, this can go as high as 20MHz if CPU frequency is 80MHz, or 26MHz
+# if CPU frequency is 160MHz or 240MHz.
+adapter speed 20000

--- a/tcl/target/esp32c2.cfg
+++ b/tcl/target/esp32c2.cfg
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The ESP32-C2 only supports JTAG.
+transport select jtag
+
+# Source the ESP common configuration file
+source [find target/esp_common.cfg]
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME esp32c2
+}
+
+if { [info exists CPUTAPID] } {
+	set _CPUTAPID $CPUTAPID
+} else {
+	set _CPUTAPID 0x0000cc25
+}
+
+set _TARGETNAME $_CHIPNAME
+set _CPUNAME cpu
+set _TAPNAME $_CHIPNAME.$_CPUNAME
+
+jtag newtap $_CHIPNAME $_CPUNAME -irlen 5 -expected-id $_CPUTAPID
+
+proc esp32c2_wdt_disable { } {
+    # Halt event can occur during config phase (before "init" is done).
+    # Ignore it since mww commands don't work at that time.
+    if { [string compare [command mode] config] == 0 } {
+        return
+    }
+
+    # Timer Group 0 WDT
+    mww 0x6001f064 0x50D83AA1
+    mww 0x6001F048 0
+    # RTC WDT
+    mww 0x6000809C 0x50D83AA1
+    mww 0x60008084 0
+    # SWD
+    mww 0x600080A4 0x8F1D312A
+    mww 0x600080A0 0x84B00000
+}
+
+# This is almost identical with the esp32c3_soc_reset.
+# Will be refactored with the other common settings.
+proc esp32c2_soc_reset { } {
+    # This procedure does "digital system reset", i.e. resets
+    # all the peripherals except for the RTC block.
+    # It is called from reset-assert-post target event callback,
+    # after assert_reset procedure was called.
+    # Since we need the hart to to execute a write to RTC_CNTL_SW_SYS_RST,
+    # temporarily take it out of reset. Save the dmcontrol state before
+    # doing so.
+    riscv dmi_write 0x10 0x80000001
+    # Trigger the reset
+    mww 0x60008000 0x9c00a000
+    # Workaround for stuck in cpu start during calibration.
+    # By writing zero to TIMG_RTCCALICFG_REG, we are disabling calibration
+    mww 0x6001F068 0
+    # Wait for the reset to happen
+    sleep 10
+    poll
+    # Disable the watchdogs again
+    esp32c2_wdt_disable
+
+    # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
+    # We will clean allhalted state by resuming the core.
+    riscv dmi_write 0x10 0x40000001
+
+    # Put the hart back into reset state. Note that we need to keep haltreq set.
+    riscv dmi_write 0x10 0x80000003
+}
+
+if { $_RTOS == "none" } {
+    target create $_TARGETNAME riscv -chain-position $_TAPNAME
+} else {
+    target create $_TARGETNAME riscv -chain-position $_TAPNAME -rtos $_RTOS
+}
+
+$_TARGETNAME configure -event reset-assert-post { esp32c2_soc_reset }
+$_TARGETNAME configure -event halted {
+    esp32c2_wdt_disable
+}
+$_TARGETNAME configure -event examine-end {
+    # Need this to handle 'apptrace init' syscall correctly because semihosting is not enabled by default
+    arm semihosting enable
+    arm semihosting_resexit enable
+    if { [info exists _SEMIHOST_BASEDIR] } {
+        if { $_SEMIHOST_BASEDIR != "" } {
+            # TODO: cherry-pick from upstream
+            # https://review.openocd.org/c/openocd/+/6888
+            # https://review.openocd.org/c/openocd/+/7005
+            # arm semihosting_basedir $_SEMIHOST_BASEDIR
+        }
+    }
+}
+$_TARGETNAME configure -event gdb-attach {
+    halt 1000
+    # by default mask interrupts while stepping
+    riscv set_maskisr steponly
+}
+
+gdb_breakpoint_override hard
+
+riscv set_reset_timeout_sec 2
+riscv set_command_timeout_sec 5
+riscv set_mem_access sysbus progbuf abstract
+riscv set_ebreakm on
+riscv set_ebreaks on
+riscv set_ebreaku on

--- a/tcl/target/esp32c3.cfg
+++ b/tcl/target/esp32c3.cfg
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The ESP32-C3 only supports JTAG.
+transport select jtag
+
+# Source the ESP common configuration file
+source [find target/esp_common.cfg]
+
+if { [info exists CHIPNAME] } {
+	set _CHIPNAME $CHIPNAME
+} else {
+	set _CHIPNAME esp32c3
+}
+
+if { [info exists CPUTAPID] } {
+	set _CPUTAPID $CPUTAPID
+} else {
+	set _CPUTAPID 0x00005c25
+}
+
+set _TARGETNAME $_CHIPNAME
+set _CPUNAME cpu
+set _TAPNAME $_CHIPNAME.$_CPUNAME
+
+jtag newtap $_CHIPNAME $_CPUNAME -irlen 5 -expected-id $_CPUTAPID
+
+proc esp32c3_wdt_disable { } {
+    # Halt event can occur during config phase (before "init" is done).
+    # Ignore it since mww commands don't work at that time.
+    if { [string compare [command mode] config] == 0 } {
+        return
+    }
+
+    # Timer Group 0 & 1 WDTs
+    mww 0x6001f064 0x50D83AA1
+    mww 0x6001F048 0
+    mww 0x60020064 0x50D83AA1
+    mww 0x60020048 0
+    # RTC WDT
+    mww 0x600080a8 0x50D83AA1
+    mww 0x60008090 0
+    # SWD
+    mww 0x600080b0 0x8F1D312A
+    mww 0x600080ac 0x84B00000
+}
+
+# This is almost identical with the esp32c2_soc_reset.
+# Will be refactored with the other common settings.
+proc esp32c3_soc_reset { } {
+    # This procedure does "digital system reset", i.e. resets
+    # all the peripherals except for the RTC block.
+    # It is called from reset-assert-post target event callback,
+    # after assert_reset procedure was called.
+    # Since we need the hart to to execute a write to RTC_CNTL_SW_SYS_RST,
+    # temporarily take it out of reset. Save the dmcontrol state before
+    # doing so.
+    riscv dmi_write 0x10 0x80000001
+    # Trigger the reset
+    mww 0x60008000 0x9c00a000
+    # Workaround for stuck in cpu start during calibration.
+    # By writing zero to TIMG_RTCCALICFG_REG, we are disabling calibration
+    mww 0x6001F068 0
+    # Wait for the reset to happen
+    sleep 10
+    poll
+    # Disable the watchdogs again
+    esp32c3_wdt_disable
+
+    # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
+    # We will clean allhalted state by resuming the core.
+    riscv dmi_write 0x10 0x40000001
+
+    # Put the hart back into reset state. Note that we need to keep haltreq set.
+    riscv dmi_write 0x10 0x80000003
+}
+
+if { $_RTOS == "none" } {
+    target create $_TARGETNAME riscv -chain-position $_TAPNAME
+} else {
+    target create $_TARGETNAME riscv -chain-position $_TAPNAME -rtos $_RTOS
+}
+
+$_TARGETNAME configure -event reset-assert-post { esp32c3_soc_reset }
+$_TARGETNAME configure -event halted {
+    esp32c3_wdt_disable
+}
+$_TARGETNAME configure -event examine-end {
+    # Need this to handle 'apptrace init' syscall correctly because semihosting is not enabled by default
+    arm semihosting enable
+    arm semihosting_resexit enable
+    if { [info exists _SEMIHOST_BASEDIR] } {
+        if { $_SEMIHOST_BASEDIR != "" } {
+            # TODO: cherry-pick from upstream
+            # https://review.openocd.org/c/openocd/+/6888
+            # https://review.openocd.org/c/openocd/+/7005
+            # arm semihosting_basedir $_SEMIHOST_BASEDIR
+        }
+    }
+}
+$_TARGETNAME configure -event gdb-attach {
+    halt 1000
+    # by default mask interrupts while stepping
+    riscv set_maskisr steponly
+}
+
+gdb_breakpoint_override hard
+
+riscv set_reset_timeout_sec 2
+riscv set_command_timeout_sec 5
+riscv set_mem_access sysbus progbuf abstract
+riscv set_ebreakm on
+riscv set_ebreaks on
+riscv set_ebreaku on

--- a/tcl/target/esp_common.cfg
+++ b/tcl/target/esp_common.cfg
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Common ESP chips definitions
+
+if { [info exists ESP_RTOS] } {
+	set _RTOS "$ESP_RTOS"
+} else {
+	set _RTOS "FreeRTOS"
+}
+
+if { [info exists ESP_SEMIHOST_BASEDIR] } {
+	set _SEMIHOST_BASEDIR $ESP_SEMIHOST_BASEDIR
+} else {
+	# by default current dir (when OOCD has been started)
+	set _SEMIHOST_BASEDIR "."
+}


### PR DESCRIPTION
Currently Espressif has 2 different RiscV chips. 
This PR adds configuration files for ESP32-C2 and ESP32-C3

openocd -s tcl -f board/esp32c3-ftdi.cfg
openocd -s tcl -f board/esp32c2-ftdi.cfg

Change-Id: I48fead33f5fd5890a7724cd5f500f2d14e2a5ffa
Signed-off-by: Erhan Kurubas <erhan.kurubas@espressif.com>