### PR TITLE
Fix dm->current_hartid corruption on hartsellen discovery

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -130,6 +130,7 @@ typedef enum {
 } yes_no_maybe_t;
 
 #define HART_INDEX_MULTIPLE	-1
+#define HART_INDEX_DIRTY	-2
 
 typedef struct {
 	struct list_head list;
@@ -1599,6 +1600,7 @@ static int examine(struct target *target)
 	dmi_write(target, DM_DMCONTROL, DM_DMCONTROL_HARTSELLO |
 			DM_DMCONTROL_HARTSELHI | DM_DMCONTROL_DMACTIVE |
 			DM_DMCONTROL_HASEL);
+	dm->current_hartid = HART_INDEX_DIRTY;
 	uint32_t dmcontrol;
 	if (dmi_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -130,7 +130,7 @@ typedef enum {
 } yes_no_maybe_t;
 
 #define HART_INDEX_MULTIPLE	-1
-#define HART_INDEX_DIRTY	-2
+#define HART_INDEX_UNKNOWN	-2
 
 typedef struct {
 	struct list_head list;
@@ -285,6 +285,8 @@ dm013_info_t *get_dm(struct target *target)
 
 static uint32_t set_dmcontrol_hartsel(uint32_t initial, int hart_index)
 {
+	assert(hart_index != HART_INDEX_UNKNOWN);
+
 	if (hart_index >= 0) {
 		initial = set_field(initial, DM_DMCONTROL_HASEL, DM_DMCONTROL_HASEL_SINGLE);
 		uint32_t index_lo = hart_index & ((1 << DM_DMCONTROL_HARTSELLO_LENGTH) - 1);
@@ -1600,10 +1602,14 @@ static int examine(struct target *target)
 	dmi_write(target, DM_DMCONTROL, DM_DMCONTROL_HARTSELLO |
 			DM_DMCONTROL_HARTSELHI | DM_DMCONTROL_DMACTIVE |
 			DM_DMCONTROL_HASEL);
-	dm->current_hartid = HART_INDEX_DIRTY;
+	dm->current_hartid = HART_INDEX_UNKNOWN;
 	uint32_t dmcontrol;
 	if (dmi_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
 		return ERROR_FAIL;
+	/* Ensure the HART_INDEX_UNKNOWN is flushed out */
+	if (dm013_select_hart(target, 0) != ERROR_OK)
+		return ERROR_FAIL;
+
 
 	if (!get_field(dmcontrol, DM_DMCONTROL_DMACTIVE)) {
 		LOG_ERROR("Debug Module did not become active. dmcontrol=0x%x",
@@ -4141,7 +4147,7 @@ static int dm013_select_hart(struct target *target, int hart_index)
 	dmcontrol = set_dmcontrol_hartsel(dmcontrol, hart_index);
 	if (dmi_write(target, DM_DMCONTROL, dmcontrol) != ERROR_OK) {
 		/* Who knows what the state is? */
-		dm->current_hartid = -2;
+		dm->current_hartid = HART_INDEX_UNKNOWN;
 		return ERROR_FAIL;
 	}
 	dm->current_hartid = hart_index;


### PR DESCRIPTION
target/riscv Fix dm->current_hartid corruption on hartsellen discovery

So basicaly, the hartsellen discovery code is changing the state of the dm without reflecting it into dm->current_hartid, leading the next dm013_select_hart to believe that hartsel is still zero (as initialized in https://github.com/riscv/riscv-openocd/blob/9eb07f258e7ae8c4a38b349481d27b0207c35100/src/target/riscv/riscv-013.c#L262), and so creating a missmatch between the hard and the soft (which appear for me at https://github.com/riscv/riscv-openocd/blob/9eb07f258e7ae8c4a38b349481d27b0207c35100/src/target/riscv/riscv-013.c#L1683)

That bug appeared from https://github.com/riscv/riscv-openocd/commit/a50b280558cc2908f43dba600461aca256bfbf10 i guess ? Unless i missed something in the spec ? and it isn't a bug but a feature ?

Signed-off-by: Charles Papon <charles.papon.90@gmail.com>