### PR TITLE
Revert "target: Update messages connected with `examine`"

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -744,22 +744,16 @@ static int default_check_reset(struct target *target)
  * Keep in sync */
 int target_examine_one(struct target *target)
 {
-	if (target->examine_attempted)
-		LOG_TARGET_INFO(target, "Retry examination.");
-
-	LOG_TARGET_INFO(target, "Examination started.");
-
 	target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_START);
 
 	int retval = target->type->examine(target);
 	if (retval != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Examination failed. examine() -> %d", retval);
 		target_reset_examined(target);
 		target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_FAIL);
 		return retval;
 	}
 
-	LOG_TARGET_INFO(target, "Target successfully examined.");
+	LOG_USER("[%s] Target successfully examined.", target_name(target));
 	target_set_examined(target);
 	target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_END);
 
@@ -778,6 +772,12 @@ static int jtag_enable_callback(enum jtag_event event, void *priv)
 	return target_examine_one(target);
 }
 
+/* When this is true, it's OK to call examine() again in the hopes that this time
+ * it will work.  Earlier than that there is probably other initialization that
+ * needs to happen (like scanning the JTAG chain) before examine should be
+ * called. */
+static bool examine_attempted;
+
 /* Targets that correctly implement init + examine, i.e.
  * no communication with target during init:
  *
@@ -787,6 +787,8 @@ int target_examine(void)
 {
 	int retval = ERROR_OK;
 	struct target *target;
+
+	examine_attempted = true;
 
 	for (target = all_targets; target; target = target->next) {
 		/* defer examination, but don't skip it */
@@ -799,11 +801,11 @@ int target_examine(void)
 		if (target->defer_examine)
 			continue;
 
-		target->examine_attempted = true;
-
 		int retval2 = target_examine_one(target);
-		if (retval2 != ERROR_OK)
+		if (retval2 != ERROR_OK) {
+			LOG_WARNING("target %s examination failed", target_name(target));
 			retval = retval2;
+		}
 	}
 	return retval;
 }
@@ -3064,11 +3066,11 @@ static int handle_target(void *priv)
 		LOG_TARGET_DEBUG(target, "target_poll() -> %d, next attempt in %dms",
 				 retval, target->backoff.interval);
 
-		if (retval != ERROR_OK && target->examine_attempted) {
+		if (retval != ERROR_OK && examine_attempted) {
 			target_reset_examined(target);
 			retval = target_examine_one(target);
 			if (retval != ERROR_OK) {
-				LOG_TARGET_DEBUG(target, "Polling again in %dms",
+				LOG_TARGET_DEBUG(target, "Examination failed. Polling again in %dms",
 					target->backoff.interval);
 				return retval;
 			}
@@ -6265,8 +6267,6 @@ static int target_create(struct jim_getopt_info *goi)
 	target->verbose_halt_msg	= true;
 
 	target->halt_issued			= false;
-
-	target->examine_attempted   = false;
 
 	/* initialize trace information */
 	target->trace_info = calloc(1, sizeof(struct trace));

--- a/src/target/target.h
+++ b/src/target/target.h
@@ -138,12 +138,6 @@ struct target {
 	 */
 	bool examined;
 
-	/* When this is true, it's OK to call examine() again in the hopes that this time
-	* it will work.  Earlier than that there is probably other initialization that
-	* needs to happen (like scanning the JTAG chain) before examine should be
-	* called. */
-	bool examine_attempted;
-
 	/**
 	 * true if the  target is currently running a downloaded
 	 * "algorithm" instead of arbitrary user code. OpenOCD code


### PR DESCRIPTION
This reverts commit a3db93b1cea56614baf04f8e88742049da9f2f1e.

Reason for revert: https://github.com/riscv/riscv-openocd/pull/931#issuecomment-1761550506