### PR TITLE
target/riscv: set_dcsr_ebreak() while target->state is still changed

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1862,15 +1862,15 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 	}
 
-	target->state = saved_tgt_state;
-	target->debug_reason = saved_dbg_reason;
-
 	/* Now init registers based on what we discovered. */
 	if (riscv_init_registers(target) != ERROR_OK)
 		return ERROR_FAIL;
 
 	if (update_dcsr(target, false) != ERROR_OK)
 		return ERROR_FAIL;
+
+	target->state = saved_tgt_state;
+	target->debug_reason = saved_dbg_reason;
 
 	if (!halted) {
 		riscv013_step_or_resume_current_hart(target, false);


### PR DESCRIPTION
Otherwise it fails.

Fixes #859.

Change-Id: Ib59e6d840316b881481a9b1e01f9d546e73bf932