### PR TITLE
github/ci Make Spike64-2 tests run regardless of Spike32 tests result

### DIFF
--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -100,7 +100,8 @@ jobs:
           git checkout "$RISCV_TESTS_REV"
           git submodule update --init --recursive
 
-      - name: Run Tests
+      - name: Run Spike32 Tests
+        id: spike32-tests
         run: |
           cd riscv-tests/debug
           ./gdbserver.py targets/RISC-V/spike32.py --print-failures \
@@ -108,6 +109,11 @@ jobs:
               --gdb /opt/riscv/toolchain/bin/riscv-none-elf-gdb \
               --sim_cmd /opt/riscv/spike/bin/spike \
               --server_cmd $GITHUB_WORKSPACE/src/openocd
+
+      - name: Run Spike64-2 Tests
+        if: success() || steps.spike32-tests.conclusion == 'failure'
+        run: |
+          cd riscv-tests/debug
           ./gdbserver.py targets/RISC-V/spike64-2.py --print-failures \
               --gcc /opt/riscv/toolchain/bin/riscv-none-elf-gcc \
               --gdb /opt/riscv/toolchain/bin/riscv-none-elf-gdb \


### PR DESCRIPTION
This patch separates the Spike tests into their own jobs and makes them run regardless of the results of the previous test. Previously, if Spike32 tests failed, Spike64-2 tests did not even run. This can be an issue if new tests are added in the riscv-tests repository which are not yet passing on riscv-openocd.

Change-Id: I0bdaee5fbbba5582babab40f176cfab49660c246