### PR TITLE
target/riscv: resume only halted harts

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4494,6 +4494,7 @@ static int riscv013_step_current_hart(struct target *target)
 
 static int riscv013_resume_prep(struct target *target)
 {
+	assert(target->state == TARGET_HALTED);
 	return riscv013_on_step_or_resume(target, false);
 }
 


### PR DESCRIPTION
With this change, failures to resume a hart due to it not being halted are more explicitly logged or reported as an error.

Change-Id: Ia55d8df85a908363d0f2140637ce1e47c1ab6251