### PR TITLE
target/riscv: refactor read_memory_progbuf()

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -161,7 +161,7 @@ size_t riscv_batch_add_dmi_read(struct riscv_batch *batch, unsigned address)
 	return batch->read_keys_used++;
 }
 
-unsigned riscv_batch_get_dmi_read_op(struct riscv_batch *batch, size_t key)
+unsigned int riscv_batch_get_dmi_read_op(const struct riscv_batch *batch, size_t key)
 {
 	assert(key < batch->read_keys_used);
 	size_t index = batch->read_keys[key];
@@ -171,7 +171,7 @@ unsigned riscv_batch_get_dmi_read_op(struct riscv_batch *batch, size_t key)
 	return (unsigned)buf_get_u32(base, DTM_DMI_OP_OFFSET, DTM_DMI_OP_LENGTH);
 }
 
-uint32_t riscv_batch_get_dmi_read_data(struct riscv_batch *batch, size_t key)
+uint32_t riscv_batch_get_dmi_read_data(const struct riscv_batch *batch, size_t key)
 {
 	assert(key < batch->read_keys_used);
 	size_t index = batch->read_keys[key];

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -66,8 +66,8 @@ void riscv_batch_add_dmi_write(struct riscv_batch *batch, unsigned address, uint
  * provides a key, the second one actually obtains the result of the read -
  * status (op) and the actual data. */
 size_t riscv_batch_add_dmi_read(struct riscv_batch *batch, unsigned address);
-unsigned riscv_batch_get_dmi_read_op(struct riscv_batch *batch, size_t key);
-uint32_t riscv_batch_get_dmi_read_data(struct riscv_batch *batch, size_t key);
+unsigned int riscv_batch_get_dmi_read_op(const struct riscv_batch *batch, size_t key);
+uint32_t riscv_batch_get_dmi_read_data(const struct riscv_batch *batch, size_t key);
 
 /* Scans in a NOP. */
 void riscv_batch_add_nop(struct riscv_batch *batch);

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -119,6 +119,23 @@ int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno 
 	return riscv_program_insert(p, lb(d, b, offset));
 }
 
+int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset,
+		unsigned int size)
+{
+	switch (size) {
+	case 1:
+		return riscv_program_lbr(p, d, b, offset);
+	case 2:
+		return riscv_program_lhr(p, d, b, offset);
+	case 4:
+		return riscv_program_lwr(p, d, b, offset);
+	case 8:
+		return riscv_program_ldr(p, d, b, offset);
+	}
+	assert(false && "Unsupported size");
+	return ERROR_FAIL;
+}
+
 int riscv_program_csrrsi(struct riscv_program *p, enum gdb_regno d, unsigned int z, enum gdb_regno csr)
 {
 	assert(csr >= GDB_REGNO_CSR0 && csr <= GDB_REGNO_CSR4095);

--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -51,6 +51,8 @@ int riscv_program_ldr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno 
 int riscv_program_lwr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
 int riscv_program_lhr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
 int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
+int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int o,
+		unsigned int s);
 
 int riscv_program_sdr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);
 int riscv_program_swr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);


### PR DESCRIPTION
There were a couple of problems with previous implementation:

* Misalligned read would return ERROR_OK and print all zeroes.

* CMDERR_BUSY for abstract access was improperly handled:

According to the spec, no assumptions can be made about DM_DATA* contents in such a case, but these were considered valid values from memory.

* A fallback to one element read was implemented when DMI_STATUS_BUSY occurred during batch reads, even though this can be accounted for.

Change-Id: I09174c61c951b2bb97a529b7f0aa5afaa995179b