### PR TITLE
[NFC] target/riscv: refactor `init_registers()`

### DIFF
--- a/src/target/riscv/gdb_regs.h
+++ b/src/target/riscv/gdb_regs.h
@@ -78,6 +78,9 @@ enum gdb_regno {
 	GDB_REGNO_FT11,
 	GDB_REGNO_FPR31 = GDB_REGNO_FT11,
 	GDB_REGNO_CSR0 = 65,
+	GDB_REGNO_FCSR = CSR_FCSR + GDB_REGNO_CSR0,
+	GDB_REGNO_FFLAGS = CSR_FFLAGS + GDB_REGNO_CSR0,
+	GDB_REGNO_FRM = CSR_FRM + GDB_REGNO_CSR0,
 	GDB_REGNO_VSTART = CSR_VSTART + GDB_REGNO_CSR0,
 	GDB_REGNO_VXSAT = CSR_VXSAT + GDB_REGNO_CSR0,
 	GDB_REGNO_VXRM = CSR_VXRM + GDB_REGNO_CSR0,
@@ -120,6 +123,6 @@ enum gdb_regno {
 	GDB_REGNO_COUNT
 };
 
-const char *gdb_regno_name(struct target *target, enum gdb_regno regno);
+const char *gdb_regno_name(const struct target *target, enum gdb_regno regno);
 
 #endif

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -260,6 +260,9 @@ struct riscv_info {
 
 	COMMAND_HELPER((*print_info), struct target *target);
 
+	/* Storage for arch_info of non-custom registers. */
+	riscv_reg_info_t shared_reg_info;
+
 	/* Storage for vector register types. */
 	struct reg_data_type_vector vector_uint8;
 	struct reg_data_type_vector vector_uint16;
@@ -390,10 +393,13 @@ int riscv_openocd_step(
 
 /*** RISC-V Interface ***/
 
-bool riscv_supports_extension(struct target *target, char letter);
+bool riscv_supports_extension(const struct target *target, char letter);
 
 /* Returns XLEN for the given (or current) hart. */
 unsigned riscv_xlen(const struct target *target);
+
+/* Returns VLENB for the given (or current) hart. */
+unsigned int riscv_vlenb(const struct target *target);
 
 /*** Support functions for the RISC-V 'RTOS', which provides multihart support
  * without requiring multiple targets.  */


### PR DESCRIPTION
The logic in `init_registers()` was quite convoluted. Initialization of each `struct reg` field is separated into function `gdb_regno_<field_name>()`.
IMHO, this makes it much easier to reason about the code.

Change-Id: Id7faa1464ce026cc5025585d0a6a95a01fb39cee