### PR TITLE
Fixes and cleanup in riscv batch and related functions

### DIFF
--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -59,13 +59,13 @@ bool riscv_batch_full(struct riscv_batch *batch);
 int riscv_batch_run(struct riscv_batch *batch);
 
 /* Adds a DM register write to this batch. */
-void riscv_batch_add_dm_write(struct riscv_batch *batch, unsigned int address, uint64_t data,
+void riscv_batch_add_dm_write(struct riscv_batch *batch, uint64_t address, uint32_t data,
 	bool read_back);
 
 /* DM register reads must be handled in two parts: the first one schedules a read and
  * provides a key, the second one actually obtains the result of the read -
  * status (op) and the actual data. */
-size_t riscv_batch_add_dm_read(struct riscv_batch *batch, unsigned int address);
+size_t riscv_batch_add_dm_read(struct riscv_batch *batch, uint64_t address);
 unsigned int riscv_batch_get_dmi_read_op(const struct riscv_batch *batch, size_t key);
 uint32_t riscv_batch_get_dmi_read_data(const struct riscv_batch *batch, size_t key);
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -5354,28 +5354,28 @@ int riscv_execute_progbuf(struct target *target, uint32_t *cmderr)
 	return r->execute_progbuf(target, cmderr);
 }
 
-void riscv_fill_dm_write_u64(struct target *target, char *buf, int a, uint64_t d)
+void riscv_fill_dm_write(struct target *target, char *buf, uint64_t a, uint32_t d)
 {
 	RISCV_INFO(r);
-	r->fill_dm_write_u64(target, buf, a, d);
+	r->fill_dm_write(target, buf, a, d);
 }
 
-void riscv_fill_dm_read_u64(struct target *target, char *buf, int a)
+void riscv_fill_dm_read(struct target *target, char *buf, uint64_t a)
 {
 	RISCV_INFO(r);
-	r->fill_dm_read_u64(target, buf, a);
+	r->fill_dm_read(target, buf, a);
 }
 
-void riscv_fill_dm_nop_u64(struct target *target, char *buf)
+void riscv_fill_dm_nop(struct target *target, char *buf)
 {
 	RISCV_INFO(r);
-	r->fill_dm_nop_u64(target, buf);
+	r->fill_dm_nop(target, buf);
 }
 
-int riscv_dmi_write_u64_bits(struct target *target)
+int riscv_get_dmi_scan_length(struct target *target)
 {
 	RISCV_INFO(r);
-	return r->dmi_write_u64_bits(target);
+	return r->get_dmi_scan_length(target);
 }
 
 static int check_if_trigger_exists(struct target *target, unsigned int index)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -231,10 +231,10 @@ struct riscv_info {
 	riscv_insn_t (*read_progbuf)(struct target *target, unsigned int index);
 	int (*execute_progbuf)(struct target *target, uint32_t *cmderr);
 	int (*invalidate_cached_progbuf)(struct target *target);
-	int (*dmi_write_u64_bits)(struct target *target);
-	void (*fill_dm_write_u64)(struct target *target, char *buf, int a, uint64_t d);
-	void (*fill_dm_read_u64)(struct target *target, char *buf, int a);
-	void (*fill_dm_nop_u64)(struct target *target, char *buf);
+	int (*get_dmi_scan_length)(struct target *target);
+	void (*fill_dm_write)(struct target *target, char *buf, uint64_t a, uint32_t d);
+	void (*fill_dm_read)(struct target *target, char *buf, uint64_t a);
+	void (*fill_dm_nop)(struct target *target, char *buf);
 
 	int (*authdata_read)(struct target *target, uint32_t *value, unsigned int index);
 	int (*authdata_write)(struct target *target, uint32_t value, unsigned int index);
@@ -429,10 +429,10 @@ riscv_insn_t riscv_read_progbuf(struct target *target, int index);
 int riscv_write_progbuf(struct target *target, int index, riscv_insn_t insn);
 int riscv_execute_progbuf(struct target *target, uint32_t *cmderr);
 
-void riscv_fill_dm_nop_u64(struct target *target, char *buf);
-void riscv_fill_dm_write_u64(struct target *target, char *buf, int a, uint64_t d);
-void riscv_fill_dm_read_u64(struct target *target, char *buf, int a);
-int riscv_dmi_write_u64_bits(struct target *target);
+void riscv_fill_dm_nop(struct target *target, char *buf);
+void riscv_fill_dm_write(struct target *target, char *buf, uint64_t a, uint32_t d);
+void riscv_fill_dm_read(struct target *target, char *buf, uint64_t a);
+int riscv_get_dmi_scan_length(struct target *target);
 
 int riscv_enumerate_triggers(struct target *target);
 


### PR DESCRIPTION
Fixes:

- Data types of address & data parameters in `riscv_batch_add_*()` and `riscv*_fill_dm*()` changed to uint64_t and uint32_t.
- Fixed the comparison in `riscv_batch_full()`.
- Fixed assertions in `riscv_batch_get_dmi_read_op()` and `riscv_batch_get_dmi_read_data()`.

Cleanup:

- Simplified calloc() fail handling in riscv_batch_alloc().
- Added explicit NULL assignments in riscv_batch_alloc() for clarity and readability. Don't rely on calloc().
- Removed suffix `_u64` from `riscv_*_fill_dm*()` since it does not have any meaning.
- Renamed `*dmi_write_u64_bits()` to `*get_dmi_scan_length()` which better describes its purpose.

Change-Id: Id70e5968528d64b2ee5476f1c00e08459a1e291d