### PR TITLE
target/riscv: set `state` and `debug_reason` in `riscv_halt_go_all_harts()`

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1874,6 +1874,12 @@ static int riscv_halt_go_all_harts(struct target *target)
 		return ERROR_FAIL;
 	if (state == RISCV_STATE_HALTED) {
 		LOG_TARGET_DEBUG(target, "Hart is already halted.");
+		if (target->state != TARGET_HALTED) {
+			target->state = TARGET_HALTED;
+			enum riscv_halt_reason halt_reason = riscv_halt_reason(target);
+			if (set_debug_reason(target, halt_reason) != ERROR_OK)
+				return ERROR_FAIL;
+		}
 	} else {
 		if (r->halt_go(target) != ERROR_OK)
 			return ERROR_FAIL;


### PR DESCRIPTION

If targets are in a halt group, and a target in the group reaches a breakpoint, the target's state was able to remain `TARGET_RUNNING`.

Addresses issue #1010

Change-Id: I734bc6da71d289c4d05b417c8bf67a7d1a56574f