### PR TITLE
target/riscv: report helpfull location during register decode

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -302,9 +302,14 @@ static void log_debug_reg(struct target *target, enum riscv_debug_reg_ordinal re
 	if (debug_level < LOG_LVL_DEBUG)
 		return;
 	const riscv_debug_reg_ctx_t context = get_riscv_debug_reg_ctx(target);
-	char buf[riscv_debug_reg_to_s(NULL, reg, context, value) + 1];
+	char * const buf = malloc(riscv_debug_reg_to_s(NULL, reg, context, value) + 1);
+	if (!buf) {
+		LOG_ERROR("Unable to allocate memory.");
+		return;
+	}
 	riscv_debug_reg_to_s(buf, reg, context, value);
 	log_printf_lf(LOG_LVL_DEBUG, file, line, func, "[%s] %s", target_name(target), buf);
+	free(buf);
 }
 
 #define LOG_DEBUG_REG(t, r, v) log_debug_reg(t, r##_ORDINAL, v, __FILE__, __LINE__, __func__)


### PR DESCRIPTION
`LOG_TARGET_DEBUG()` reports file, line and function name at the call
site. This information is not helpfull if it always points to the same
location inside `log_debug_reg()`.

Additionally, avoid using VLA in `log_debug_reg()`, since OpenOCD style guide(`doc/manual/style.txt`) prohibits it:

> - use malloc() to create dynamic arrays. Do @b not use @c alloca
> or variable length arrays on the stack. non-MMU hosts(uClinux) and
> pthreads require modest and predictable stack usage.