### PR TITLE
target:riscv: optimize register accesses

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -212,7 +212,8 @@ typedef struct {
 
 static int poll_target(struct target *target, bool announce);
 static int riscv011_poll(struct target *target);
-static int get_register(struct target *target, riscv_reg_t *value, int regid);
+static int get_register(struct target *target, riscv_reg_t *value,
+		enum gdb_regno regid);
 
 /*** Utility functions. ***/
 
@@ -1324,7 +1325,8 @@ static int register_write(struct target *target, unsigned int number,
 	return ERROR_OK;
 }
 
-static int get_register(struct target *target, riscv_reg_t *value, int regid)
+static int get_register(struct target *target, riscv_reg_t *value,
+		enum gdb_regno regid)
 {
 	riscv011_info_t *info = get_info(target);
 
@@ -1368,7 +1370,8 @@ static int get_register(struct target *target, riscv_reg_t *value, int regid)
 	return ERROR_OK;
 }
 
-static int set_register(struct target *target, int regid, uint64_t value)
+static int set_register(struct target *target, enum gdb_regno regid,
+		riscv_reg_t value)
 {
 	return register_write(target, regid, value);
 }

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1533,8 +1533,10 @@ int riscv_flush_registers(struct target *target)
 	return ERROR_OK;
 }
 
-/* Convert: RISC-V hart's halt reason --> OpenOCD's generic debug reason */
-static int set_debug_reason(struct target *target, enum riscv_halt_reason halt_reason)
+/**
+ * Set OpenOCD's generic debug reason from the RISC-V halt reason.
+ */
+int set_debug_reason(struct target *target, enum riscv_halt_reason halt_reason)
 {
 	RISCV_INFO(r);
 	r->trigger_hit = -1;

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -376,8 +376,16 @@ int riscv_current_hartid(const struct target *target);
  * consecutive and start with mhartid=0. */
 unsigned int riscv_count_harts(struct target *target);
 
-/** Set register, updating the cache. */
+/**
+ * Set the register value. For cacheable registers, only the cache is updated
+ * (write-back mode).
+ */
 int riscv_set_register(struct target *target, enum gdb_regno i, riscv_reg_t v);
+/**
+ * Set the register value and immediately write it to the target
+ * (write-through mode).
+ */
+int riscv_write_register(struct target *target, enum gdb_regno i, riscv_reg_t v);
 /** Get register, from the cache if it's in there. */
 int riscv_get_register(struct target *target, riscv_reg_t *value,
 		enum gdb_regno r);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -178,10 +178,13 @@ struct riscv_info {
 
 	/* Helper functions that target the various RISC-V debug spec
 	 * implementations. */
-	int (*get_register)(struct target *target, riscv_reg_t *value, int regid);
-	int (*set_register)(struct target *target, int regid, uint64_t value);
-	int (*get_register_buf)(struct target *target, uint8_t *buf, int regno);
-	int (*set_register_buf)(struct target *target, int regno,
+	int (*get_register)(struct target *target, riscv_reg_t *value,
+			enum gdb_regno regno);
+	int (*set_register)(struct target *target, enum gdb_regno regno,
+			riscv_reg_t value);
+	int (*get_register_buf)(struct target *target, uint8_t *buf,
+			enum gdb_regno regno);
+	int (*set_register_buf)(struct target *target, enum gdb_regno regno,
 			const uint8_t *buf);
 	int (*select_target)(struct target *target);
 	int (*get_hart_state)(struct target *target, enum riscv_hart_state *state);


### PR DESCRIPTION
These commits reduce the number of accesses to target's registers by better utilizing register cache.