### PR TITLE
target/riscv: Implement ability to re-examine target

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -11515,6 +11515,13 @@ riscv exec_progbuf 0x0330000f 0x0000100f
 riscv exec_progbuf 0x94a20405
 @end example
 
+@subsection RISC-V Syntacore hardware-specific Commands
+
+@deffn {Command} {riscv re_examine}
+Enforce (re)examination of target. This command requires that all watchpoints and
+breakpoints to be deleted before use.
+@end deffn
+
 @section ARC Architecture
 @cindex ARC
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4560,6 +4560,28 @@ COMMAND_HANDLER(riscv_set_enable_ge_lt_trigger)
 	return ERROR_COMMAND_SYNTAX_ERROR;
 }
 
+COMMAND_HANDLER(handle_re_examine_target)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	RISCV_INFO(r);
+
+	if (target->watchpoints || target->breakpoints) {
+		LOG_TARGET_ERROR(target, "Please, remove all breakpoints and watchpoints.");
+		return ERROR_FAIL;
+	}
+
+	if (riscv_flush_registers(target) != ERROR_OK) {
+		LOG_TARGET_ERROR(target, "Flush of register cache failed.");
+		return ERROR_FAIL;
+	}
+
+	free_wp_triggers_cache(target);
+	r->triggers_enumerated = false;
+
+	target_reset_examined(target);
+	return target_examine_one(target);
+}
+
 static const struct command_registration riscv_exec_command_handlers[] = {
 	{
 		.name = "dump_sample_buf",
@@ -4829,6 +4851,13 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 		.mode = COMMAND_CONFIG,
 		.usage = "[on|off]",
 		.help = "When on, allow OpenOCD to use GE/LT triggers in wp."
+	},
+	{
+		.name = "re_examine",
+		.handler = handle_re_examine_target,
+		.mode = COMMAND_EXEC,
+		.help = "Enforce (re)examination of target",
+		.usage = "",
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -515,6 +515,9 @@ static void free_wp_triggers_cache(struct target *target)
 {
 	RISCV_INFO(r);
 
+	if (!r->wp_triggers_negative_cache)
+		return;
+
 	for (unsigned int i = 0; i < r->trigger_count; ++i) {
 		struct tdata1_cache *elem_1, *tmp_1;
 		list_for_each_entry_safe(elem_1, tmp_1, &r->wp_triggers_negative_cache[i], elem_tdata1) {
@@ -528,6 +531,7 @@ static void free_wp_triggers_cache(struct target *target)
 		}
 	}
 	free(r->wp_triggers_negative_cache);
+	r->wp_triggers_negative_cache = NULL;
 }
 
 static void riscv_deinit_target(struct target *target)

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -647,15 +647,6 @@ static int no_mmu(struct target *target, int *enabled)
 	return ERROR_OK;
 }
 
-/**
- * Reset the @c examined flag for the given target.
- * Pure paranoia -- targets are zeroed on allocation.
- */
-static inline void target_reset_examined(struct target *target)
-{
-	target->examined = false;
-}
-
 static int default_examine(struct target *target)
 {
 	target_set_examined(target);

--- a/src/target/target.h
+++ b/src/target/target.h
@@ -451,6 +451,15 @@ static inline void target_set_examined(struct target *target)
 }
 
 /**
+ * Reset the @c examined flag for the given target.
+ * Pure paranoia -- targets are zeroed on allocation.
+ */
+static inline void target_reset_examined(struct target *target)
+{
+	target->examined = false;
+}
+
+/**
  * Add the @a breakpoint for @a target.
  *
  * This routine is a wrapper for target->type->add_breakpoint.


### PR DESCRIPTION
Add a new OpenOCD command `re_examine` to enforce re-examination of target. Some of existing hardware have a writable misa.V bit. It means that it can be enabled by software. We need an opportunity to enforce `examine` procedure in OpenOCD to query the capabilities of the target.

Also this patch includes commit with fix of a little issue connected with clearing triggers cache.