### PR TITLE
target: Try to examine unexamined target in halt()

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -589,8 +589,14 @@ int target_halt(struct target *target)
 	int retval;
 	/* We can't poll until after examine */
 	if (!target_was_examined(target)) {
-		LOG_ERROR("Target not examined yet");
-		return ERROR_FAIL;
+		/* Try to examine the target right now, in case the target we're
+		 * talking to didn't examine correctly during `init`. */
+		LOG_TARGET_INFO(target, "Try to examine unexamined target in target_halt().");
+		target_examine();
+		if (!target_was_examined(target)) {
+			LOG_ERROR("Target not examined yet");
+			return ERROR_FAIL;
+		}
 	}
 
 	retval = target->type->halt(target);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -591,10 +591,10 @@ int target_halt(struct target *target)
 	if (!target_was_examined(target)) {
 		/* Try to examine the target right now, in case the target we're
 		 * talking to didn't examine correctly during `init`. */
-		LOG_TARGET_INFO(target, "Try to examine unexamined target in target_halt().");
+		LOG_TARGET_INFO(target, "Trying to examine unexamined target before halt attempt.");
 		target_examine();
 		if (!target_was_examined(target)) {
-			LOG_ERROR("Target not examined yet");
+			LOG_TARGET_ERROR(target, "Re-examination before halt failed. Target not examined yet.");
 			return ERROR_FAIL;
 		}
 	}


### PR DESCRIPTION
Some targets fail to examine during `init`, e.g. for timing reasons. The right solution is a better config script, but that ends up being complicated to figure out. This is a bit of a hack, but hopefully silently fixes the problem so users won't have to deal with it at all.

Change-Id: Ib04d0680eb4136f06c383caa6775dd2581a08ce0
Signed-off-by: Tim Newsome <tim@sifive.com>