### PR TITLE
contrib: Match upstream.

### DIFF
--- a/contrib/cross-build.sh
+++ b/contrib/cross-build.sh
@@ -24,7 +24,7 @@
 # export HIDAPI_SRC=/path/to/hidapi
 # export OPENOCD_CONFIG="--enable-..."
 # cd /work/dir
-# .../path/to/openocd/contrib/cross-build.sh <host-triplet>
+# /path/to/openocd/contrib/cross-build.sh <host-triplet>
 #
 # For static linking, a workaround is to
 # export LIBUSB1_CONFIG="--enable-static --disable-shared"


### PR DESCRIPTION
Upstream has a checkpatch failure here. I had fixed it because I didn't know how else to properly get around it back then. Reintroduce the problem. Now this file is identical to upstream.

Change-Id: Ic03b6bb42945ddbcfd2fe12c0cab5b05eda1a50c