### PR TITLE
repair git2cl fetch url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tools/git2cl"]
 	path = tools/git2cl
-	url = https://git.savannah.nongnu.org/git/git2cl.git
+	url = https://github.com/lobaro/git2cl.git
 [submodule "jimtcl"]
 	path = jimtcl
 	url = https://github.com/msteveb/jimtcl.git


### PR DESCRIPTION
seems like upstream for git2cl is gone: https://git.savannah.nongnu.org/git/git2cl
replace submodule url with one from github