### PR TITLE
gdb_server: Removed unused function gdb_set_frontend_state_running

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -4152,12 +4152,6 @@ int gdb_register_commands(struct command_context *cmd_ctx)
 	return register_commands(cmd_ctx, NULL, gdb_command_handlers);
 }
 
-void gdb_set_frontend_state_running(struct connection *connection)
-{
-	struct gdb_connection *gdb_con = connection->priv;
-	gdb_con->frontend_state = TARGET_RUNNING;
-}
-
 void gdb_service_free(void)
 {
 	free(gdb_port);

--- a/src/server/gdb_server.h
+++ b/src/server/gdb_server.h
@@ -35,8 +35,6 @@ static inline struct target *get_target_from_connection(struct connection *conne
 	return gdb_service->target;
 }
 
-void gdb_set_frontend_state_running(struct connection *connection);
-
 #define ERROR_GDB_BUFFER_TOO_SMALL (-800)
 #define ERROR_GDB_TIMEOUT (-801)
 


### PR DESCRIPTION
Small non-functional change: unused function removed that does not exist in the OpenOCD upstream, either.

Change-Id: Ibeab5b41a24183673cc02ca919b2f7285309e6f4