### PR TITLE
Fix error on exit with uninitialized target

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -535,9 +535,12 @@ static void riscv_deinit_target(struct target *target)
 	LOG_TARGET_DEBUG(target, "riscv_deinit_target()");
 
 	struct riscv_info *info = target->arch_info;
-	struct target_type *tt = get_target_type(target);
-	if (!tt)
-		LOG_TARGET_ERROR(target, "Could not identify target type.");
+	struct target_type *tt = NULL;
+	if (info->dtm_version != DTM_DTMCS_VERSION_UNKNOWN) {
+		tt = get_target_type(target);
+		if (!tt)
+			LOG_TARGET_ERROR(target, "Could not identify target type.");
+	}
 
 	if (riscv_flush_registers(target) != ERROR_OK)
 		LOG_TARGET_ERROR(target, "Failed to flush registers. Ignoring this error.");


### PR DESCRIPTION
riscv_deinit_target() tries to get_target_type() even if the examination failed or was not called at all. dtm_version is not known and an annoying error is printed:

  Error: [riscv.cpu.0] Unsupported DTM version: -1
  Error: [riscv.cpu.0] Could not identify target type.

Avoid calling get_target_type() if dtm_version is
DTM_DTMCS_VERSION_UNKNOWN.


Change-Id: I48239b1b11561357e845f3a6cb3a8e3b19e35715