### PR TITLE
target/riscv: hide_csrs configuration option

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10553,6 +10553,23 @@ $_TARGETNAME expose_custom 32=myregister
 @end example
 @end deffn
 
+@deffn {Config Command} {riscv hide_csrs} n[-m] [,n1[-m1]] [...]
+The RISC-V Specification defines many CSRs, and we may want to avoid showing
+each CSR to the user, as they may not be relevant to the task at hand. For
+example, we may choose not to show trigger or PMU registers for simple
+debugging scenarios. This command allows to mark individual registers or
+register ranges (inclusive) as "hidden". Such hidden registers won't be
+displayed in GDB or @code{reg} command output.
+
+@example
+
+# Hide range of RISC-V CSRs
+# CSR_TSELECT - 1952 and CSR_DATA1 - 1953
+$_TARGETNAME riscv hide_csrs 1952-1953
+
+@end example
+@end deffn
+
 @deffn {Command} {riscv memory_sample} bucket address|clear [size=4]
 Configure OpenOCD to frequently read size bytes at the given addresses.
 Execute the command with no arguments to see the current configuration. Use

--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10564,7 +10564,7 @@ displayed in GDB or @code{reg} command output.
 @example
 
 # Hide range of RISC-V CSRs
-# CSR_TSELECT - 1952 and CSR_DATA1 - 1953
+# CSR_TSELECT - 1952 and CSR_TDATA1 - 1953
 $_TARGETNAME riscv hide_csrs 1952-1953
 
 @end example

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -433,6 +433,11 @@ static void riscv_deinit_target(struct target *target)
 	riscv_free_registers(target);
 
 	range_list_t *entry, *tmp;
+	list_for_each_entry_safe(entry, tmp, &info->hide_csr, list) {
+		free(entry->name);
+		free(entry);
+	}
+
 	list_for_each_entry_safe(entry, tmp, &info->expose_csr, list) {
 		free(entry->name);
 		free(entry);
@@ -2937,6 +2942,26 @@ COMMAND_HANDLER(riscv_set_expose_custom)
 	return ret;
 }
 
+COMMAND_HANDLER(riscv_hide_csrs)
+{
+	if (CMD_ARGC == 0) {
+		LOG_ERROR("Command expects parameters");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+
+	struct target *target = get_current_target(CMD_CTX);
+	RISCV_INFO(info);
+	int ret = ERROR_OK;
+
+	for (unsigned int i = 0; i < CMD_ARGC; i++) {
+		ret = parse_ranges(&info->hide_csr, CMD_ARGV[i], "csr", 0xfff);
+		if (ret != ERROR_OK)
+			break;
+	}
+
+	return ret;
+}
+
 COMMAND_HANDLER(riscv_authdata_read)
 {
 	unsigned int index = 0;
@@ -3676,6 +3701,16 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 			"etc. This must be executed before `init`."
 	},
 	{
+		.name = "hide_csrs",
+		.handler = riscv_hide_csrs,
+		.mode = COMMAND_CONFIG,
+		.usage = "{n0|n-m0}[,n1|n-m1]......",
+		.help = "Configure a list of inclusive ranges for CSRs to hide from gdb. "
+			"Hidden registers are still available, but are not listed in "
+			"gdb target description and `reg` command output."
+			"This must be executed before `init`."
+	},
+	{
 		.name = "authdata_read",
 		.handler = riscv_authdata_read,
 		.usage = "[index]",
@@ -3926,6 +3961,7 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 
 	INIT_LIST_HEAD(&r->expose_csr);
 	INIT_LIST_HEAD(&r->expose_custom);
+	INIT_LIST_HEAD(&r->hide_csr);
 
 	r->vsew64_supported = YNM_MAYBE;
 }
@@ -5213,6 +5249,14 @@ int riscv_init_registers(struct target *target)
 								csr_number, entry->name ? entry->name : reg_name);
 
 						r->exist = true;
+						break;
+					}
+			} else if (r->exist && !list_empty(&info->hide_csr)) {
+				range_list_t *entry;
+				list_for_each_entry(entry, &info->hide_csr, list)
+					if ((entry->low <= csr_number) && (csr_number <= entry->high)) {
+						LOG_TARGET_DEBUG(target, "Hiding CSR %d (name=%s)", csr_number, r->name);
+						r->hidden = true;
 						break;
 					}
 			}

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3707,7 +3707,7 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 		.usage = "{n0|n-m0}[,n1|n-m1]......",
 		.help = "Configure a list of inclusive ranges for CSRs to hide from gdb. "
 			"Hidden registers are still available, but are not listed in "
-			"gdb target description and `reg` command output."
+			"gdb target description and `reg` command output. "
 			"This must be executed before `init`."
 	},
 	{

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -254,6 +254,10 @@ typedef struct {
 	 * from range 0xc000 ... 0xffff. */
 	struct list_head expose_custom;
 
+	/* The list of registers to mark as "hidden". Hidden registers are available
+	 * but do not appear in gdb targets description or reg command output. */
+	struct list_head hide_csr;
+
 	riscv_sample_config_t sample_config;
 	struct riscv_sample_buf sample_buf;
 


### PR DESCRIPTION
This option allows users to mark certain CSRs as hidden so they could be expluded from *reg* output and target.xml

Change-Id: Iddf8456cd3901f572f8590329ebba5229974d24a