### PR TITLE
target/riscv: Add target name logging to most log prints.

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -88,7 +88,7 @@ bool riscv_batch_full(struct riscv_batch *batch)
 int riscv_batch_run(struct riscv_batch *batch)
 {
 	if (batch->used_scans == 0) {
-		LOG_DEBUG("Ignoring empty batch.");
+		LOG_TARGET_DEBUG(batch->target, "Ignoring empty batch.");
 		return ERROR_OK;
 	}
 
@@ -107,7 +107,7 @@ int riscv_batch_run(struct riscv_batch *batch)
 	keep_alive();
 
 	if (jtag_execute_queue() != ERROR_OK) {
-		LOG_ERROR("Unable to execute JTAG queue");
+		LOG_TARGET_ERROR(batch->target, "Unable to execute JTAG queue");
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -57,12 +57,12 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 {
 	struct semihosting *semihosting = target->semihosting;
 	if (!semihosting) {
-		LOG_DEBUG("   -> NONE (!semihosting)");
+		LOG_TARGET_DEBUG(target, "   -> NONE (!semihosting)");
 		return SEMIHOSTING_NONE;
 	}
 
 	if (!semihosting->is_active) {
-		LOG_DEBUG("   -> NONE (!semihosting->is_active)");
+		LOG_TARGET_DEBUG(target, "   -> NONE (!semihosting->is_active)");
 		return SEMIHOSTING_NONE;
 	}
 
@@ -93,7 +93,7 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 		LOG_TARGET_DEBUG(target, "compare 0x%08x from 0x%" PRIx64 " against 0x%08x",
 			value, address, magic[i]);
 		if (value != magic[i]) {
-			LOG_DEBUG("   -> NONE (no magic)");
+			LOG_TARGET_DEBUG(target, "   -> NONE (no magic)");
 			return SEMIHOSTING_NONE;
 		}
 	}
@@ -109,13 +109,13 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 
 		result = riscv_get_register(target, &r0, GDB_REGNO_A0);
 		if (result != ERROR_OK) {
-			LOG_DEBUG("   -> ERROR (couldn't read a0)");
+			LOG_TARGET_DEBUG(target, "   -> ERROR (couldn't read a0)");
 			return SEMIHOSTING_ERROR;
 		}
 
 		result = riscv_get_register(target, &r1, GDB_REGNO_A1);
 		if (result != ERROR_OK) {
-			LOG_DEBUG("   -> ERROR (couldn't read a1)");
+			LOG_TARGET_DEBUG(target, "   -> ERROR (couldn't read a1)");
 			return SEMIHOSTING_ERROR;
 		}
 
@@ -129,12 +129,12 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 
 			*retval = semihosting_common(target);
 			if (*retval != ERROR_OK) {
-				LOG_ERROR("Failed semihosting operation (0x%02X)", semihosting->op);
+				LOG_TARGET_ERROR(target, "Failed semihosting operation (0x%02X)", semihosting->op);
 				return SEMIHOSTING_ERROR;
 			}
 		} else {
 			/* Unknown operation number, not a semihosting call. */
-			LOG_DEBUG("   -> NONE (unknown operation number)");
+			LOG_TARGET_DEBUG(target, "   -> NONE (unknown operation number)");
 			return SEMIHOSTING_NONE;
 		}
 	}
@@ -149,11 +149,11 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 	 * operation to complete.
 	 */
 	if (semihosting->is_resumable && !semihosting->hit_fileio) {
-		LOG_DEBUG("   -> HANDLED");
+		LOG_TARGET_DEBUG(target, "   -> HANDLED");
 		return SEMIHOSTING_HANDLED;
 	}
 
-	LOG_DEBUG("   -> WAITING");
+	LOG_TARGET_DEBUG(target, "   -> WAITING");
 	return SEMIHOSTING_WAITING;
 }
 
@@ -166,7 +166,7 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
  */
 static int riscv_semihosting_setup(struct target *target, int enable)
 {
-	LOG_DEBUG("[%s] enable=%d", target_name(target), enable);
+	LOG_TARGET_DEBUG(target, "enable=%d", enable);
 
 	struct semihosting *semihosting = target->semihosting;
 	if (semihosting)
@@ -183,7 +183,7 @@ static int riscv_semihosting_post_result(struct target *target)
 		return 0;
 	}
 
-	LOG_DEBUG("0x%" PRIx64, semihosting->result);
+	LOG_TARGET_DEBUG(target, "Result: 0x%" PRIx64, semihosting->result);
 	riscv_set_register(target, GDB_REGNO_A0, semihosting->result);
 	return 0;
 }


### PR DESCRIPTION
This patch adds target name (LOG_TARGET_XXXX) to logging calls where it makes sense. This is especially useful when debugging multiple targets at once, such as multicore systems.

Change-Id: Ia9861f3fa0e6e5908b683c2a8280659c3c264395