### PR TITLE
Remove rtos.gdb_v_packet.

### DIFF
--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -98,7 +98,6 @@ static int os_alloc(struct target *target, struct rtos_type *ostype,
 
 	/* RTOS drivers can override the packet handler in _create(). */
 	os->gdb_thread_packet = rtos_thread_packet;
-	os->gdb_v_packet = NULL;
 	os->gdb_target_for_threadid = rtos_target_for_threadid;
 	os->cmd_ctx = cmd_ctx;
 

--- a/src/rtos/rtos.h
+++ b/src/rtos/rtos.h
@@ -58,7 +58,6 @@ struct rtos {
 	struct thread_detail *thread_details;
 	int thread_count;
 	int (*gdb_thread_packet)(struct connection *connection, char const *packet, int packet_size);
-	int (*gdb_v_packet)(struct connection *connection, char const *packet, int packet_size);
 	int (*gdb_target_for_threadid)(struct connection *connection, threadid_t thread_id, struct target **p_target);
 	void *rtos_specific_params;
 	/* Populated in rtos.c, so that individual RTOSes can register commands. */

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -3268,11 +3268,6 @@ static int gdb_v_packet(struct connection *connection,
 	int result;
 
 	struct target *target = get_target_from_connection(connection);
-	if (target->rtos != NULL && target->rtos->gdb_v_packet != NULL) {
-		int out = target->rtos->gdb_v_packet(connection, packet, packet_size);
-		if (out != GDB_THREAD_PACKET_NOT_CONSUMED)
-			return out;
-	}
 
 	if (strncmp(packet, "vCont", 5) == 0) {
 		bool handled;


### PR DESCRIPTION
It was a left-over from `-rtos riscv` and isn't used.

Change-Id: Ie7e380600cd1331c6d382f654474270efad9f127
Signed-off-by: Tim Newsome <tim@sifive.com>