### PR TITLE
Properly set dmcs2.grouptype.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1505,7 +1505,7 @@ static int set_group(struct target *target, bool *supported, unsigned group, gro
 	uint32_t write_val = DM_DMCS2_HGWRITE;
 	assert(group <= 31);
 	write_val = set_field(write_val, DM_DMCS2_GROUP, group);
-	write_val = set_field(write_val, DM_DMCS2_GROUPTYPE, (grouptype == HALTGROUP) ? 1 : 0);
+	write_val = set_field(write_val, DM_DMCS2_GROUPTYPE, (grouptype == HALTGROUP) ? 0 : 1);
 	if (dmi_write(target, DM_DMCS2, write_val) != ERROR_OK)
 		return ERROR_FAIL;
 	uint32_t read_val;


### PR DESCRIPTION
In #697 this had gotten inverted.

Change-Id: Id86e2cfee0d15c1f05846c1fd5ac83dde26575a2
Signed-off-by: Tim Newsome <tim@sifive.com>