### PR TITLE
Improve a debug log in freertos_update_threads()

### DIFF
--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -590,7 +590,7 @@ static int freertos_update_threads(struct rtos *rtos)
 			return retval;
 		}
 		LOG_DEBUG("FreeRTOS: Read thread count for list %u at 0x%" PRIx64 ", value %" PRIu64,
-										i, list_of_lists[i], list_thread_count);
+								i, list_of_lists[i] + freertos->list_uxNumberOfItems_offset, list_thread_count);
 
 		if (list_thread_count == 0)
 			continue;


### PR DESCRIPTION
To make the log more accurate and comprehensible. In case the offset is non-zero.

Signed-off-by: Chao Du <duchao@eswincomputing.com>