### PR TITLE
target/riscv: OpenOCD fails with assert during running "reset" command

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -515,7 +515,10 @@ static dmi_status_t dmi_scan(struct target *target, uint32_t *address_in,
 	memset(in, 0, num_bytes);
 	memset(out, 0, num_bytes);
 
-	assert(info->abits != 0);
+	if (info->abits == 0) {
+		LOG_TARGET_ERROR(target, "Can't access DMI because addrbits=0.");
+		return DMI_STATUS_FAILED;
+	}
 
 	buf_set_u32(out, DTM_DMI_OP_OFFSET, DTM_DMI_OP_LENGTH, op);
 	buf_set_u32(out, DTM_DMI_DATA_OFFSET, DTM_DMI_DATA_LENGTH, data_out);


### PR DESCRIPTION
OpenOCD fails in the presence of inactive/unresponsive cores

I faced with case when inactive core returns 0 while reading dtmcontrol. This leads to failure on assert: "addrbits != 0" in "dbus_scan".

Also change "read_bits","poll_target" funcs to avoid a lot lines in logs

Change-Id: If852126755317789602b7372c5c5732183fff6c5