### PR TITLE
Revive 0.11 debug spec support

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -67,6 +67,8 @@
  * to the target. Afterwards use cache_get... to read results.
  */
 
+static int handle_halt(struct target *target, bool announce);
+
 #define get_field(reg, mask) (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
 #define set_field(reg, mask, val) (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
 
@@ -1192,7 +1194,7 @@ static int full_step(struct target *target, bool announce)
 			return ERROR_FAIL;
 		}
 	}
-	return ERROR_OK;
+	return handle_halt(target, announce);
 }
 
 static uint64_t reg_cache_get(struct target *target, unsigned int number)

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1195,16 +1195,6 @@ static int full_step(struct target *target, bool announce)
 	return ERROR_OK;
 }
 
-static int resume(struct target *target, int debug_execution, bool step)
-{
-	if (debug_execution) {
-		LOG_ERROR("TODO: debug_execution is true");
-		return ERROR_FAIL;
-	}
-
-	return execute_resume(target, step);
-}
-
 static uint64_t reg_cache_get(struct target *target, unsigned int number)
 {
 	struct reg *r = &target->reg_cache->reg_list[number];
@@ -1935,7 +1925,7 @@ static int riscv011_resume(struct target *target, int current,
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 
 	r->prepped = false;
-	return resume(target, debug_execution, false);
+	return execute_resume(target, false);
 }
 
 static int assert_reset(struct target *target)


### PR DESCRIPTION
This had bitrotted away. Tested against HiFive1. Several tests still don't pass, but I'm not convinced they ever did.

At least now you can use flash, set triggers, and single step again.