### PR TITLE
Don't read dmcontrol to set hartsel

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4110,11 +4110,7 @@ static int riscv013_select_current_hart(struct target *target)
 	if (r->current_hartid == dm->current_hartid)
 		return ERROR_OK;
 
-	uint32_t dmcontrol;
-	/* TODO: can't we just "dmcontrol = DMI_DMACTIVE"? */
-	if (dmi_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
-		return ERROR_FAIL;
-	dmcontrol = set_hartsel(dmcontrol, r->current_hartid);
+	uint32_t dmcontrol = set_hartsel(DM_DMCONTROL_DMACTIVE, r->current_hartid);
 	int result = dmi_write(target, DM_DMCONTROL, dmcontrol);
 	dm->current_hartid = r->current_hartid;
 	return result;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4110,7 +4110,8 @@ static int riscv013_select_current_hart(struct target *target)
 	if (r->current_hartid == dm->current_hartid)
 		return ERROR_OK;
 
-	uint32_t dmcontrol = set_hartsel(DM_DMCONTROL_DMACTIVE, r->current_hartid);
+	uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE;
+	dmcontrol = set_hartsel(dmcontrol, r->current_hartid);
 	int result = dmi_write(target, DM_DMCONTROL, dmcontrol);
 	dm->current_hartid = r->current_hartid;
 	return result;


### PR DESCRIPTION
We already know what dmcontrol should be. This addresses a long-standing TODO. In a toy test, this reduced the number of scans by 10+%. (Most of those are probably in poll(), so don't actually affect perceived performance.)

Change-Id: I18e5ca391f0f5fb35f30d44dfef834e5a66aee20
Signed-off-by: Tim Newsome <tim@sifive.com>