### PR TITLE
target/riscv: Replace watchpoint value mask comparison value with macro.

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1375,10 +1375,7 @@ static void trigger_from_watchpoint(struct trigger *trigger,
 
 int riscv_add_watchpoint(struct target *target, struct watchpoint *watchpoint)
 {
-	// NOTE: typeof is needed because of upstream OpenOCD bug. This should be
-	// replaced by WATCHPOINT_IGNORE_DATA_VALUE_MASK once it is available
-	// See: https://review.openocd.org/c/openocd/+/7840
-	if (watchpoint->mask != ~(typeof(watchpoint->mask))0) {
+	if (watchpoint->mask != WATCHPOINT_IGNORE_DATA_VALUE_MASK) {
 		LOG_TARGET_ERROR(target, "Watchpoints on data values are not implemented");
 		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}


### PR DESCRIPTION
This patch replaces ~(typeof(watchpoint->mask))0 with
WATCHPOINT_IGNORE_DATA_VALUE_MASK. This improves
readability and moves the RISCV target in line with
other targets.

Change-Id: I15ac4d4ee76098b304d9b22f720911ba4329c190
Signed-off-by: Marek Vrbka <marek.vrbka@codasip.com>