### PR TITLE
target: Update messages connected with `examine`

### DIFF
--- a/src/target/target.h
+++ b/src/target/target.h
@@ -138,6 +138,12 @@ struct target {
 	 */
 	bool examined;
 
+	/* When this is true, it's OK to call examine() again in the hopes that this time
+	* it will work.  Earlier than that there is probably other initialization that
+	* needs to happen (like scanning the JTAG chain) before examine should be
+	* called. */
+	bool examine_attempted;
+
 	/**
 	 * true if the  target is currently running a downloaded
 	 * "algorithm" instead of arbitrary user code. OpenOCD code


### PR DESCRIPTION
Move `examine_attempted` flag to target struct to make it target specific. 

`Info` messages for retry and `Error` messages for failure added.

P.S. I have to request this patch here because of https://review.openocd.org/c/openocd/+/6964. There is no such patch in upstream openocd repo.