### PR TITLE
target/riscv: leaf PTE check PTE_W missing

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1975,7 +1975,7 @@ static int riscv_address_translate(struct target *target,
 		if (!(pte & PTE_V) || (!(pte & PTE_R) && (pte & PTE_W)))
 			return ERROR_FAIL;
 
-		if ((pte & PTE_R) || (pte & PTE_X)) /* Found leaf PTE. */
+		if ((pte & PTE_R) || (pte & PTE_W) || (pte & PTE_X)) /* Found leaf PTE. */
 			break;
 
 		i--;


### PR DESCRIPTION
When permission bits R, W, and X in PTE all three are zero, the PTE is a pointer to the next level of the page table; otherwise, it is a leaf PTE. Here PTE_W is missed.

Change-Id: I82a4cc4e64280f0fcad75b20e51b617520aff29b