### PR TITLE
target/riscv: Select hart in update_dcsr()

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1558,6 +1558,9 @@ static int wait_for_authbusy(struct target *target, uint32_t *dmstatus)
 
 static int update_dcsr(struct target *target, bool step)
 {
+	if (dm013_select_target(target) != ERROR_OK)
+		return ERROR_FAIL;
+
 	riscv_reg_t dcsr;
 	/* We want to twiddle some bits in the debug CSR so debugging works. */
 	int result = register_read_direct(target, &dcsr, GDB_REGNO_DCSR);


### PR DESCRIPTION
Otherwise we may end up modifying DCSR of a different hart.

Fixes a bug introduced in f0898155d1e83c0f8691396eb01103cd3beb470c.

Change-Id: I39bde21a1444623ed150f2b3d504b9318b9d6191