### PR TITLE
target/riscv: Add support for Sv57 (and Sv57x4) translation mode

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -221,7 +221,33 @@ static const virt2phys_info_t sv48x4 = {
 	.pte_ppn_shift = {10, 19, 28, 37},
 	.pte_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ffff},
 	.pa_ppn_shift = {12, 21, 30, 39},
-	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x7ffff},
+	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ffff},
+};
+
+static const virt2phys_info_t sv57 = {
+	.name = "Sv57",
+	.va_bits = 57,
+	.level = 5,
+	.pte_shift = 3,
+	.vpn_shift = {12, 21, 30, 39, 48},
+	.vpn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff},
+	.pte_ppn_shift = {10, 19, 28, 37, 46},
+	.pte_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
+	.pa_ppn_shift = {12, 21, 30, 39, 48},
+	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
+};
+
+static const virt2phys_info_t sv57x4 = {
+	.name = "Sv57x4",
+	.va_bits = 59,
+	.level = 5,
+	.pte_shift = 3,
+	.vpn_shift = {12, 21, 30, 39, 48},
+	.vpn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x7ff},
+	.pte_ppn_shift = {10, 19, 28, 37, 46},
+	.pte_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
+	.pa_ppn_shift = {12, 21, 30, 39, 48},
+	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
 };
 
 static enum riscv_halt_reason riscv_halt_reason(struct target *target);
@@ -2208,6 +2234,9 @@ static int riscv_virt2phys_v(struct target *target, target_addr_t virtual, targe
 		case SATP_MODE_SV48:
 			vsatp_info = &sv48;
 			break;
+		case SATP_MODE_SV57:
+			vsatp_info = &sv57;
+			break;
 		case SATP_MODE_OFF:
 			vsatp_info = NULL;
 			break;
@@ -2229,6 +2258,9 @@ static int riscv_virt2phys_v(struct target *target, target_addr_t virtual, targe
 			break;
 		case HGATP_MODE_SV48X4:
 			hgatp_info = &sv48x4;
+			break;
+		case HGATP_MODE_SV57X4:
+			hgatp_info = &sv57x4;
 			break;
 		case HGATP_MODE_OFF:
 			hgatp_info = NULL;
@@ -2312,6 +2344,9 @@ static int riscv_virt2phys(struct target *target, target_addr_t virtual, target_
 			break;
 		case SATP_MODE_SV48:
 			satp_info = &sv48;
+			break;
+		case SATP_MODE_SV57:
+			satp_info = &sv57;
 			break;
 		case SATP_MODE_OFF:
 			LOG_TARGET_ERROR(target, "No translation or protection."

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -30,7 +30,7 @@ struct riscv_program;
 #define RISCV_HGATP_PPN(xlen)  ((xlen) == 32 ? HGATP32_PPN : HGATP64_PPN)
 #define RISCV_PGSHIFT 12
 
-#define PG_MAX_LEVEL 4
+#define PG_MAX_LEVEL 5
 
 #define RISCV_NUM_MEM_ACCESS_METHODS  3
 


### PR DESCRIPTION
Also fix Sv48x4 translation mode (riscv.c:224). According to riscv privileged specification, `pa_ppn_mask` in `sv48x4` mode should be same as in `sv48` mode.