### PR TITLE
If XLEN=64 and vsew=64 fails, fall back to vsew=32.

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1992,13 +1992,15 @@ static int riscv013_get_register_buf(struct target *target,
 
 	unsigned vnum = regno - GDB_REGNO_V0;
 
-	struct riscv_program program;
-	riscv_program_init(&program, target);
-	riscv_program_insert(&program, vmv_x_s(S0, vnum));
-	riscv_program_insert(&program, vslide1down_vx(vnum, vnum, S0, true));
-
 	int result = ERROR_OK;
 	for (unsigned i = 0; i < debug_vl; i++) {
+		/* Can't reuse the same program because riscv_program_exec() adds
+		 * ebreak to the end every time. */
+		struct riscv_program program;
+		riscv_program_init(&program, target);
+		riscv_program_insert(&program, vmv_x_s(S0, vnum));
+		riscv_program_insert(&program, vslide1down_vx(vnum, vnum, S0, true));
+
 		/* Executing the program might result in an exception if there is some
 		 * issue with the vector implementation/instructions we're using. If that
 		 * happens, attempt to restore as usual. We may have clobbered the

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1732,8 +1732,8 @@ static int examine(struct target *target)
 			LOG_TARGET_WARNING(target, "Couldn't read vlenb; vector register access won't work.");
 		r->vlenb = 0;
 	} else {
-		LOG_TARGET_INFO(target, "Vector support with vlenb=%d", r->vlenb);
 		r->vlenb = vlenb;
+		LOG_TARGET_INFO(target, "Vector support with vlenb=%d", r->vlenb);
 	}
 
 	/* Now init registers based on what we discovered. */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -116,12 +116,6 @@ struct trigger {
 	int unique_id;
 };
 
-typedef enum {
-	YNM_MAYBE,
-	YNM_YES,
-	YNM_NO
-} yes_no_maybe_t;
-
 #define HART_INDEX_MULTIPLE	-1
 #define HART_INDEX_UNKNOWN	-2
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3926,6 +3926,8 @@ void riscv_info_init(struct target *target, riscv_info_t *r)
 
 	INIT_LIST_HEAD(&r->expose_csr);
 	INIT_LIST_HEAD(&r->expose_custom);
+
+	r->vsew64_supported = YNM_MAYBE;
 }
 
 static int riscv_resume_go_all_harts(struct target *target)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -259,6 +259,8 @@ typedef struct {
 
 	/* Track when we were last asked to do something substantial. */
 	int64_t last_activity;
+
+	yes_no_maybe_t vsew64_supported;
 } riscv_info_t;
 
 COMMAND_HELPER(riscv_print_info_line, const char *section, const char *key,

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -41,6 +41,12 @@ typedef uint64_t riscv_reg_t;
 typedef uint32_t riscv_insn_t;
 typedef uint64_t riscv_addr_t;
 
+typedef enum {
+	YNM_MAYBE,
+	YNM_YES,
+	YNM_NO
+} yes_no_maybe_t;
+
 enum riscv_mem_access_method {
 	RISCV_MEM_ACCESS_UNSPECIFIED,
 	RISCV_MEM_ACCESS_PROGBUF,


### PR DESCRIPTION
This should make vector accesses work on 64-bit harts that implement Zve32*. There doesn't appear to be any way to easily determine what vsew values are allowed, so try and notice the failure.