### PR TITLE
riscv/program: Removed dead code for save/restore of registers

### DIFF
--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -28,13 +28,6 @@ struct riscv_program {
 	/* Number of 32-bit instructions in the program. */
 	size_t instruction_count;
 
-	/* Side effects of executing this program.  These must be accounted for
-	 * in order to maintain correct executing of the target system.  */
-	bool writes_xreg[RISCV_REGISTER_COUNT];
-
-	/* XLEN on the target. */
-	int target_xlen;
-
 	/* execution result of the program */
 	/* TODO: remove this field. We should make it a parameter to riscv_program_exec */
 	riscv_progbuf_exec_result_t execution_result;


### PR DESCRIPTION
Function riscv_program_exec() contains code for restoring of register values after progbuf execution. This code is not used anymore by current OpenOCD, and hence removed.

Related discussion can be found under:
https://github.com/riscv/riscv-openocd/issues/982

Change-Id: I4c79bec081522b6fc0d16367cef51ed19a131962