### PR TITLE
target/riscv: Stop caching writes to DPC

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4960,8 +4960,6 @@ static bool gdb_regno_cacheable(enum gdb_regno regno, bool is_write)
 	 * CSRs. */
 	switch (regno) {
 		case GDB_REGNO_DPC:
-			return true;
-
 		case GDB_REGNO_VSTART:
 		case GDB_REGNO_VXSAT:
 		case GDB_REGNO_VXRM:


### PR DESCRIPTION
Since DPC is WARL (same rules as MEPC according to the specification), it is possible that
writes to it won't result in the exact value present. Therefore, writes to it shouldn't be cached, same as with other WARL registers.

Change-Id: Ib7a4041bc2730c3cd40d5a4db8ba52a8e8788256