### PR TITLE
Support JScan3 mode

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev
       - run: ./bootstrap
-      - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --enable-ftdi-oscan1
+      - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --enable-ftdi-cjtag
       - run: make -j`nproc`
       - run: file src/openocd | grep 64-bit
       - run: src/openocd --version

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ m4_define([ADAPTER_OPT], [m4_translit(ADAPTER_ARG($1), [_], [-])])
 
 m4_define([USB1_ADAPTERS],
 	[[[ftdi], [MPSSE mode of FTDI based devices], [FTDI]],
-	[[ftdi_oscan1], [cJTAG OSCAN1 tunneled thru MPSSE], [FTDI_OSCAN1]],
+	[[ftdi_oscan1], [cJTAG OScan1 tunneled thru MPSSE], [FTDI_OSCAN1]],
 	[[stlink], [ST-Link Programmer], [HLADAPTER_STLINK]],
 	[[ti_icdi], [TI ICDI JTAG Programmer], [HLADAPTER_ICDI]],
 	[[ulink], [Keil ULINK JTAG Programmer], [ULINK]],

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ m4_define([ADAPTER_OPT], [m4_translit(ADAPTER_ARG($1), [_], [-])])
 
 m4_define([USB1_ADAPTERS],
 	[[[ftdi], [MPSSE mode of FTDI based devices], [FTDI]],
-	[[ftdi_oscan1], [cJTAG OScan1 tunneled thru MPSSE], [FTDI_OSCAN1]],
+	[[ftdi_cjtag], [cJTAG (OScan1) tunneled thru MPSSE], [FTDI_CJTAG]],
 	[[stlink], [ST-Link Programmer], [HLADAPTER_STLINK]],
 	[[ti_icdi], [TI ICDI JTAG Programmer], [HLADAPTER_ICDI]],
 	[[ulink], [Keil ULINK JTAG Programmer], [ULINK]],

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ m4_define([ADAPTER_OPT], [m4_translit(ADAPTER_ARG($1), [_], [-])])
 
 m4_define([USB1_ADAPTERS],
 	[[[ftdi], [MPSSE mode of FTDI based devices], [FTDI]],
-	[[ftdi_cjtag], [cJTAG (OScan1) tunneled thru MPSSE], [FTDI_CJTAG]],
+	[[ftdi_cjtag], [cJTAG (OScan1, JScan3) tunneled thru MPSSE], [FTDI_CJTAG]],
 	[[stlink], [ST-Link Programmer], [HLADAPTER_STLINK]],
 	[[ti_icdi], [TI ICDI JTAG Programmer], [HLADAPTER_ICDI]],
 	[[ulink], [Keil ULINK JTAG Programmer], [ULINK]],

--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -2602,6 +2602,15 @@ probes by defining the signal TMSC_EN using
 @command{ftdi layout_signal TMSC_EN -data <mask>}.
 @end deffn
 
+@deffn {Command} {ftdi jscan3_mode} on|off
+Enable or disable JScan3 mode. This mode uses the classic 4-wire JTAG protocol
+in chips whose JTAG port is only compliant with the cJTAG standard (IEEE 1149.7).
+
+Since cJTAG needs a 2-wire escape sequence to select the operating mode,
+a cJTAG adapter like ARM-JTAG-SWD by Olimex is still required. This means
+that a cJTAG probe configuration script must be used too.
+@end deffn
+
 @deffn {Command} {ftdi layout_signal} name [@option{-data}|@option{-ndata} data_mask] [@option{-input}|@option{-ninput} input_mask] [@option{-oe}|@option{-noe} oe_mask] [@option{-alias}|@option{-nalias} name]
 Creates a signal with the specified @var{name}, controlled by one or more FTDI
 GPIO pins via a range of possible buffer connections. The masks are FTDI GPIO

--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -107,16 +107,16 @@ static bool swd_mode;
 
 #if BUILD_FTDI_OSCAN1 == 1
 /*
-  The cJTAG 2-wire OSCAN1 protocol, in lieu of 4-wire JTAG, is a configuration option
+  The cJTAG 2-wire OScan1 protocol, in lieu of 4-wire JTAG, is a configuration option
   for some SoCs. An FTDI-based adapter that can be configured to appropriately drive
-  the bidirectional pin TMSC is able to drive OSCAN1 protocol.  For example, an Olimex
+  the bidirectional pin TMSC is able to drive OScan1 protocol.  For example, an Olimex
   ARM-USB-TINY-H with the ARM-JTAG-SWD adapter, connected to a cJTAG-enabled
   target board is such a topology.  A TCK cycle with TMS=1/TDI=N translates to a TMSC
   output of N, and a TCK cycle with TMS=0 translates to a TMSC input from the target back
-  to the adapter/probe.  The OSCAN1 protocol uses 3 TCK cycles to generate the data flow
-  that is equivalent to that of a single TCK cycle in 4-wire JTAG. The OSCAN1-related
+  to the adapter/probe.  The OScan1 protocol uses 3 TCK cycles to generate the data flow
+  that is equivalent to that of a single TCK cycle in 4-wire JTAG. The OScan1-related
   code in this module translates IR/DR scan commanads and JTAG state traversal commands
-  to the two-wire clocking and signaling of OSCAN1 protocol, if placed into oscan1 mode
+  to the two-wire clocking and signaling of OScan1 protocol, if placed into OScan1 mode
   during initialization.
 */
 static void oscan1_reset_online_activate(void);
@@ -670,7 +670,7 @@ static void ftdi_execute_command(struct jtag_command *cmd)
 	switch (cmd->type) {
 		case JTAG_RESET:
 #if BUILD_FTDI_OSCAN1 == 1
-			oscan1_reset_online_activate(); /* put the target back into OSCAN1 mode */
+			oscan1_reset_online_activate(); /* put the target back into OScan1 mode */
 #endif
 			break;
 		case JTAG_RUNTEST:
@@ -679,7 +679,7 @@ static void ftdi_execute_command(struct jtag_command *cmd)
 		case JTAG_TLR_RESET:
 			ftdi_execute_statemove(cmd);
 #if BUILD_FTDI_OSCAN1 == 1
-			oscan1_reset_online_activate(); /* put the target back into OSCAN1 mode */
+			oscan1_reset_online_activate(); /* put the target back into OScan1 mode */
 #endif
 			break;
 		case JTAG_PATHMOVE:
@@ -763,7 +763,7 @@ static int ftdi_initialize(void)
 	} else if (oscan1_mode) {
 		struct signal *sig = find_signal_by_name("JTAG_SEL");
 		if (!sig) {
-			LOG_ERROR("OSCAN1 mode is active but JTAG_SEL signal is not defined");
+			LOG_ERROR("OScan1 mode is active but JTAG_SEL signal is not defined");
 			return ERROR_JTAG_INIT_FAILED;
 		}
 		/* A dummy JTAG_SEL would have zero mask */
@@ -816,7 +816,7 @@ static void oscan1_mpsse_clock_data(struct mpsse_ctx *ctx, const uint8_t *out, u
 		int bitnum;
 		uint8_t bit;
 
-		/* OSCAN1 uses 3 separate clocks */
+		/* OScan1 uses 3 separate clocks */
 
 		/* drive TMSC to the *negation* of the desired TDI value */
 		bitnum = out_offset + i;
@@ -862,7 +862,7 @@ static void oscan1_mpsse_clock_tms_cs(struct mpsse_ctx *ctx, const uint8_t *out,
 		uint8_t tmsbit;
 		uint8_t tdibit;
 
-		/* OSCAN1 uses 3 separate clocks */
+		/* OScan1 uses 3 separate clocks */
 
 		/* drive TMSC to the *negation* of the desired TDI value */
 		tdibit = tdi ? 0 : 1;
@@ -921,114 +921,114 @@ static void oscan1_reset_online_activate(void)
 	uint16_t tdovalue;
 
 	static const struct {
-	  int8_t tck;
-	  int8_t tms;
-	  int8_t tdi;
+		int8_t tck;
+		int8_t tms;
+		int8_t tdi;
 	} sequence[] = {
-	  /* TCK=0, TMS=1, TDI=0 (drive TMSC to 0 baseline) */
-	  {'0', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (drive TMSC to 0 baseline) */
+		{'0', '1', '0'},
 
-	  /* Drive cJTAG escape sequence for TAP reset - 8 TMSC edges */
-	  /* TCK=1, TMS=1, TDI=0 (rising edge of TCK with TMSC still 0) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK with TMSC still 0) */
-	  {'0', '1', '0'},
+		/* Drive cJTAG escape sequence for TAP reset - 8 TMSC edges */
+		/* TCK=1, TMS=1, TDI=0 (rising edge of TCK with TMSC still 0) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK with TMSC still 0) */
+		{'0', '1', '0'},
 
-	  /* 3 TCK pulses for padding */
-	  /* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
-	  {'0', '1', '0'},
+		/* 3 TCK pulses for padding */
+		/* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (drive rising TCK edge) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (drive falling TCK edge) */
+		{'0', '1', '0'},
 
-	  /* Drive cJTAG escape sequence for SELECT */
-	  /* TCK=1, TMS=1, TDI=0 (rising edge of TCK with TMSC still 0, TAP reset that was just setup occurs here too) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
-	  {'1', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK with TMSC still 0) */
-	  {'0', '1', '0'},
+		/* Drive cJTAG escape sequence for SELECT */
+		/* TCK=1, TMS=1, TDI=0 (rising edge of TCK with TMSC still 0, TAP reset that was just setup occurs here too) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=1, TMS=1, TDI=1 (drive rising TMSC edge) */
+		{'1', '1', '1'},
+		/* TCK=1, TMS=1, TDI=0 (drive falling TMSC edge) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK with TMSC still 0) */
+		{'0', '1', '0'},
 
-	  /* Drive cJTAG escape sequence for activation */
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK with TMSC still 0... online mode activated... also OAC bit0==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... OAC bit1==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=1 (falling edge TCK) */
-	  {'0', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=1 (rising edge TCK... OAC bit2==1) */
-	  {'1', '1', '1'},
-	  /* TCK=0, TMS=1, TDI=1 (falling edge TCK, TMSC stays high) */
-	  {'0', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=1 (rising edge TCK... OAC bit3==1) */
-	  {'1', '1', '1'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit0==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit1==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit2==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=1 (falling edge TCK) */
-	  {'0', '1', '1'},
-	  /* TCK=1, TMS=1, TDI=1 (rising edge TCK... EC bit3==1) */
-	  {'1', '1', '1'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit0==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit1==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit2==0) */
-	  {'1', '1', '0'},
-	  /* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
-	  {'0', '1', '0'},
-	  /* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit3==0) */
-	  {'1', '1', '0'},
+		/* Drive cJTAG escape sequence for activation */
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK with TMSC still 0... online mode activated... also OAC bit0==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... OAC bit1==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=1 (falling edge TCK) */
+		{'0', '1', '1'},
+		/* TCK=1, TMS=1, TDI=1 (rising edge TCK... OAC bit2==1) */
+		{'1', '1', '1'},
+		/* TCK=0, TMS=1, TDI=1 (falling edge TCK, TMSC stays high) */
+		{'0', '1', '1'},
+		/* TCK=1, TMS=1, TDI=1 (rising edge TCK... OAC bit3==1) */
+		{'1', '1', '1'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit0==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit1==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... EC bit2==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=1 (falling edge TCK) */
+		{'0', '1', '1'},
+		/* TCK=1, TMS=1, TDI=1 (rising edge TCK... EC bit3==1) */
+		{'1', '1', '1'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit0==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit1==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit2==0) */
+		{'1', '1', '0'},
+		/* TCK=0, TMS=1, TDI=0 (falling edge TCK) */
+		{'0', '1', '0'},
+		/* TCK=1, TMS=1, TDI=0 (rising edge TCK... CP bit3==0) */
+		{'1', '1', '0'},
 	};
 
 
@@ -1356,7 +1356,7 @@ static const struct command_registration ftdi_subcommand_handlers[] = {
 		.name = "oscan1_mode",
 		.handler = &ftdi_handle_oscan1_mode_command,
 		.mode = COMMAND_ANY,
-		.help = "set to 'on' to use OSCAN1 mode for signaling, otherwise 'off' (default is 'off')",
+		.help = "set to 'on' to use OScan1 mode for signaling, otherwise 'off' (default is 'off')",
 		.usage = "(on|off)",
 	},
 #endif

--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -930,6 +930,7 @@ static void cjtag_reset_online_activate(void)
 	struct signal *tdi = find_signal_by_name("TDI");
 	struct signal *tms = find_signal_by_name("TMS");
 	struct signal *tdo = find_signal_by_name("TDO");
+	struct signal *tmsc_en = find_signal_by_name("TMSC_EN");
 	uint16_t tdovalue;
 
 	static struct {
@@ -1078,6 +1079,10 @@ static void cjtag_reset_online_activate(void)
 		sequence[ESCAPE_SEQ_OAC_BIT2].tdi = '0';
 		sequence[ESCAPE_SEQ_OAC_BIT2+1].tdi = '0';
 	}
+
+	/* if defined TMSC_EN, replace tms with it */
+	if (tmsc_en)
+		tms = tmsc_en;
 
 	/* Send the sequence to the adapter */
 	for (size_t i = 0; i < sizeof(sequence)/sizeof(sequence[0]); i++)

--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -85,7 +85,7 @@
 /* FTDI access library includes */
 #include "mpsse.h"
 
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 #define DO_CLOCK_DATA clock_data
 #define DO_CLOCK_TMS_CS clock_tms_cs
 #define DO_CLOCK_TMS_CS_OUT clock_tms_cs_out
@@ -105,7 +105,7 @@ static uint8_t ftdi_jtag_mode = JTAG_MODE;
 
 static bool swd_mode;
 
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 /*
   The cJTAG 2-wire OScan1 protocol, in lieu of 4-wire JTAG, is a configuration option
   for some SoCs. An FTDI-based adapter that can be configured to appropriately drive
@@ -275,7 +275,7 @@ static int ftdi_get_signal(const struct signal *s, uint16_t *value_out)
 	return ERROR_OK;
 }
 
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 static void clock_data(struct mpsse_ctx *ctx, const uint8_t *out, unsigned out_offset, uint8_t *in,
 		     unsigned in_offset, unsigned length, uint8_t mode)
 {
@@ -669,7 +669,7 @@ static void ftdi_execute_command(struct jtag_command *cmd)
 {
 	switch (cmd->type) {
 		case JTAG_RESET:
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 			oscan1_reset_online_activate(); /* put the target back into OScan1 mode */
 #endif
 			break;
@@ -678,7 +678,7 @@ static void ftdi_execute_command(struct jtag_command *cmd)
 			break;
 		case JTAG_TLR_RESET:
 			ftdi_execute_statemove(cmd);
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 			oscan1_reset_online_activate(); /* put the target back into OScan1 mode */
 #endif
 			break;
@@ -759,7 +759,7 @@ static int ftdi_initialize(void)
 		/* A dummy SWD_EN would have zero mask */
 		if (sig->data_mask)
 			ftdi_set_signal(sig, '1');
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 	} else if (oscan1_mode) {
 		struct signal *sig = find_signal_by_name("JTAG_SEL");
 		if (!sig) {
@@ -801,7 +801,7 @@ static int ftdi_quit(void)
 	return ERROR_OK;
 }
 
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 static void oscan1_mpsse_clock_data(struct mpsse_ctx *ctx, const uint8_t *out, unsigned out_offset, uint8_t *in,
 		     unsigned in_offset, unsigned length, uint8_t mode)
 {
@@ -900,7 +900,7 @@ static void oscan1_mpsse_clock_tms_cs_out(struct mpsse_ctx *ctx, const uint8_t *
 }
 
 
-static void oscan1_set_tck_tms_tdi(struct signal *tck, char tckvalue, struct signal *tms,
+static void cjtag_set_tck_tms_tdi(struct signal *tck, char tckvalue, struct signal *tms,
 				   char tmsvalue, struct signal *tdi, char tdivalue)
 {
 	ftdi_set_signal(tms, tmsvalue);
@@ -1058,12 +1058,12 @@ static void oscan1_reset_online_activate(void)
 
 	/* Send the sequence to the adapter */
 	for (size_t i = 0; i < sizeof(sequence)/sizeof(sequence[0]); i++)
-		oscan1_set_tck_tms_tdi(tck, sequence[i].tck, tms, sequence[i].tms, tdi, sequence[i].tdi);
+		cjtag_set_tck_tms_tdi(tck, sequence[i].tck, tms, sequence[i].tms, tdi, sequence[i].tdi);
 
 	ftdi_get_signal(tdo, &tdovalue);  /* Just to force a flush */
 }
 
-#endif /* #if BUILD_FTDI_OSCAN1 == 1 */
+#endif /* #if BUILD_FTDI_CJTAG == 1 */
 
 COMMAND_HANDLER(ftdi_handle_device_desc_command)
 {
@@ -1276,7 +1276,7 @@ COMMAND_HANDLER(ftdi_handle_tdo_sample_edge_command)
 	return ERROR_OK;
 }
 
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 COMMAND_HANDLER(ftdi_handle_oscan1_mode_command)
 {
 	if (CMD_ARGC > 1)
@@ -1351,7 +1351,7 @@ static const struct command_registration ftdi_subcommand_handlers[] = {
 			"allow signalling speed increase)",
 		.usage = "(rising|falling)",
 	},
-#if BUILD_FTDI_OSCAN1 == 1
+#if BUILD_FTDI_CJTAG == 1
 	{
 		.name = "oscan1_mode",
 		.handler = &ftdi_handle_oscan1_mode_command,


### PR DESCRIPTION
This PR aims to add support for cJTAG star-4 mode JScan3. This mode allows to use standard 4-wire JTAG with cJTAG hardware implementation.

Main changes:

- rename ftdi-oscan1 to ftdi-cjtag
- add JScan3 documentation 
- support JScan3 using jscan3_mode variable and the proper escape sequence