### PR TITLE
target/riscv: Fix 0.13 examine target->status not being halted after halt_go

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1708,6 +1708,7 @@ static int examine(struct target *target)
 					info->index);
 			return ERROR_FAIL;
 		}
+		target->state = TARGET_HALTED;
 	}
 
 	/* Without knowing anything else we can at least mess with the


### PR DESCRIPTION
Hi,

So, i had a error while the "init" command execute : 
Error: 212 420 riscv-013.c:4826 riscv013_step_or_resume_current_hart(): [saxon.cpu0] Hart is not halted!

It was due to riscv013_halt_go which assume the target->status is updated outside itself (by the openocd core i think).
The issue is that riscv013_halt_go is also used in the examine function to halt the CPU.

So, the target->status wasn't updated to TARGET_HALTED, which produced the error later in the examine execution, durring the riscv013_step_or_resume_current_hart call.