### PR TITLE
target/riscv: Correctly set target->state in deassert_reset

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2452,11 +2452,13 @@ static int deassert_reset(struct target *target)
 				return ERROR_FAIL;
 			}
 		}
-		if (target->reset_halt)
+		if (target->reset_halt) {
 			target->state = TARGET_HALTED;
-		else
+			target->debug_reason = DBG_REASON_DBGRQ;
+		} else {
 			target->state = TARGET_RUNNING;
-		target->debug_reason = DBG_REASON_DBGRQ;
+			target->debug_reason = DBG_REASON_NOTHALTED;
+		}
 
 		if (get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET)) {
 			/* Ack reset. */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2452,7 +2452,10 @@ static int deassert_reset(struct target *target)
 				return ERROR_FAIL;
 			}
 		}
-		target->state = TARGET_HALTED;
+		if (target->reset_halt)
+			target->state = TARGET_HALTED;
+		else
+			target->state = TARGET_RUNNING;
 		target->debug_reason = DBG_REASON_DBGRQ;
 
 		if (get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET)) {


### PR DESCRIPTION
This bug didn't lead to problems that I can see, but it would with some upcoming changes. It might fix #749.

Change-Id: I552acbae9977150c4c9e573f8852033bc80fcebb
Signed-off-by: Tim Newsome <tim@sifive.com>