### PR TITLE
target/riscv: remove `riscv_hart_count()`

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2150,8 +2150,7 @@ static int examine(struct target *target)
 	/* Some regression suites rely on seeing 'Examined RISC-V core' to know
 	 * when they can connect with gdb/telnet.
 	 * We will need to update those suites if we want to change that text. */
-	LOG_TARGET_INFO(target, "Examined RISC-V core; found %d harts",
-			riscv_count_harts(target));
+	LOG_TARGET_INFO(target, "Examined RISC-V core");
 	LOG_TARGET_INFO(target, " XLEN=%d, misa=0x%" PRIx64, r->xlen, r->misa);
 	return ERROR_OK;
 }
@@ -2201,13 +2200,6 @@ static int riscv013_authdata_write(struct target *target, uint32_t value, unsign
 	}
 
 	return ERROR_OK;
-}
-
-static int riscv013_hart_count(struct target *target)
-{
-	dm013_info_t *dm = get_dm(target);
-	assert(dm);
-	return dm->hart_count;
 }
 
 /* Try to find out the widest memory access size depending on the selected memory access methods. */
@@ -2772,7 +2764,6 @@ static int init_target(struct command_context *cmd_ctx,
 	generic_info->dm_read = &dm_read;
 	generic_info->dm_write = &dm_write;
 	generic_info->read_memory = read_memory;
-	generic_info->hart_count = &riscv013_hart_count;
 	generic_info->data_bits = &riscv013_data_bits;
 	generic_info->print_info = &riscv013_print_info;
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -5067,16 +5067,6 @@ static void riscv_invalidate_register_cache(struct target *target)
 }
 
 
-unsigned int riscv_count_harts(struct target *target)
-{
-	if (!target)
-		return 1;
-	RISCV_INFO(r);
-	if (!r || !r->hart_count)
-		return 1;
-	return r->hart_count(target);
-}
-
 /**
  * If write is true:
  *   return true iff we are guaranteed that the register will contain exactly

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -253,8 +253,6 @@ struct riscv_info {
 	int (*read_memory)(struct target *target, target_addr_t address,
 			uint32_t size, uint32_t count, uint8_t *buffer, uint32_t increment);
 
-	/* How many harts are attached to the DM that this target is attached to? */
-	int (*hart_count)(struct target *target);
 	unsigned (*data_bits)(struct target *target);
 
 	COMMAND_HELPER((*print_info), struct target *target);
@@ -396,10 +394,6 @@ unsigned riscv_xlen(const struct target *target);
 
 /*** Support functions for the RISC-V 'RTOS', which provides multihart support
  * without requiring multiple targets.  */
-
-/* Lists the number of harts in the system, which are assumed to be
- * consecutive and start with mhartid=0. */
-unsigned int riscv_count_harts(struct target *target);
 
 /**
  * Set the register value. For cacheable registers, only the cache is updated


### PR DESCRIPTION
The motivalion for the change:
* `riscv_hart_count()` is used only once to print the value into the log
  during exmination.
* The returned value is a bit confusing: it's not the total number of
targets on the TAP. It is the number of targets accessable through the
same DM. So the name of the function is misleading.
* This value is already reported on `-d3` level.

So the function seems redundant and can be safely removed.