### PR TITLE
Revert "target/riscv: Reject size 2 soft breakpoints when C extension not supported"

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1237,17 +1237,15 @@ static int riscv_add_breakpoint(struct target *target, struct breakpoint *breakp
 	LOG_TARGET_DEBUG(target, "@0x%" TARGET_PRIxADDR, breakpoint->address);
 	assert(breakpoint);
 	if (breakpoint->type == BKPT_SOFT) {
-		const bool c_extension_supported = riscv_supports_extension(target, 'C');
-		if (!(breakpoint->length == 4 || (breakpoint->length == 2 && c_extension_supported))) {
-			LOG_TARGET_ERROR(target, "Invalid breakpoint length %d, supported lengths: %s", breakpoint->length,
-				c_extension_supported ? "2, 4" : "4");
+		/** @todo check RVC for size/alignment */
+		if (!(breakpoint->length == 4 || breakpoint->length == 2)) {
+			LOG_TARGET_ERROR(target, "Invalid breakpoint length %d", breakpoint->length);
 			return ERROR_FAIL;
 		}
 
-		const unsigned int required_align = c_extension_supported ? 2 : 4;
-		if ((breakpoint->address % required_align) != 0) {
-			LOG_TARGET_ERROR(target, "Invalid breakpoint alignment for address 0x%" TARGET_PRIxADDR
-				", required alignment: %u", breakpoint->address, required_align);
+		if (0 != (breakpoint->address % 2)) {
+			LOG_TARGET_ERROR(target, "Invalid breakpoint alignment for address 0x%" TARGET_PRIxADDR,
+				breakpoint->address);
 			return ERROR_FAIL;
 		}
 


### PR DESCRIPTION
Reverts riscv/riscv-openocd#908.

This change causes issues because it's not completely clear whether misa.C must be set if Zc* is implemented. (https://github.com/riscv/riscv-code-size-reduction/issues/228#issuecomment-1773356402 suggests it might be required, but the specs themselves aren't clear enough about it.)

Potentially we could test c.nop in examine() (https://github.com/riscv/riscv-openocd/pull/908#discussion_r1366422047). But let's get OpenOCD back to full functionality soon, and then maybe we can reintroduce this change in a more robust way.