### PR TITLE
target/breakpoints: Clear software breakpoints from available targets

### DIFF
--- a/src/rtos/hwthread.c
+++ b/src/rtos/hwthread.c
@@ -95,6 +95,9 @@ static int hwthread_update_threads(struct rtos *rtos)
 
 	target = rtos->target;
 
+	/* wipe out previous thread details if any */
+	rtos_free_threadlist(rtos);
+
 	/* determine the number of "threads" */
 	if (target->smp) {
 		foreach_smp_target(head, target->smp_targets) {

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2737,6 +2737,9 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 	if (target->state == TARGET_UNKNOWN || state != previous_riscv_state) {
 		switch (state) {
 			case RISCV_STATE_HALTED:
+				if (previous_riscv_state == RISCV_STATE_UNAVAILABLE)
+					LOG_TARGET_INFO(target, "became available (halted)");
+
 				LOG_TARGET_DEBUG(target, "  triggered a halt; previous_target_state=%d",
 					previous_target_state);
 				target->state = TARGET_HALTED;
@@ -2782,6 +2785,9 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 				break;
 
 			case RISCV_STATE_RUNNING:
+				if (previous_riscv_state == RISCV_STATE_UNAVAILABLE)
+					LOG_TARGET_INFO(target, "became available (running)");
+
 				LOG_TARGET_DEBUG(target, "  triggered running");
 				target->state = TARGET_RUNNING;
 				target->debug_reason = DBG_REASON_NOTHALTED;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4663,7 +4663,7 @@ static bool gdb_regno_cacheable(enum gdb_regno regno, bool is_write)
 
 		case GDB_REGNO_TSELECT:	/* I think this should be above, but then it doesn't work. */
 		case GDB_REGNO_TDATA1:	/* Changes value when tselect is changed. */
-		case GDB_REGNO_TDATA2:  /* Changse value when tselect is changed. */
+		case GDB_REGNO_TDATA2:  /* Changes value when tselect is changed. */
 		default:
 			return false;
 	}


### PR DESCRIPTION
If a target where a software breakpoint was set is not currently available, but there are other targets in the same SMP group that are available, then we can use those to remove the software breakpoint.