### PR TITLE
target/riscv: Don't ignore maskmax for icount.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -854,7 +854,7 @@ static int maybe_add_trigger_t3(struct target *target, bool vs, bool vu,
 	ret = find_next_free_trigger(target, CSR_TDATA1_TYPE_ICOUNT, false, &idx);
 	if (ret != ERROR_OK)
 		return ret;
-	ret = set_trigger(target, idx, tdata1, 0, CSR_MCONTROL_MASKMAX(riscv_xlen(target)));
+	ret = set_trigger(target, idx, tdata1, 0, 0);
 	if (ret != ERROR_OK)
 		return ret;
 	r->trigger_unique_id[idx] = unique_id;


### PR DESCRIPTION
Icount triggers don't have a maskmax field at all. This is a cut and paste error.

Change-Id: I001b3d41bf683599706dba713f7be475e8dd1668