### PR TITLE
Add null pointer check before right shift for bscan tunneling.

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -115,8 +115,10 @@ int riscv_batch_run(struct riscv_batch *batch)
 
 	if (bscan_tunnel_ir_width != 0) {
 		/* need to right-shift "in" by one bit, because of clock skew between BSCAN TAP and DM TAP */
-		for (size_t i = 0; i < batch->used_scans; ++i)
-			buffer_shr((batch->fields + i)->in_value, DMI_SCAN_BUF_SIZE, 1);
+		for (size_t i = 0; i < batch->used_scans; ++i) {
+			if ((batch->fields + i)->in_value)
+				buffer_shr((batch->fields + i)->in_value, DMI_SCAN_BUF_SIZE, 1);
+		}
 	}
 
 	for (size_t i = 0; i < batch->used_scans; ++i)


### PR DESCRIPTION
Add a null pointer check to address issue #855.

Change-Id: I5d4764c777f33d48705b3e5273eb840c13cfbfb7