### PR TITLE
target/riscv: Don't assert in riscv013_get_register()

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4945,8 +4945,11 @@ int riscv_get_register(struct target *target, riscv_reg_t *value,
  */
 int riscv_save_register(struct target *target, enum gdb_regno regid)
 {
-	assert(target->state == TARGET_HALTED &&
-			"Doesn't make sense to populate register cache on non-halted targets.");
+	if (target->state != TARGET_HALTED) {
+		LOG_TARGET_ERROR(target, "Can't save register %s on a hart that is not halted.",
+				 gdb_regno_name(regid));
+		return ERROR_FAIL;
+	}
 	assert(gdb_regno_cacheable(regid, /* is write? */ false) &&
 			"Only cacheable registers can be saved.");
 


### PR DESCRIPTION
When the target isn't halted, simply return an error. This used to be purely internal code so an assert was appropriate. Now after some refactoring and with unavailable harts you could get here when the hart is unavailable. In that case the right thing is simply to return an error message.

Change-Id: I49d26a11fe7565c645fd2480e89a2c35ea9b1688