### PR TITLE
[target/riscv] support for smp group manipulation

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -10812,6 +10812,18 @@ When utilizing version 0.11 of the RISC-V Debug Specification,
 and DBUS registers, respectively.
 @end deffn
 
+@deffn {Command} {riscv smp} [on|off]
+Display, enable or disable SMP handling mode. This command is needed only if
+user wants to temporary @b{disable} SMP handling for an existing SMP group
+(see @code{aarch64 smp} for additional information). To define an SMP
+group the command @code{target smp} should be used.
+@end deffn
+
+@deffn {Command} {riscv smp_gdb} [core_id]
+Display/set the current core displayed in GDB. This is needed only if
+@code{riscv smp} was used.
+@end deffn
+
 @deffn {Command} {riscv use_bscan_tunnel} value
 Enable or disable use of a BSCAN tunnel to reach the Debug Module. Supply the
 width of the DM transport TAP's instruction register to enable. Supply a

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4383,6 +4383,9 @@ static const struct command_registration riscv_command_handlers[] = {
 		.usage = "",
 		.chain = semihosting_common_handlers
 	},
+	{
+		.chain = smp_command_handlers
+	},
 	COMMAND_REGISTRATION_DONE
 };
 


### PR DESCRIPTION
this functionality allows to query if a target belongs to some smp group and to dynamically turn on/off smp-specific behavior

Change-Id: I469453d95e7c1640a91bc60d80c854404e508535