### PR TITLE
fix crash when we try to read vector register on a running target

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2369,14 +2369,14 @@ static int riscv013_get_register_buf(struct target *target,
 	if (dm013_select_target(target) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (riscv_save_register(target, GDB_REGNO_S0) != ERROR_OK)
-		return ERROR_FAIL;
-
 	riscv_reg_t mstatus, vtype, vl;
 	unsigned int debug_vl, debug_vsew;
 
 	if (prep_for_vector_access(target, &mstatus, &vtype, &vl,
 				&debug_vl, &debug_vsew) != ERROR_OK)
+		return ERROR_FAIL;
+
+	if (riscv_save_register(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
 
 	unsigned int vnum = regno - GDB_REGNO_V0;
@@ -2424,14 +2424,14 @@ static int riscv013_set_register_buf(struct target *target,
 	if (dm013_select_target(target) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (riscv_save_register(target, GDB_REGNO_S0) != ERROR_OK)
-		return ERROR_FAIL;
-
 	riscv_reg_t mstatus, vtype, vl;
 	unsigned int debug_vl, debug_vsew;
 
 	if (prep_for_vector_access(target, &mstatus, &vtype, &vl,
 				&debug_vl, &debug_vsew) != ERROR_OK)
+		return ERROR_FAIL;
+
+	if (riscv_save_register(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
 
 	unsigned int vnum = regno - GDB_REGNO_V0;


### PR DESCRIPTION
When vector register is accessed we should try to preserve S0 only when `prep_for_vector_access` is successul. Otherwise we'll end up triggering

```
assert(target->state == TARGET_HALTED &&
             "Doesn't make sense to populate register cache on non-halted targets.");
```

Change-Id: I0e140d69faa67f8817310cf18a4db3c581013de2