### PR TITLE
target/riscv: respect error code from dm013_select_target in select_prepped_harts

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4228,8 +4228,7 @@ static int select_prepped_harts(struct target *target)
 		return ERROR_FAIL;
 	if (!dm->hasel_supported) {
 		r->prepped = false;
-		dm013_select_target(target);
-		return ERROR_OK;
+		return dm013_select_target(target);
 	}
 
 	assert(dm->hart_count);


### PR DESCRIPTION

Change-Id: I3099589521538590e366d60629e49cfc74e2d0c6