### PR TITLE
When dcsr.ebreak* might be cleared, halt the target and set it again

### DIFF
--- a/src/jtag/drivers/xds110.c
+++ b/src/jtag/drivers/xds110.c
@@ -579,7 +579,7 @@ static bool usb_get_response(uint32_t *total_bytes_read, uint32_t timeout)
 
 static bool usb_send_command(uint16_t size)
 {
-	int written;
+	int written = 0;
 	bool success = true;
 
 	/* Check the packet length */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -44,7 +44,6 @@ static int riscv013_halt_prep(struct target *target);
 static int riscv013_halt_go(struct target *target);
 static int riscv013_resume_go(struct target *target);
 static int riscv013_step_current_hart(struct target *target);
-static int riscv013_on_halt(struct target *target);
 static int riscv013_on_step(struct target *target);
 static int riscv013_resume_prep(struct target *target);
 static enum riscv_halt_reason riscv013_halt_reason(struct target *target);
@@ -2476,7 +2475,6 @@ static int init_target(struct command_context *cmd_ctx,
 	generic_info->get_hart_state = &riscv013_get_hart_state;
 	generic_info->resume_go = &riscv013_resume_go;
 	generic_info->step_current_hart = &riscv013_step_current_hart;
-	generic_info->on_halt = &riscv013_on_halt;
 	generic_info->resume_prep = &riscv013_resume_prep;
 	generic_info->halt_prep = &riscv013_halt_prep;
 	generic_info->halt_go = &riscv013_halt_go;
@@ -4500,11 +4498,6 @@ static int riscv013_resume_prep(struct target *target)
 static int riscv013_on_step(struct target *target)
 {
 	return riscv013_on_step_or_resume(target, true);
-}
-
-static int riscv013_on_halt(struct target *target)
-{
-	return ERROR_OK;
 }
 
 static enum riscv_halt_reason riscv013_halt_reason(struct target *target)

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -205,6 +205,9 @@ typedef struct {
 
 	/* This target was selected using hasel. */
 	bool selected;
+
+	/* This hart was placed into a halt group in examine(). */
+	bool haltgroup_supported;
 } riscv013_info_t;
 
 static LIST_HEAD(dm_list);
@@ -1890,7 +1893,7 @@ static int examine(struct target *target)
 		bool haltgroup_supported;
 		if (set_group(target, &haltgroup_supported, target->smp, HALT_GROUP) != ERROR_OK)
 			return ERROR_FAIL;
-		if (haltgroup_supported)
+		if (info->haltgroup_supported)
 			LOG_INFO("Core %d made part of halt group %d.", target->coreid,
 					target->smp);
 		else

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -474,6 +474,7 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
 	if (r->reset_delays_wait >= 0) {
 		r->reset_delays_wait--;
 		if (r->reset_delays_wait < 0) {
+			LOG_TARGET_DEBUG(target, "reset_delays_wait done");
 			info->dmi_busy_delay = 0;
 			info->ac_busy_delay = 0;
 		}

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2934,6 +2934,17 @@ int riscv_openocd_poll(struct target *target)
 		}
 	}
 
+	/* Call tick() for every hart. What happens in tick() is opaque to this
+	 * layer. The reason it's outside the previous loop is that at this point
+	 * the state of every hart has settled, so any side effects happening in
+	 * tick() won't affect the delicate poll() code. */
+	foreach_smp_target(entry, targets) {
+		struct target *t = entry->target;
+		struct riscv_info *info = riscv_info(t);
+		if (info->tick && info->tick(t) != ERROR_OK)
+			return ERROR_FAIL;
+	}
+
 	/* Sample memory if any target is running. */
 	foreach_smp_target(entry, targets) {
 		struct target *t = entry->target;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2752,6 +2752,10 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 					}
 				}
 
+				if (r->handle_became_halted &&
+						r->handle_became_halted(target, previous_riscv_state) != ERROR_OK)
+					return ERROR_FAIL;
+
 				/* We shouldn't do the callbacks yet. What if
 				 * there are multiple harts that halted at the
 				 * same time? We need to set debug reason on each
@@ -2769,12 +2773,18 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 				LOG_TARGET_DEBUG(target, "  triggered running");
 				target->state = TARGET_RUNNING;
 				target->debug_reason = DBG_REASON_NOTHALTED;
+				if (r->handle_became_running &&
+						r->handle_became_running(target, previous_riscv_state) != ERROR_OK)
+					return ERROR_FAIL;
 				break;
 
 			case RISCV_STATE_UNAVAILABLE:
 				LOG_TARGET_DEBUG(target, "  became unavailable");
 				LOG_TARGET_INFO(target, "became unavailable.");
 				target->state = TARGET_UNAVAILABLE;
+				if (r->handle_became_unavailable &&
+						r->handle_became_unavailable(target, previous_riscv_state) != ERROR_OK)
+					return ERROR_FAIL;
 				break;
 
 			case RISCV_STATE_NON_EXISTENT:

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2752,8 +2752,6 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 					}
 				}
 
-				r->on_halt(target);
-
 				/* We shouldn't do the callbacks yet. What if
 				 * there are multiple harts that halted at the
 				 * same time? We need to set debug reason on each
@@ -4538,7 +4536,6 @@ static int riscv_step_rtos_hart(struct target *target)
 	r->on_step(target);
 	if (r->step_current_hart(target) != ERROR_OK)
 		return ERROR_FAIL;
-	r->on_halt(target);
 	if (target->state != TARGET_HALTED) {
 		LOG_ERROR("Hart was not halted after single step!");
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -193,6 +193,17 @@ struct riscv_info {
 	 * was resumed. */
 	int (*resume_go)(struct target *target);
 	int (*step_current_hart)(struct target *target);
+
+	/* These get called from riscv_poll_hart(), which is a house of cards
+	 * together with openocd_poll(), so be careful not to upset things too
+	 * much. */
+	int (*handle_became_halted)(struct target *target,
+		enum riscv_hart_state previous_riscv_state);
+	int (*handle_became_running)(struct target *target,
+		enum riscv_hart_state previous_riscv_state);
+	int (*handle_became_unavailable)(struct target *target,
+		enum riscv_hart_state previous_riscv_state);
+
 	/* Get this target as ready as possible to resume, without actually
 	 * resuming. */
 	int (*resume_prep)(struct target *target);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -204,6 +204,10 @@ struct riscv_info {
 	int (*handle_became_unavailable)(struct target *target,
 		enum riscv_hart_state previous_riscv_state);
 
+	/* Called periodically (no guarantees about frequency), while there's
+	 * nothing else going on. */
+	int (*tick)(struct target *target);
+
 	/* Get this target as ready as possible to resume, without actually
 	 * resuming. */
 	int (*resume_prep)(struct target *target);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -193,7 +193,6 @@ struct riscv_info {
 	 * was resumed. */
 	int (*resume_go)(struct target *target);
 	int (*step_current_hart)(struct target *target);
-	int (*on_halt)(struct target *target);
 	/* Get this target as ready as possible to resume, without actually
 	 * resuming. */
 	int (*resume_prep)(struct target *target);


### PR DESCRIPTION
I don't have a great target to test this on. What I've done:
1. Hack the code to force halt_set_dcsr_ebreak() to be called at various times even when it's not necessary. Ran all the usual tests that way.
2. Tested this against a target which returns a single DMI failure when a hart is powered up, while having the call to set_dcsr_ebreak() from examine() commented out. After examine() completed, halt_set_dcsr_ebreak() was called from tick() as expected.

This also helps with #853, although it's not really optimal.