### PR TITLE
Enable the RISC-V semihosting control command

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -9533,6 +9533,10 @@ requests by using a special SVC instruction that is trapped at the
 Supervisor Call vector by OpenOCD.
 @end deffn
 
+@deffn {Command} {riscv semihosting} [@option{enable}|@option{disable}]
+@cindex RISCV semihosting
+@end deffn
+
 @deffn {Command} {arm semihosting_redirect} (@option{disable} | @option{tcp} <port>
 [@option{debug}|@option{stdio}|@option{all})
 @cindex ARM semihosting
@@ -9567,6 +9571,10 @@ Enabling this option forwards semihosting I/O to GDB process using the
 File-I/O remote protocol extension. This is especially useful for
 interacting with remote files or displaying console messages in the
 debugger.
+@end deffn
+
+@deffn {Command} {riscv semihosting_fileio} [@option{enable}|@option{disable}]
+@cindex RISCV semihosting
 @end deffn
 
 @deffn {Command} {arm semihosting_resexit} [@option{enable}|@option{disable}]

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4094,6 +4094,13 @@ static const struct command_registration riscv_command_handlers[] = {
 		.chain = riscv_exec_command_handlers
 	},
 	{
+		.name = "riscv",
+		.mode = COMMAND_ANY,
+		.help = "RISCV Additional Command Group",
+		.usage = "",
+		.chain = semihosting_common_handlers
+	},
+	{
 		.name = "arm",
 		.mode = COMMAND_ANY,
 		.help = "ARM Command Group",


### PR DESCRIPTION
After modification, the following commands will take effect: monitor riscv semihosting enable/disable
monitor riscv semihosting_fileio enable/disable