### PR TITLE
Fix incorrect braces caused by #732

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1340,11 +1340,11 @@ static int register_write_direct(struct target *target, unsigned number,
 		if (number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31) {
 			if (riscv_supports_extension(target, 'D')) {
 				if (riscv_program_insert(&program,
-							fmv_d_x(number - GDB_REGNO_FPR0, S0) != ERROR_OK))
+							fmv_d_x(number - GDB_REGNO_FPR0, S0)) != ERROR_OK)
 					return ERROR_FAIL;
 			} else {
 				if (riscv_program_insert(&program,
-							fmv_w_x(number - GDB_REGNO_FPR0, S0) != ERROR_OK))
+							fmv_w_x(number - GDB_REGNO_FPR0, S0)) != ERROR_OK)
 					return ERROR_FAIL;
 			}
 		} else if (number == GDB_REGNO_VTYPE) {


### PR DESCRIPTION
Actually we want to compare result of riscv_program_insert() with ERROR_OK, not its second argument