### PR TITLE
target/riscv: gdb_regno_name takes an enum.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -5539,7 +5539,7 @@ static void init_custom_csr_names(struct target *target)
 	}
 }
 
-const char *gdb_regno_name(struct target *target, unsigned int regno)
+const char *gdb_regno_name(struct target *target, enum gdb_regno regno)
 {
 	RISCV_INFO(info);
 


### PR DESCRIPTION
Otherwise it won't compile for me. Not sure why that doesn't affect the automated builds.

Change-Id: Ic66c743e1698c4c0772e5601723cb5c711b4fa5c