### PR TITLE
Remove mention of esp32c2, esp32c3 from doc

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -4838,8 +4838,6 @@ compact Thumb2 instruction set. Supports also ARMv6-M and ARMv8-M cores
 @item @code{esirisc} -- this is an EnSilica eSi-RISC core.
 The current implementation supports eSi-32xx cores.
 @item @code{esp32} -- this is an Espressif SoC with dual Xtensa cores.
-@item @code{esp32c2} -- this is an Espressif SoC with single RISC-V core.
-@item @code{esp32c3} -- this is an Espressif SoC with single RISC-V core.
 @item @code{esp32s2} -- this is an Espressif SoC with single Xtensa core.
 @item @code{esp32s3} -- this is an Espressif SoC with dual Xtensa cores.
 @item @code{fa526} -- resembles arm920 (w/o Thumb).


### PR DESCRIPTION
Targets "esp32c2" and "esp32c3" should not be mentioned in the doc under "target types" because these are not standalone OpenOCD targets.

They are merely a set of .cfg files which use the generic "riscv" target.