### PR TITLE
workflow: Use ubuntu-20.04 to build snapshot

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,7 +8,7 @@ name: OpenOCD Snapshot
 
 jobs:
   package:
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
     env:
       DL_DIR: ../downloads
       BUILD_DIR: ../build


### PR DESCRIPTION
Ubuntu 18.04 is deprecated by github.

Change-Id: Id0e700a99f74b482b0c735be0a12f81fe65b7ca3