### PR TITLE
target/riscv: Don't write to zero.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4718,6 +4718,9 @@ unsigned int riscv_count_harts(struct target *target)
  */
 static bool gdb_regno_cacheable(enum gdb_regno regno, bool is_write)
 {
+	if (regno == GDB_REGNO_ZERO)
+		return !is_write;
+
 	/* GPRs, FPRs, vector registers are just normal data stores. */
 	if (regno <= GDB_REGNO_XPR31 ||
 			(regno >= GDB_REGNO_FPR0 && regno <= GDB_REGNO_FPR31) ||


### PR DESCRIPTION
During a previous patch, the ignoring of writes to register zero was deleted. This patch restores it to the original.

Change-Id: Ieb028a5b2e3f691e4847713c7bc809e10726e18c