### PR TITLE
Remove an extra call to kept_alive()

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -481,7 +481,6 @@ int server_loop(struct command_context *command_context)
 				timeout_ms = polling_period;
 			tv.tv_usec = timeout_ms * 1000;
 			/* Only while we're sleeping we'll let others run */
-			kept_alive();
 			retval = socket_select(fd_max + 1, &read_fds, NULL, NULL, &tv);
 		}
 


### PR DESCRIPTION
This incorrect extra call has been removed from upstream code already in March 2022, see https://review.openocd.org/c/openocd/+/6836.

Remove it from riscv-openocd as well.

Change-Id: Ie341f5578c8bfdc518adf1e4bc134919ab76f803