### PR TITLE
Update espressif chips

### DIFF
--- a/tcl/board/esp32c3-builtin.cfg
+++ b/tcl/board/esp32c3-builtin.cfg
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-C3 connected via builtin USB-JTAG adapter.
+#
+# For example, OpenOCD can be started for ESP32-C3 debugging on
+#
+#   openocd -f board/esp32c3-builtin.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/esp_usb_jtag.cfg]
+# Source the ESP32-C3 configuration file
+source [find target/esp32c3.cfg]
+
+adapter speed 40000

--- a/tcl/board/esp32c6-builtin.cfg
+++ b/tcl/board/esp32c6-builtin.cfg
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-C6 connected via builtin USB-JTAG adapter.
+#
+# For example, OpenOCD can be started for ESP32-C6 debugging on
+#
+#   openocd -f board/esp32c6-builtin.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/esp_usb_jtag.cfg]
+# Source the ESP32-C6 configuration file
+source [find target/esp32c6.cfg]
+
+adapter speed 40000

--- a/tcl/board/esp32h2-builtin.cfg
+++ b/tcl/board/esp32h2-builtin.cfg
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-C3 connected via builtin USB-JTAG adapter.
+#
+# For example, OpenOCD can be started for ESP32-C3 debugging on
+#
+#   openocd -f board/esp32c3-builtin.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/esp_usb_jtag.cfg]
+# Source the ESP32-C3 configuration file
+source [find target/esp32h2.cfg]
+
+adapter speed 40000

--- a/tcl/board/esp32s3-builtin.cfg
+++ b/tcl/board/esp32s3-builtin.cfg
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Example OpenOCD configuration file for ESP32-S3 connected via builtin USB-JTAG adapter.
+#
+# For example, OpenOCD can be started for ESP32-S3 debugging on
+#
+#   openocd -f board/esp32s3-builtin.cfg
+#
+
+# Source the JTAG interface configuration file
+source [find interface/esp_usb_jtag.cfg]
+# Source the ESP32-S3 configuration file
+source [find target/esp32s3.cfg]
+
+adapter speed 40000

--- a/tcl/interface/esp_usb_jtag.cfg
+++ b/tcl/interface/esp_usb_jtag.cfg
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Espressif builtin USB-JTAG adapter
+#
+
+adapter driver esp_usb_jtag
+
+espusbjtag vid_pid 0x303a 0x1001
+espusbjtag caps_descriptor 0x2000

--- a/tcl/target/esp32.cfg
+++ b/tcl/target/esp32.cfg
@@ -1,99 +1,35 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The ESP32 only supports JTAG.
-transport select jtag
 
-# Source the ESP common configuration file
+# Source the ESP common configuration file.
 source [find target/esp_common.cfg]
 
-if { [info exists CHIPNAME] } {
-	set _CHIPNAME $CHIPNAME
-} else {
-	set _CHIPNAME esp32
-}
-
-if { [info exists CPUTAPID] } {
-	set _CPUTAPID $CPUTAPID
-} else {
-	set _CPUTAPID 0x120034e5
-}
+# Target specific global variables
+set _CHIPNAME 					"esp32"
+set _CPUTAPID 					0x120034e5
+set _ESP_ARCH 					"xtensa"
+set _ONLYCPU					3
+set _FLASH_VOLTAGE 				3.3
+set _ESP_SMP_TARGET				1
+set _ESP_SMP_BREAK 				1
+set _ESP_EFUSE_MAC_ADDR_REG 	0x3ff5A004
 
 if { [info exists ESP32_ONLYCPU] } {
 	set _ONLYCPU $ESP32_ONLYCPU
-} else {
-	set _ONLYCPU 2
 }
 
 if { [info exists ESP32_FLASH_VOLTAGE] } {
 	set _FLASH_VOLTAGE $ESP32_FLASH_VOLTAGE
-} else {
-	set _FLASH_VOLTAGE 3.3
 }
 
-set _CPU0NAME cpu0
-set _CPU1NAME cpu1
-set _TARGETNAME_0 $_CHIPNAME.$_CPU0NAME
-set _TARGETNAME_1 $_CHIPNAME.$_CPU1NAME
-
-jtag newtap $_CHIPNAME $_CPU0NAME -irlen 5 -expected-id $_CPUTAPID
-if { $_ONLYCPU != 1 } {
-	jtag newtap $_CHIPNAME $_CPU1NAME -irlen 5 -expected-id $_CPUTAPID
-} else {
-	jtag newtap $_CHIPNAME $_CPU1NAME -irlen 5 -disable -expected-id $_CPUTAPID
+proc esp32_memprot_is_enabled { } {
+	return 0
 }
 
-# PRO-CPU
-target create $_TARGETNAME_0 $_CHIPNAME -endian little -chain-position $_TARGETNAME_0 -coreid 0
-# APP-CPU
-if { $_ONLYCPU != 1 } {
-	target create $_TARGETNAME_1 $_CHIPNAME -endian little -chain-position $_TARGETNAME_1 -coreid 1
-	target smp $_TARGETNAME_0 $_TARGETNAME_1
+proc esp32_soc_reset { } {
+	soft_reset_halt
 }
 
-$_TARGETNAME_0 esp32 flashbootstrap $_FLASH_VOLTAGE
-$_TARGETNAME_0 xtensa maskisr on
-$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
-$_TARGETNAME_0 configure -event reset-assert-post { soft_reset_halt }
-
-$_TARGETNAME_0 configure -event gdb-attach {
-	$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
-	# necessary to auto-probe flash bank when GDB is connected
-	halt 1000
-}
-
-if { $_ONLYCPU != 1 } {
-	$_TARGETNAME_1 configure -event gdb-attach {
-		$_TARGETNAME_1 xtensa smpbreak BreakIn BreakOut
-		# necessary to auto-probe flash bank when GDB is connected
-		halt 1000
-	}
-	$_TARGETNAME_1 configure -event reset-assert-post { soft_reset_halt }
-}
-
-$_TARGETNAME_0 configure -event examine-end {
-    # Need to enable to set 'semihosting_basedir'
-    arm semihosting enable
-    arm semihosting_resexit enable
-    if { [info exists _SEMIHOST_BASEDIR] } {
-        if { $_SEMIHOST_BASEDIR != "" } {
-            arm semihosting_basedir $_SEMIHOST_BASEDIR
-        }
-    }
-}
-
-if { $_ONLYCPU != 1 } {
-	$_TARGETNAME_1 configure -event examine-end {
-		# Need to enable to set 'semihosting_basedir'
-		arm semihosting enable
-		arm semihosting_resexit enable
-		if { [info exists _SEMIHOST_BASEDIR] } {
-			if { $_SEMIHOST_BASEDIR != "" } {
-				arm semihosting_basedir $_SEMIHOST_BASEDIR
-			}
-		}
-	}
-}
-
-gdb_breakpoint_override hard
+create_esp_target $_ESP_ARCH
 
 source [find target/xtensa-core-esp32.cfg]

--- a/tcl/target/esp32c2.cfg
+++ b/tcl/target/esp32c2.cfg
@@ -1,30 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The ESP32-C2 only supports JTAG.
-transport select jtag
 
-# Source the ESP common configuration file
+# Source the ESP common configuration file.
 source [find target/esp_common.cfg]
 
-if { [info exists CHIPNAME] } {
-	set _CHIPNAME $CHIPNAME
-} else {
-	set _CHIPNAME esp32c2
-}
+# Target specific global variables
+set _CHIPNAME 					"riscv"
+set _CPUTAPID 					0x0000cc25
+set _ESP_ARCH 					"riscv"
+set _ONLYCPU					1
+set _ESP_SMP_TARGET				0
+set _ESP_SMP_BREAK 				0
+set _ESP_EFUSE_MAC_ADDR_REG  	0x60008840
 
-if { [info exists CPUTAPID] } {
-	set _CPUTAPID $CPUTAPID
-} else {
-	set _CPUTAPID 0x0000cc25
-}
-
-set _TARGETNAME $_CHIPNAME
-set _CPUNAME cpu
-set _TAPNAME $_CHIPNAME.$_CPUNAME
-
-jtag newtap $_CHIPNAME $_CPUNAME -irlen 5 -expected-id $_CPUTAPID
-
-proc esp32c2_wdt_disable { } {
+# Target specific functions should be implemented for each riscv chips.
+proc riscv_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -42,9 +32,9 @@ proc esp32c2_wdt_disable { } {
     mww 0x600080A0 0x84B00000
 }
 
-# This is almost identical with the esp32c3_soc_reset.
-# Will be refactored with the other common settings.
-proc esp32c2_soc_reset { } {
+proc riscv_soc_reset { } {
+	global _RISCV_DMCONTROL
+
     # This procedure does "digital system reset", i.e. resets
     # all the peripherals except for the RTC block.
     # It is called from reset-assert-post target event callback,
@@ -52,7 +42,7 @@ proc esp32c2_soc_reset { } {
     # Since we need the hart to to execute a write to RTC_CNTL_SW_SYS_RST,
     # temporarily take it out of reset. Save the dmcontrol state before
     # doing so.
-    riscv dmi_write 0x10 0x80000001
+    riscv dmi_write $_RISCV_DMCONTROL 0x80000001
     # Trigger the reset
     mww 0x60008000 0x9c00a000
     # Workaround for stuck in cpu start during calibration.
@@ -62,50 +52,66 @@ proc esp32c2_soc_reset { } {
     sleep 10
     poll
     # Disable the watchdogs again
-    esp32c2_wdt_disable
+    riscv_wdt_disable
 
     # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
     # We will clean allhalted state by resuming the core.
-    riscv dmi_write 0x10 0x40000001
+    riscv dmi_write $_RISCV_DMCONTROL 0x40000001
 
     # Put the hart back into reset state. Note that we need to keep haltreq set.
-    riscv dmi_write 0x10 0x80000003
+    riscv dmi_write $_RISCV_DMCONTROL 0x80000003
 }
 
-if { $_RTOS == "none" } {
-    target create $_TARGETNAME riscv -chain-position $_TAPNAME
-} else {
-    target create $_TARGETNAME riscv -chain-position $_TAPNAME -rtos $_RTOS
+proc riscv_memprot_is_enabled { } {
+	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
+
+	# PMPADDR 0-1 covers entire valid IRAM range and PMPADDR 2-3 covers entire DRAM region
+	# pmpcfg0 holds the configuration for the PMP 0-3 address registers
+
+	# read pmpcfg0 and extract into 8-bit variables.
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203a0
+	set pmpcfg0 [riscv dmi_read $_RISCV_ABS_DATA0]
+
+	set pmp0cfg [expr {($pmpcfg0 >> (8 * 0)) & 0xFF}]
+	set pmp1cfg [expr {($pmpcfg0 >> (8 * 1)) & 0xFF}]
+	set pmp2cfg [expr {($pmpcfg0 >> (8 * 2)) & 0xFF}]
+	set pmp3cfg [expr {($pmpcfg0 >> (8 * 3)) & 0xFF}]
+
+	# read PMPADDR 0-3
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b0
+	set pmpaddr0 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b1
+	set pmpaddr1 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b2
+	set pmpaddr2 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b3
+	set pmpaddr3 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+
+	set IRAM_LOW 	0x40380000
+	set IRAM_HIGH 	0x403C0000
+	set DRAM_LOW 	0x3FCA0000
+	set DRAM_HIGH 	0x3FCE0000
+	set PMP_RWX     0x07
+	set PMP_RW     	0x03
+
+	# The lock bit remains unset during the execution of the 2nd stage bootloader.
+	# Thus we do not perform a lock bit check for IRAM and DRAM regions.
+
+	# Check OpenOCD can write and execute from IRAM.
+	if {$pmpaddr0 >= $IRAM_LOW && $pmpaddr1 <= $IRAM_HIGH} {
+    	if {($pmp0cfg & $PMP_RWX) != 0 || ($pmp1cfg & $PMP_RWX) != $PMP_RWX} {
+			return 1
+		}
+	}
+
+	# Check OpenOCD can read/write entire DRAM region.
+	if {$pmpaddr2 >= $DRAM_LOW && $pmpaddr3 <= $DRAM_HIGH} {
+    	if {($pmp2cfg & $PMP_RW) != 0 && ($pmp3cfg & $PMP_RW) != $PMP_RW} {
+			return 1
+		}
+	}
+
+	return 0
 }
 
-$_TARGETNAME configure -event reset-assert-post { esp32c2_soc_reset }
-$_TARGETNAME configure -event halted {
-    esp32c2_wdt_disable
-}
-$_TARGETNAME configure -event examine-end {
-    # Need this to handle 'apptrace init' syscall correctly because semihosting is not enabled by default
-    arm semihosting enable
-    arm semihosting_resexit enable
-    if { [info exists _SEMIHOST_BASEDIR] } {
-        if { $_SEMIHOST_BASEDIR != "" } {
-            # TODO: cherry-pick from upstream
-            # https://review.openocd.org/c/openocd/+/6888
-            # https://review.openocd.org/c/openocd/+/7005
-            # arm semihosting_basedir $_SEMIHOST_BASEDIR
-        }
-    }
-}
-$_TARGETNAME configure -event gdb-attach {
-    halt 1000
-    # by default mask interrupts while stepping
-    riscv set_maskisr steponly
-}
-
-gdb_breakpoint_override hard
-
-riscv set_reset_timeout_sec 2
-riscv set_command_timeout_sec 5
-riscv set_mem_access sysbus progbuf abstract
-riscv set_ebreakm on
-riscv set_ebreaks on
-riscv set_ebreaku on
+create_esp_target $_ESP_ARCH

--- a/tcl/target/esp32c3.cfg
+++ b/tcl/target/esp32c3.cfg
@@ -1,30 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The ESP32-C3 only supports JTAG.
-transport select jtag
 
-# Source the ESP common configuration file
+# Source the ESP common configuration file.
 source [find target/esp_common.cfg]
 
-if { [info exists CHIPNAME] } {
-	set _CHIPNAME $CHIPNAME
-} else {
-	set _CHIPNAME esp32c3
-}
+# Target specific global variables
+set _CHIPNAME 					"riscv"
+set _CPUTAPID 					0x00005c25
+set _ESP_ARCH					"riscv"
+set _ONLYCPU					1
+set _ESP_SMP_TARGET				0
+set _ESP_SMP_BREAK 				0
+set _ESP_EFUSE_MAC_ADDR_REG  	0x60008844
 
-if { [info exists CPUTAPID] } {
-	set _CPUTAPID $CPUTAPID
-} else {
-	set _CPUTAPID 0x00005c25
-}
-
-set _TARGETNAME $_CHIPNAME
-set _CPUNAME cpu
-set _TAPNAME $_CHIPNAME.$_CPUNAME
-
-jtag newtap $_CHIPNAME $_CPUNAME -irlen 5 -expected-id $_CPUTAPID
-
-proc esp32c3_wdt_disable { } {
+# Target specific functions should be implemented for each riscv chips.
+proc riscv_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -46,7 +36,9 @@ proc esp32c3_wdt_disable { } {
 
 # This is almost identical with the esp32c2_soc_reset.
 # Will be refactored with the other common settings.
-proc esp32c3_soc_reset { } {
+proc riscv_soc_reset { } {
+	global _RISCV_DMCONTROL
+
     # This procedure does "digital system reset", i.e. resets
     # all the peripherals except for the RTC block.
     # It is called from reset-assert-post target event callback,
@@ -54,7 +46,7 @@ proc esp32c3_soc_reset { } {
     # Since we need the hart to to execute a write to RTC_CNTL_SW_SYS_RST,
     # temporarily take it out of reset. Save the dmcontrol state before
     # doing so.
-    riscv dmi_write 0x10 0x80000001
+    riscv dmi_write $_RISCV_DMCONTROL 	0x80000001
     # Trigger the reset
     mww 0x60008000 0x9c00a000
     # Workaround for stuck in cpu start during calibration.
@@ -64,50 +56,26 @@ proc esp32c3_soc_reset { } {
     sleep 10
     poll
     # Disable the watchdogs again
-    esp32c3_wdt_disable
+    riscv_wdt_disable
 
     # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
     # We will clean allhalted state by resuming the core.
-    riscv dmi_write 0x10 0x40000001
+    riscv dmi_write $_RISCV_DMCONTROL 	0x40000001
 
     # Put the hart back into reset state. Note that we need to keep haltreq set.
-    riscv dmi_write 0x10 0x80000003
+    riscv dmi_write $_RISCV_DMCONTROL 	0x80000003
 }
 
-if { $_RTOS == "none" } {
-    target create $_TARGETNAME riscv -chain-position $_TAPNAME
-} else {
-    target create $_TARGETNAME riscv -chain-position $_TAPNAME -rtos $_RTOS
-}
-
-$_TARGETNAME configure -event reset-assert-post { esp32c3_soc_reset }
-$_TARGETNAME configure -event halted {
-    esp32c3_wdt_disable
-}
-$_TARGETNAME configure -event examine-end {
-    # Need this to handle 'apptrace init' syscall correctly because semihosting is not enabled by default
-    arm semihosting enable
-    arm semihosting_resexit enable
-    if { [info exists _SEMIHOST_BASEDIR] } {
-        if { $_SEMIHOST_BASEDIR != "" } {
-            # TODO: cherry-pick from upstream
-            # https://review.openocd.org/c/openocd/+/6888
-            # https://review.openocd.org/c/openocd/+/7005
-            # arm semihosting_basedir $_SEMIHOST_BASEDIR
-        }
+proc riscv_memprot_is_enabled { } {
+    # IRAM0 PMS lock, SENSITIVE_CORE_X_IRAM0_PMS_CONSTRAIN_0_REG
+    if { [get_mmr_bit 0x600C10A8 0] != 0 } {
+        return 1
     }
-}
-$_TARGETNAME configure -event gdb-attach {
-    halt 1000
-    # by default mask interrupts while stepping
-    riscv set_maskisr steponly
+    # DRAM0 PMS lock, SENSITIVE_CORE_X_DRAM0_PMS_CONSTRAIN_0_REG
+    if { [get_mmr_bit 0x600C10C0 0] != 0 } {
+        return 1
+    }
+    return 0
 }
 
-gdb_breakpoint_override hard
-
-riscv set_reset_timeout_sec 2
-riscv set_command_timeout_sec 5
-riscv set_mem_access sysbus progbuf abstract
-riscv set_ebreakm on
-riscv set_ebreaks on
-riscv set_ebreaku on
+create_esp_target $_ESP_ARCH

--- a/tcl/target/esp32c6.cfg
+++ b/tcl/target/esp32c6.cfg
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+# Source the ESP common configuration file.
+source [find target/esp_common.cfg]
+
+# Target specific global variables
+set _CHIPNAME 					"riscv"
+set _CPUTAPID 					0x0000dc25
+set _ESP_ARCH					"riscv"
+set _ONLYCPU					1
+set _ESP_SMP_TARGET				0
+set _ESP_SMP_BREAK 				0
+set _ESP_EFUSE_MAC_ADDR_REG  	0x600B0844
+
+# Target specific functions should be implemented for each riscv chips.
+proc riscv_wdt_disable { } {
+    # Halt event can occur during config phase (before "init" is done).
+    # Ignore it since mww commands don't work at that time.
+    if { [string compare [command mode] config] == 0 } {
+        return
+    }
+
+    # Timer Group 0 & 1 WDTs
+    mww 0x60008064 0x50D83AA1
+    mww 0x60008048 0
+    mww 0x60009064 0x50D83AA1
+    mww 0x60009048 0
+    # LP_WDT_RTC
+    mww 0x600b1c18 0x50D83AA1
+    mww 0x600B1C00 0
+    # LP_WDT_SWD
+    mww 0x600b1c20 0x50D83AA1
+    mww 0x600b1c1c 0x40000000
+}
+
+proc riscv_soc_reset { } {
+	global _RISCV_DMCONTROL _RISCV_SB_CS _RISCV_SB_ADDR0 _RISCV_SB_DATA0
+
+    riscv dmi_write $_RISCV_DMCONTROL 		0x80000001
+    riscv dmi_write $_RISCV_SB_CS 			0x48000
+    riscv dmi_write $_RISCV_SB_ADDR0 		0x600b1034
+    riscv dmi_write $_RISCV_SB_DATA0		0x80000000
+    # clear dmactive to clear sbbusy otherwise debug module gets stuck
+    riscv dmi_write $_RISCV_DMCONTROL 		0
+
+    riscv dmi_write $_RISCV_SB_CS 			0x48000
+    riscv dmi_write $_RISCV_SB_ADDR0 		0x600b1038
+    riscv dmi_write $_RISCV_SB_DATA0 		0x10000000
+
+    # clear dmactive to clear sbbusy otherwise debug module gets stuck
+    riscv dmi_write $_RISCV_DMCONTROL 		0
+    riscv dmi_write $_RISCV_DMCONTROL 		0x40000001
+    # Here debugger reads dmstatus as 0xc03a2
+
+    # Wait for the reset to happen
+    sleep 10
+    poll
+    # Here debugger reads dmstatus as 0x3a2
+
+    # Disable the watchdogs again
+    riscv_wdt_disable
+
+    # Here debugger reads anyhalted and allhalted bits as set (0x3a2)
+    # We will clean allhalted state by resuming the core.
+    riscv dmi_write $_RISCV_DMCONTROL 		0x40000001
+
+    # Put the hart back into reset state. Note that we need to keep haltreq set.
+    riscv dmi_write $_RISCV_DMCONTROL 		0x80000003
+}
+
+proc riscv_memprot_is_enabled { } {
+	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
+
+	# If IRAM/DRAM split is enabled TOR address match mode is used.
+    # If IRAM/DRAM split is disabled NAPOT mode is used.
+	# In order to determine if the IRAM/DRAM regions are protected against RWX/RW,
+	# it is necessary to first read the mode and then apply the appropriate method for checking.
+	# We can understand the mode reading pmp5cfg in pmpcfg1 register.
+	# If it is none we know that pmp6cfg and pmp7cfg is in TOR mode.
+
+	# Read pmpcfg1 and extract into 8-bit variables.
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203a1
+	set pmpcfg1 [riscv dmi_read $_RISCV_ABS_DATA0]
+
+	set pmp5cfg [expr {($pmpcfg1 >> (8 * 1)) & 0xFF}]
+	set pmp6cfg [expr {($pmpcfg1 >> (8 * 2)) & 0xFF}]
+	set pmp7cfg [expr {($pmpcfg1 >> (8 * 3)) & 0xFF}]
+
+	set IRAM_LOW 	0x40800000
+	set IRAM_HIGH 	0x40880000
+	set DRAM_LOW 	0x40800000
+	set DRAM_HIGH 	0x40880000
+	set PMP_RWX     0x07
+	set PMP_RW     	0x03
+	set PMP_A		[expr {($pmp5cfg >> 3) & 0x03}]
+
+	if {$PMP_A == 0} {
+		# TOR mode used to protect valid address space.
+
+		# Read PMPADDR 5-7
+		riscv dmi_write $_RISCV_ABS_CMD 0x2203b5
+		set pmpaddr5 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+		riscv dmi_write $_RISCV_ABS_CMD 0x2203b6
+		set pmpaddr6 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+		riscv dmi_write $_RISCV_ABS_CMD 0x2203b7
+		set pmpaddr7 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+
+		# The lock bit remains unset during the execution of the 2nd stage bootloader.
+		# Thus we do not perform a lock bit check for IRAM and DRAM regions.
+
+		# Check OpenOCD can write and execute from IRAM.
+		if {$pmpaddr5 >= $IRAM_LOW && $pmpaddr6 <= $IRAM_HIGH} {
+			if {($pmp5cfg & $PMP_RWX) != 0 || ($pmp6cfg & $PMP_RWX) != $PMP_RWX} {
+				return 1
+			}
+		}
+
+		# Check OpenOCD can read/write  entire DRAM region.
+		if {$pmpaddr7 >= $DRAM_LOW && $pmpaddr7 <= $DRAM_HIGH} {
+			if {($pmp7cfg & $PMP_RW) != $PMP_RW} {
+				return 1
+			}
+		}
+	} elseif {$PMP_A == 3} {
+		# NAPOT mode used to protect valid address space.
+
+		# Read PMPADDR 5
+		riscv dmi_write $_RISCV_ABS_CMD 0x2203b5
+		set pmpaddr5 [expr {[riscv dmi_read $_RISCV_ABS_DATA0]}]
+
+		# Expected value written to the pmpaddr5
+		set pmpaddr_napot [expr {($IRAM_LOW | (($IRAM_HIGH - $IRAM_LOW - 1) >> 1)) >> 2}]
+		if {($pmpaddr_napot != $pmpaddr5) ||  ($pmp5cfg & $PMP_RWX) != $PMP_RWX} {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+create_esp_target $_ESP_ARCH

--- a/tcl/target/esp32h2.cfg
+++ b/tcl/target/esp32h2.cfg
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+# Source the ESP common configuration file.
+source [find target/esp_common.cfg]
+
+# Target specific global variables
+set _CHIPNAME 					"riscv"
+set _CPUTAPID 					0x00010c25
+set _ESP_ARCH					"riscv"
+set _ONLYCPU					1
+set _ESP_SMP_TARGET				0
+set _ESP_SMP_BREAK 				0
+set _ESP_EFUSE_MAC_ADDR_REG  	0x600B0844
+
+# Target specific functions should be implemented for each riscv chips.
+proc riscv_wdt_disable { } {
+    # Halt event can occur during config phase (before "init" is done).
+    # Ignore it since mww commands don't work at that time.
+    if { [string compare [command mode] config] == 0 } {
+        return
+    }
+
+    # Timer Group 0 & 1 WDTs
+    mww 0x60009064 0x50D83AA1
+    mww 0x60009048 0
+    mww 0x6000A064 0x50D83AA1
+    mww 0x6000A048 0
+    # WDT_RTC
+    #mww 0x600b1c18 0x50D83AA1
+    #mww 0x600B1C00 0
+    # WDT_SWD
+    #mww 0x600b1c20 0x8F1D312A
+    #mww 0x600b1c1c 0x84B00000
+}
+
+proc riscv_soc_reset { } {
+	global _RISCV_DMCONTROL _RISCV_SB_CS _RISCV_SB_ADDR0 _RISCV_SB_DATA0
+
+    riscv dmi_write $_RISCV_DMCONTROL 	0x80000001
+    riscv dmi_write $_RISCV_SB_CS 		0x48000
+    riscv dmi_write $_RISCV_SB_ADDR0 	0x600b1034
+    riscv dmi_write $_RISCV_SB_DATA0 	0x80000000
+    # clear dmactive to clear sbbusy otherwise debug module gets stuck
+    riscv dmi_write $_RISCV_DMCONTROL 	0
+
+    riscv dmi_write $_RISCV_SB_CS 		0x48000
+    riscv dmi_write $_RISCV_SB_ADDR0 	0x600b1038
+    riscv dmi_write $_RISCV_SB_DATA0 	0x10000000
+
+    # clear dmactive to clear sbbusy otherwise debug module gets stuck
+    riscv dmi_write $_RISCV_DMCONTROL 	0
+    riscv dmi_write $_RISCV_DMCONTROL 	0x40000001
+    # Here debugger reads dmstatus as 0xc03a2
+
+    # Wait for the reset to happen
+    sleep 10
+    poll
+    # Here debugger reads dmstatus as 0x3a2
+
+    # Disable the watchdogs again
+    riscv_wdt_disable
+
+    # Here debugger reads anyhalted and allhalted bits as set (0x3a2)
+    # We will clean allhalted state by resuming the core.
+    riscv dmi_write $_RISCV_DMCONTROL 	0x40000001
+
+    # Put the hart back into reset state. Note that we need to keep haltreq set.
+    riscv dmi_write $_RISCV_DMCONTROL 	0x80000003
+}
+
+proc riscv_memprot_is_enabled { } {
+	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
+	# If IRAM/DRAM split is enabled, PMPADDR 5-6 will cover valid IRAM region and PMPADDR 7 will cover valid DRAM region
+	# Only TOR mode is used for IRAM and DRAM protections.
+
+	# Read pmpcfg1 and extract into 8-bit variables.
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203a1
+	set pmpcfg1 [riscv dmi_read $_RISCV_ABS_DATA0]
+
+	set pmp5cfg [expr {($pmpcfg1 >> (8 * 1)) & 0xFF}]
+	set pmp6cfg [expr {($pmpcfg1 >> (8 * 2)) & 0xFF}]
+	set pmp7cfg [expr {($pmpcfg1 >> (8 * 3)) & 0xFF}]
+
+	# Read PMPADDR 5-7
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b5
+	set pmpaddr5 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b6
+	set pmpaddr6 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+	riscv dmi_write $_RISCV_ABS_CMD 0x2203b7
+	set pmpaddr7 [expr {[riscv dmi_read $_RISCV_ABS_DATA0] << 2}]
+
+	set IRAM_LOW 	0x40800000
+	set IRAM_HIGH 	0x40850000
+	set DRAM_LOW 	0x40800000
+	set DRAM_HIGH 	0x40850000
+
+	set PMP_RWX     0x07
+	set PMP_RW     	0x03
+
+	# The lock bit remains unset during the execution of the 2nd stage bootloader.
+	# Thus, we do not perform a lock bit check for IRAM and DRAM regions.
+
+	# Check OpenOCD can write and execute from IRAM.
+	if {$pmpaddr5 >= $IRAM_LOW && $pmpaddr6 <= $IRAM_HIGH} {
+		if {($pmp5cfg & $PMP_RWX) != 0 || ($pmp6cfg & $PMP_RWX) != $PMP_RWX} {
+			return 1
+		}
+	}
+
+	# Check OpenOCD can read/write  entire DRAM region.
+	# If IRAM/DRAM split is disabled, pmpaddr7 will be zero, checking only IRAM region is enough.
+	if {$pmpaddr7 != 0 && $pmpaddr7 >= $DRAM_LOW && $pmpaddr7 <= $DRAM_HIGH} {
+		if {($pmp7cfg & $PMP_RW) != $PMP_RW} {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+create_esp_target $_ESP_ARCH

--- a/tcl/target/esp32s2.cfg
+++ b/tcl/target/esp32s2.cfg
@@ -1,32 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The ESP32-S2 only supports JTAG.
-transport select jtag
 
-set CPU_MAX_ADDRESS 0xFFFFFFFF
-source [find bitsbytes.tcl]
-source [find memory.tcl]
-source [find mmr_helpers.tcl]
-# Source the ESP common configuration file
+# Source the ESP common configuration file.
 source [find target/esp_common.cfg]
 
-if { [info exists CHIPNAME] } {
-	set _CHIPNAME $CHIPNAME
-} else {
-	set _CHIPNAME esp32s2
-}
-
-if { [info exists CPUTAPID] } {
-	set _CPUTAPID $CPUTAPID
-} else {
-	set _CPUTAPID 0x120034e5
-}
-
-set _TARGETNAME $_CHIPNAME
-set _CPUNAME cpu
-set _TAPNAME $_CHIPNAME.$_CPUNAME
-
-jtag newtap $_CHIPNAME $_CPUNAME -irlen 5 -expected-id $_CPUTAPID
+# Target specific global variables
+set _CHIPNAME 					"esp32s2"
+set _CPUTAPID 					0x120034e5
+set _ESP_ARCH					"xtensa"
+set _ONLYCPU					1
+set _ESP_SMP_TARGET				0
+set _ESP_SMP_BREAK 				1
+set _ESP_EFUSE_MAC_ADDR_REG  	0x3f41A004
 
 proc esp32s2_memprot_is_enabled { } {
 	# IRAM0, DPORT_PMS_PRO_IRAM0_0_REG
@@ -48,33 +33,10 @@ proc esp32s2_memprot_is_enabled { } {
 	return 0
 }
 
-target create $_TARGETNAME esp32s2 -endian little -chain-position $_TAPNAME
-
-$_TARGETNAME configure -event gdb-attach {
-	# necessary to auto-probe flash bank when GDB is connected and generate proper memory map
-	halt 1000
-	if { [esp32s2_memprot_is_enabled] } {
-		# 'reset halt' to disable memory protection and allow flasher to work correctly
-		echo "Memory protection is enabled. Reset target to disable it..."
-		reset halt
-	}
+proc esp32s2_soc_reset { } {
+	soft_reset_halt
 }
 
-xtensa maskisr on
-
-$_TARGETNAME configure -event examine-end {
-	# Need to enable to set 'semihosting_basedir'
-	arm semihosting enable
-	arm semihosting_resexit enable
-	if { [info exists _SEMIHOST_BASEDIR] } {
-		if { $_SEMIHOST_BASEDIR != "" } {
-			arm semihosting_basedir $_SEMIHOST_BASEDIR
-		}
-	}
-}
-
-$_TARGETNAME configure -event reset-assert-post { soft_reset_halt }
-
-gdb_breakpoint_override hard
+create_esp_target $_ESP_ARCH
 
 source [find target/xtensa-core-esp32s2.cfg]

--- a/tcl/target/esp32s3.cfg
+++ b/tcl/target/esp32s3.cfg
@@ -1,44 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The ESP32-S3 only supports JTAG.
-transport select jtag
 
-set CPU_MAX_ADDRESS 0xFFFFFFFF
-source [find bitsbytes.tcl]
-source [find memory.tcl]
-source [find mmr_helpers.tcl]
-# Source the ESP common configuration file
+# Source the ESP common configuration file.
 source [find target/esp_common.cfg]
 
-
-if { [info exists CHIPNAME] } {
-	set _CHIPNAME $CHIPNAME
-} else {
-	set _CHIPNAME esp32s3
-}
-
-if { [info exists CPUTAPID] } {
-	set _CPUTAPID $CPUTAPID
-} else {
-	set _CPUTAPID 0x120034e5
-}
+# Target specific global variables
+set _CHIPNAME 					"esp32s3"
+set _CPUTAPID 					0x120034e5
+set _ESP_ARCH 					"xtensa"
+set _ONLYCPU					3
+set _ESP_SMP_TARGET				1
+set _ESP_SMP_BREAK 				1
+set _ESP_EFUSE_MAC_ADDR_REG  	0x60007044
 
 if { [info exists ESP32_S3_ONLYCPU] } {
 	set _ONLYCPU $ESP32_S3_ONLYCPU
-} else {
-	set _ONLYCPU 2
-}
-
-set _CPU0NAME cpu0
-set _CPU1NAME cpu1
-set _TARGETNAME_0 $_CHIPNAME.$_CPU0NAME
-set _TARGETNAME_1 $_CHIPNAME.$_CPU1NAME
-
-jtag newtap $_CHIPNAME $_CPU0NAME -irlen 5 -expected-id $_CPUTAPID
-if { $_ONLYCPU != 1 } {
-	jtag newtap $_CHIPNAME $_CPU1NAME -irlen 5 -expected-id $_CPUTAPID
-} else {
-	jtag newtap $_CHIPNAME $_CPU1NAME -irlen 5 -disable -expected-id $_CPUTAPID
 }
 
 proc esp32s3_memprot_is_enabled { } {
@@ -89,66 +65,10 @@ proc esp32s3_memprot_is_enabled { } {
 	return 0
 }
 
-# PRO-CPU
-target create $_TARGETNAME_0 $_CHIPNAME -endian little -chain-position $_TARGETNAME_0 -coreid 0
-# APP-CPU
-if { $_ONLYCPU != 1 } {
-	target create $_TARGETNAME_1 $_CHIPNAME -endian little -chain-position $_TARGETNAME_1 -coreid 1
-	target smp $_TARGETNAME_0 $_TARGETNAME_1
+proc esp32s3_soc_reset { } {
+	soft_reset_halt
 }
 
-$_TARGETNAME_0 xtensa maskisr on
-$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
-$_TARGETNAME_0 configure -event examine-end {
-	# Need to enable to set 'semihosting_basedir'
-	arm semihosting enable
-	arm semihosting_resexit enable
-	if { [info exists _SEMIHOST_BASEDIR] } {
-		if { $_SEMIHOST_BASEDIR != "" } {
-			arm semihosting_basedir $_SEMIHOST_BASEDIR
-		}
-	}
-}
-
-if { $_ONLYCPU != 1 } {
-	$_TARGETNAME_1 configure -event examine-end {
-		# Need to enable to set 'semihosting_basedir'
-		arm semihosting enable
-		arm semihosting_resexit enable
-		if { [info exists _SEMIHOST_BASEDIR] } {
-			if { $_SEMIHOST_BASEDIR != "" } {
-				arm semihosting_basedir $_SEMIHOST_BASEDIR
-			}
-		}
-	}
-}
-
-$_TARGETNAME_0 configure -event gdb-attach {
-	$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
-	# necessary to auto-probe flash bank when GDB is connected and generate proper memory map
-	halt 1000
-	if { [esp32s3_memprot_is_enabled] } {
-		# 'reset halt' to disable memory protection and allow flasher to work correctly
-		echo "Memory protection is enabled. Reset target to disable it..."
-		reset halt
-	}
-}
-$_TARGETNAME_0 configure -event reset-assert-post { soft_reset_halt }
-
-if { $_ONLYCPU != 1 } {
-	$_TARGETNAME_1 configure -event gdb-attach {
-		$_TARGETNAME_1 xtensa smpbreak BreakIn BreakOut
-		# necessary to auto-probe flash bank when GDB is connected
-		halt 1000
-		if { [esp32s3_memprot_is_enabled] } {
-			# 'reset halt' to disable memory protection and allow flasher to work correctly
-			echo "Memory protection is enabled. Reset target to disable it..."
-			reset halt
-		}
-	}
-	$_TARGETNAME_1 configure -event reset-assert-post { soft_reset_halt }
-}
-
-gdb_breakpoint_override hard
+create_esp_target $_ESP_ARCH
 
 source [find target/xtensa-core-esp32s3.cfg]

--- a/tcl/target/esp_common.cfg
+++ b/tcl/target/esp_common.cfg
@@ -1,16 +1,189 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
+
+set CPU_MAX_ADDRESS 0xFFFFFFFF
+source [find bitsbytes.tcl]
+source [find memory.tcl]
+source [find mmr_helpers.tcl]
+
 # Common ESP chips definitions
 
+# Espressif supports only NuttX in the upstream.
+# FreeRTOS support is not upstreamed yet.
+set _RTOS "hwthread"
 if { [info exists ESP_RTOS] } {
 	set _RTOS "$ESP_RTOS"
-} else {
-	set _RTOS "FreeRTOS"
 }
 
+# by default current dir (when OOCD has been started)
+set _SEMIHOST_BASEDIR "."
 if { [info exists ESP_SEMIHOST_BASEDIR] } {
 	set _SEMIHOST_BASEDIR $ESP_SEMIHOST_BASEDIR
-} else {
-	# by default current dir (when OOCD has been started)
-	set _SEMIHOST_BASEDIR "."
+}
+
+proc set_esp_common_variables { } {
+	global _CHIPNAME _ONLYCPU _ESP_SMP_TARGET
+	global _CPUNAME_0 _CPUNAME_1 _TARGETNAME_0 _TARGETNAME_1 _TAPNAME_0 _TAPNAME_1
+	global _ESP_WDT_DISABLE _ESP_SOC_RESET _ESP_MEMPROT_IS_ENABLED
+
+	# For now we support dual core at most.
+	if { $_ONLYCPU == 1 && $_ESP_SMP_TARGET == 0} {
+		set _TARGETNAME_0 				$_CHIPNAME
+		set _CPUNAME_0					cpu
+		set _TAPNAME_0 					$_CHIPNAME.$_CPUNAME_0
+	} else {
+		set _CPUNAME_0 					cpu0
+		set _CPUNAME_1 					cpu1
+		set _TARGETNAME_0 				$_CHIPNAME.$_CPUNAME_0
+		set _TARGETNAME_1 				$_CHIPNAME.$_CPUNAME_1
+		set _TAPNAME_0 					$_TARGETNAME_0
+		set _TAPNAME_1 					$_TARGETNAME_1
+	}
+
+	set _ESP_WDT_DISABLE 			"${_CHIPNAME}_wdt_disable"
+	set _ESP_SOC_RESET 				"${_CHIPNAME}_soc_reset"
+	set _ESP_MEMPROT_IS_ENABLED 	"${_CHIPNAME}_memprot_is_enabled"
+}
+
+proc create_esp_jtag { } {
+	global _CHIPNAME _CPUNAME_0 _CPUNAME_1 _CPUTAPID _ONLYCPU
+	jtag newtap $_CHIPNAME $_CPUNAME_0 -irlen 5 -expected-id $_CPUTAPID
+	if { $_ONLYCPU != 1 } {
+		jtag newtap $_CHIPNAME $_CPUNAME_1 -irlen 5 -expected-id $_CPUTAPID
+	} elseif [info exists _CPUNAME_1] {
+		jtag newtap $_CHIPNAME $_CPUNAME_1 -irlen 5 -disable -expected-id $_CPUTAPID
+	}
+}
+
+proc create_openocd_targets  { } {
+	global _TARGETNAME_0 _TARGETNAME_1 _TAPNAME_0 _TAPNAME_1 _RTOS _CHIPNAME _ONLYCPU
+
+	target create $_TARGETNAME_0 $_CHIPNAME -chain-position $_TAPNAME_0 -coreid 0 -rtos $_RTOS
+	if { $_ONLYCPU != 1 } {
+		target create $_TARGETNAME_1 $_CHIPNAME -chain-position $_TAPNAME_1 -coreid 1 -rtos $_RTOS
+		target smp $_TARGETNAME_0 $_TARGETNAME_1
+	}
+}
+
+proc create_esp_target { ARCH } {
+	set_esp_common_variables
+	create_esp_jtag
+	create_openocd_targets
+	configure_openocd_events
+
+	if { $ARCH == "xtensa"} {
+		configure_esp_xtensa_default_settings
+	} else {
+		# riscv targets are not upstreamed yet.
+		# they can be found at the official Espressif fork.
+	}
+}
+
+#################### Set event handlers and default settings  ####################
+
+proc configure_event_examine_end { } {
+	global _TARGETNAME_0 _TARGETNAME_1 _ONLYCPU
+
+	$_TARGETNAME_0 configure -event examine-end {
+		# Need to enable to set 'semihosting_basedir'
+		arm semihosting enable
+		arm semihosting_resexit enable
+		if { [info exists _SEMIHOST_BASEDIR] } {
+			if { $_SEMIHOST_BASEDIR != "" } {
+				arm semihosting_basedir $_SEMIHOST_BASEDIR
+			}
+		}
+	}
+
+	if { $_ONLYCPU != 1 } {
+		$_TARGETNAME_1 configure -event examine-end {
+			# Need to enable to set 'semihosting_basedir'
+			arm semihosting enable
+			arm semihosting_resexit enable
+			if { [info exists _SEMIHOST_BASEDIR] } {
+				if { $_SEMIHOST_BASEDIR != "" } {
+					arm semihosting_basedir $_SEMIHOST_BASEDIR
+				}
+			}
+		}
+	}
+}
+
+proc configure_event_reset_assert_post { } {
+	global _TARGETNAME_0 _TARGETNAME_1 _ONLYCPU
+
+	$_TARGETNAME_0 configure -event reset-assert-post {
+		global _ESP_SOC_RESET
+		$_ESP_SOC_RESET
+	}
+
+	if { $_ONLYCPU != 1 } {
+		$_TARGETNAME_1 configure -event reset-assert-post {
+			global _ESP_SOC_RESET
+			$_ESP_SOC_RESET
+		}
+	}
+}
+
+proc configure_event_halted { } {
+	global _TARGETNAME_0
+
+	$_TARGETNAME_0 configure -event halted {
+		global _ESP_WDT_DISABLE
+	    $_ESP_WDT_DISABLE
+	    esp halted_event_handler
+	}
+}
+
+proc configure_event_gdb_attach { } {
+	global _TARGETNAME_0 _TARGETNAME_1 _ONLYCPU
+
+	$_TARGETNAME_0 configure -event gdb-attach {
+		if { $_ESP_SMP_BREAK != 0 } {
+			$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
+		}
+		# necessary to auto-probe flash bank when GDB is connected and generate proper memory map
+		halt 1000
+		if { [$_ESP_MEMPROT_IS_ENABLED] } {
+			# 'reset halt' to disable memory protection and allow flasher to work correctly
+			echo "Memory protection is enabled. Reset target to disable it..."
+			reset halt
+		}
+	}
+
+	if { $_ONLYCPU != 1 } {
+		$_TARGETNAME_1 configure -event gdb-attach {
+			if { $_ESP_SMP_BREAK != 0 } {
+				$_TARGETNAME_1 xtensa smpbreak BreakIn BreakOut
+			}
+			# necessary to auto-probe flash bank when GDB is connected
+			halt 1000
+			if { [$_ESP_MEMPROT_IS_ENABLED] } {
+				# 'reset halt' to disable memory protection and allow flasher to work correctly
+				echo "Memory protection is enabled. Reset target to disable it..."
+				reset halt
+			}
+		}
+	}
+}
+
+proc configure_openocd_events { } {
+	configure_event_examine_end
+	configure_event_reset_assert_post
+	configure_event_gdb_attach
+}
+
+proc configure_esp_xtensa_default_settings { } {
+	global _TARGETNAME_0 _ESP_SMP_BREAK _FLASH_VOLTAGE _CHIPNAME
+
+	$_TARGETNAME_0 xtensa maskisr on
+	if { $_ESP_SMP_BREAK != 0 } {
+		$_TARGETNAME_0 xtensa smpbreak BreakIn BreakOut
+	}
+
+	gdb_breakpoint_override hard
+
+	if { [info exists _FLASH_VOLTAGE] } {
+		$_TARGETNAME_0 $_CHIPNAME flashbootstrap $_FLASH_VOLTAGE
+	}
 }

--- a/tcl/target/esp_common.cfg
+++ b/tcl/target/esp_common.cfg
@@ -6,6 +6,14 @@ source [find bitsbytes.tcl]
 source [find memory.tcl]
 source [find mmr_helpers.tcl]
 
+# Riscv Debug Module Registers which are used around esp configuration files.
+set _RISCV_ABS_DATA0	0x04
+set _RISCV_DMCONTROL	0x10
+set _RISCV_ABS_CMD		0x17
+set _RISCV_SB_CS		0x38
+set _RISCV_SB_ADDR0		0x39
+set _RISCV_SB_DATA0		0x3C
+
 # Common ESP chips definitions
 
 # Espressif supports only NuttX in the upstream.
@@ -69,13 +77,12 @@ proc create_esp_target { ARCH } {
 	set_esp_common_variables
 	create_esp_jtag
 	create_openocd_targets
-	configure_openocd_events
+	configure_openocd_events $ARCH
 
 	if { $ARCH == "xtensa"} {
 		configure_esp_xtensa_default_settings
 	} else {
-		# riscv targets are not upstreamed yet.
-		# they can be found at the official Espressif fork.
+		configure_esp_riscv_default_settings
 	}
 }
 
@@ -131,7 +138,6 @@ proc configure_event_halted { } {
 	$_TARGETNAME_0 configure -event halted {
 		global _ESP_WDT_DISABLE
 	    $_ESP_WDT_DISABLE
-	    esp halted_event_handler
 	}
 }
 
@@ -167,10 +173,23 @@ proc configure_event_gdb_attach { } {
 	}
 }
 
-proc configure_openocd_events { } {
+proc configure_openocd_events { ARCH } {
+	if { $ARCH == "riscv" } {
+		configure_event_halted
+	}
 	configure_event_examine_end
 	configure_event_reset_assert_post
 	configure_event_gdb_attach
+}
+
+proc configure_esp_riscv_default_settings { } {
+	gdb_breakpoint_override hard
+	riscv set_reset_timeout_sec 2
+	riscv set_command_timeout_sec 5
+	riscv set_mem_access sysbus progbuf abstract
+	riscv set_ebreakm on
+	riscv set_ebreaks on
+	riscv set_ebreaku on
 }
 
 proc configure_esp_xtensa_default_settings { } {


### PR DESCRIPTION
Below commits cherry picked  from the upstream.

```
c07c91a14 tcl/board: add esp32s3-builtin.cfg file
c5a48f9ed tcl/interface: add Espressif builtin usb_jtag config file.
be5f326e0 tcl/target: update esp32s3.cfg to reference shared functions in the esp_common.cfg
e5e44d0f6 tcl/target: update esp32s2.cfg to reference shared functions in the esp_common.cfg
5a458e7d4 tcl/target: update esp32.cfg to reference shared functions in the esp_common.cfg
5a615ad10 tcl/target: move Espressif shared functions to esp_common.cfg
```

Based on these commits, esp32c3 and esp32c2 are updated.
Additionally, related to new Espressif riscv chip config files are added. ( esp32c6 and esp32h2)