### PR TITLE
riscv/run_algorithm : Add support for memory parameters

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1946,14 +1946,20 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 {
 	RISCV_INFO(info);
 
-	if (num_mem_params > 0) {
-		LOG_ERROR("Memory parameters are not supported for RISC-V algorithms.");
-		return ERROR_FAIL;
-	}
-
 	if (target->state != TARGET_HALTED) {
 		LOG_WARNING("target not halted");
 		return ERROR_TARGET_NOT_HALTED;
+	}
+
+	/* Write memory parameters to the target memory */
+	for (int i = 0; i < num_mem_params; i++) {
+		if (mem_params[i].direction != PARAM_IN) {
+			int retval = target_write_buffer(target, mem_params[i].address, mem_params[i].size, mem_params[i].value);
+			if (retval != ERROR_OK) {
+				LOG_ERROR("Couldn't write input mem param into the memory.");
+				return retval;
+			}
+		}
 	}
 
 	/* Save registers */
@@ -2078,6 +2084,18 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 		if (r->type->set(r, buf) != ERROR_OK) {
 			LOG_ERROR("set(%s) failed", r->name);
 			return ERROR_FAIL;
+		}
+	}
+
+	/* Read memory parameters from the target memory */
+	for (int i = 0; i < num_mem_params; i++) {
+		if (mem_params[i].direction != PARAM_OUT) {
+			int retval = target_read_buffer(target, mem_params[i].address, mem_params[i].size,
+					mem_params[i].value);
+			if (retval != ERROR_OK) {
+				LOG_ERROR("Couldn't read output mem param from the memory.");
+				return retval;
+			}
 		}
 	}
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1953,7 +1953,8 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 
 	/* Write memory parameters to the target memory */
 	for (int i = 0; i < num_mem_params; i++) {
-		if (mem_params[i].direction != PARAM_IN) {
+		if (mem_params[i].direction == PARAM_OUT ||
+				mem_params[i].direction == PARAM_IN_OUT) {
 			int retval = target_write_buffer(target, mem_params[i].address, mem_params[i].size, mem_params[i].value);
 			if (retval != ERROR_OK) {
 				LOG_ERROR("Couldn't write input mem param into the memory.");
@@ -2089,7 +2090,8 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 
 	/* Read memory parameters from the target memory */
 	for (int i = 0; i < num_mem_params; i++) {
-		if (mem_params[i].direction != PARAM_OUT) {
+		if (mem_params[i].direction == PARAM_IN ||
+				mem_params[i].direction == PARAM_IN_OUT) {
 			int retval = target_read_buffer(target, mem_params[i].address, mem_params[i].size,
 					mem_params[i].value);
 			if (retval != ERROR_OK) {

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1957,7 +1957,8 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 				mem_params[i].direction == PARAM_IN_OUT) {
 			int retval = target_write_buffer(target, mem_params[i].address, mem_params[i].size, mem_params[i].value);
 			if (retval != ERROR_OK) {
-				LOG_ERROR("Couldn't write input mem param into the memory.");
+				LOG_ERROR("Couldn't write input mem param into the memory, addr=0x%" TARGET_PRIxADDR " size=0x%" PRIx32,
+						mem_params[i].address, mem_params[i].size);
 				return retval;
 			}
 		}
@@ -2095,7 +2096,8 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 			int retval = target_read_buffer(target, mem_params[i].address, mem_params[i].size,
 					mem_params[i].value);
 			if (retval != ERROR_OK) {
-				LOG_ERROR("Couldn't read output mem param from the memory.");
+				LOG_ERROR("Couldn't read output mem param from the memory, addr=0x%" TARGET_PRIxADDR " size=0x%" PRIx32,
+						mem_params[i].address, mem_params[i].size);
 				return retval;
 			}
 		}


### PR DESCRIPTION
This PR add support for riscv_run_algorithm memory parameters. (read/write the main memory).
This is usefull for some openocd flash chip drivers, which load a little access program + the data into the main memory in order to read / write the flash efficiently.

Tested on hardware against : 
https://github.com/SpinalHDL/openocd_riscv/blob/058dfa50d625893bee9fecf8d604141911fac125/src/flash/nor/vexriscv_nor_spi.c#L345
https://github.com/SpinalHDL/openocd_riscv/blob/058dfa50d625893bee9fecf8d604141911fac125/src/flash/nor/vexriscv_nor_spi.c#L394
https://github.com/SpinalHDL/openocd_riscv/tree/riscv_spinal/src/flash/nor/vexriscv_algo

Note, the bandwidth is realy low, so there is ?likely? some overhead somewere in riscv_run_algorithm.

Signed-off-by: Dolu1990 <charles.papon.90@gmail.com>