### PR TITLE
Code for 'SIZE'  of type 2 trigger

### DIFF
--- a/src/target/riscv/debug_defines.h
+++ b/src/target/riscv/debug_defines.h
@@ -695,6 +695,13 @@
  * \FcsrMcontrolTiming of 1 matching as well.
  */
 /*
+ * This field contains the 2 high bits of the access size. The low bits come
+ * from \FcsrMcontrolSizelo.
+ */
+#define CSR_MCONTROL_SIZEHI_OFFSET          0x15
+#define CSR_MCONTROL_SIZEHI_LENGTH          2
+#define CSR_MCONTROL_SIZEHI                 0x600000
+/*
  * This field contains the 2 low bits of the access size. The high bits come
  * from \FcsrMcontrolSizehi. The combined value is interpreted as follows:
  */
@@ -706,47 +713,47 @@
  * The behavior is only well-defined if $|select|=0$, or if the access
  * size is XLEN.
  */
-#define CSR_MCONTROL_SIZELO_ANY             0
+#define CSR_MCONTROL_SIZE_ANY               0
 /*
  * 8bit: The trigger will only match against 8-bit memory accesses.
  */
-#define CSR_MCONTROL_SIZELO_8BIT            1
+#define CSR_MCONTROL_SIZE_8BIT              1
 /*
  * 16bit: The trigger will only match against 16-bit memory accesses or
  * execution of 16-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_16BIT           2
+#define CSR_MCONTROL_SIZE_16BIT             2
 /*
  * 32bit: The trigger will only match against 32-bit memory accesses or
  * execution of 32-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_32BIT           3
+#define CSR_MCONTROL_SIZE_32BIT             3
 /*
  * 48bit: The trigger will only match against execution of 48-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_48BIT           4
+#define CSR_MCONTROL_SIZE_48BIT             4
 /*
  * 64bit: The trigger will only match against 64-bit memory accesses or
  * execution of 64-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_64BIT           5
+#define CSR_MCONTROL_SIZE_64BIT             5
 /*
  * 80bit: The trigger will only match against execution of 80-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_80BIT           6
+#define CSR_MCONTROL_SIZE_80BIT             6
 /*
  * 96bit: The trigger will only match against execution of 96-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_96BIT           7
+#define CSR_MCONTROL_SIZE_96BIT             7
 /*
  * 112bit: The trigger will only match against execution of 112-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_112BIT          8
+#define CSR_MCONTROL_SIZE_112BIT            8
 /*
  * 128bit: The trigger will only match against 128-bit memory accesses or
  * execution of 128-bit instructions.
  */
-#define CSR_MCONTROL_SIZELO_128BIT          9
+#define CSR_MCONTROL_SIZE_128BIT            9
 /*
  * An implementation must support the value of 0, but all other values
  * are optional. When an implementation supports address triggers

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -544,6 +544,37 @@ static int maybe_add_trigger_t2(struct target *target,
 	if (trigger->write)
 		tdata1 |= CSR_MCONTROL_STORE;
 
+	if (trigger->execute == false) {
+		/* set size for watchpoint */
+		const unsigned stab[] = {
+			0, /* 0 bits  0 bytes */
+			1, /* 8 bits  1 bytes */
+			2, /* 16bits  2 bytes */
+			0, /* 24bits  3 bytes */
+			3, /* 32bits  4 bytes */
+			0, /* 40bits  5 bytes */
+			4, /* 48bits  6 bytes */
+			0, /* 56bits  7 bytes */
+			5, /* 64bits  8 bytes */
+			0, /* 72bits  9 bytes */
+			6, /* 80bits  10bytes */
+			0, /* 88bits  11bytes */
+			7, /* 96bits  12bytes */
+			0, /* 104bits 13bytes */
+			8, /* 112bits 14bytes */
+			0, /* 120bits 15bytes */
+			9, /* 128bits 16bytes */
+		};
+		unsigned size = trigger->length > 16 ? 0 : stab[trigger->length];
+		if (size == 0) {
+			LOG_DEBUG("Trigger doesn't support watchpoint "
+				"with a length of %u bytes", trigger->length);
+			return ERROR_FAIL;
+		}
+		tdata1 = set_field(tdata1, CSR_MCONTROL_SIZEHI, (size >> 2) & 0x3);
+		tdata1 = set_field(tdata1, CSR_MCONTROL_SIZELO, (size >> 0) & 0x3);
+	}
+
 	riscv_set_register(target, GDB_REGNO_TDATA1, tdata1);
 
 	uint64_t tdata1_rb;


### PR DESCRIPTION
Define CSR_MCONTROL_SIZEHI.

watchpoint set SIZE. 
Code will always execute at a fixed address, but not data.
For example, setting a watchpoint to a struct
```c
struct point {
    uint32_t x;
    uint32_ty;
} pp;
```
The address cannot match the address of pp when accessing pp.y