### PR TITLE
target/riscv: cleanup trigger setup

### DIFF
--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -292,6 +292,8 @@ struct riscv_info {
 	int64_t last_activity;
 
 	yes_no_maybe_t vsew64_supported;
+
+	bool range_trigger_fallback_encountered;
 };
 
 COMMAND_HELPER(riscv_print_info_line, const char *section, const char *key,


### PR DESCRIPTION
* Add a warning when eq trigger is setup and it's behavior is different from other triggers.

* Make eq trigger's behavior consistent with other triggers in case of length == 1.

* Fix a bug in setting chained triggers (LT, GT case).

* Improve logging.

Change-Id: Id1ed0d11971b8ed875afbb979e6c8a8b51dd3818