### PR TITLE
flash: fix clang static analyzer build errors

### DIFF
--- a/src/flash/nand/davinci.c
+++ b/src/flash/nand/davinci.c
@@ -605,8 +605,6 @@ static int davinci_write_page_ecc4infix(struct nand_device *nand, uint32_t page,
 		/* write this "out-of-band" data -- infix */
 		davinci_write_block_data(nand, oob, 16);
 		oob += 16;
-		oob_size -= 16;
-
 	} while (data_size);
 
 	/* the last data and OOB writes included the spare area */

--- a/src/flash/nor/dsp5680xx_flash.c
+++ b/src/flash/nor/dsp5680xx_flash.c
@@ -45,14 +45,11 @@
 
 static int dsp5680xx_build_sector_list(struct flash_bank *bank)
 {
-	uint32_t offset = HFM_FLASH_BASE_ADDR;
-
 	bank->sectors = malloc(sizeof(struct flash_sector) * bank->num_sectors);
 
 	for (unsigned int i = 0; i < bank->num_sectors; ++i) {
 		bank->sectors[i].offset = i * HFM_SECTOR_SIZE;
 		bank->sectors[i].size = HFM_SECTOR_SIZE;
-		offset += bank->sectors[i].size;
 		bank->sectors[i].is_erased = -1;
 		bank->sectors[i].is_protected = -1;
 	}


### PR DESCRIPTION
Cherry pick 631d0bddfaadac63a7d8ff3ef916614d62c86b1e from upstream:

flash: fix clang static analyzer build errors
    
Fixes "variable set but not used" errors.
Tested with Homebrew clang version 13.0.1
    
Signed-off-by: Erhan Kurubas <erhan.kurubas@espressif.com>
Change-Id: Ia90baf5b4857db2b5569ebe6adbbb832de772aad
