### PR TITLE
Set the current_thread when no FreeRTOS task was created.

### DIFF
--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -501,6 +501,7 @@ static int freertos_update_threads(struct rtos *rtos)
 			LOG_ERROR("Error allocating memory for %" PRIu64 " threads", thread_list_size);
 			return ERROR_FAIL;
 		}
+		rtos->current_thread = 1;
 		rtos->thread_details->threadid = 1;
 		rtos->thread_details->exists = true;
 		rtos->thread_details->extra_info_str = NULL;


### PR DESCRIPTION
The 'current thread' was not set when no FreeRTOS task created. Which could lead a wrongly invoking of freertos_get_thread_reg_list.

Change-Id: I0e0f8327080ef698d7ed4aae5ac2a630d532ddeb