### PR TITLE
target/riscv: decode DMI scans in batch access

### DIFF
--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -78,4 +78,10 @@ size_t riscv_batch_available_scans(struct riscv_batch *batch);
 /* Return true iff the last scan in the batch returned DMI_OP_BUSY. */
 bool riscv_batch_dmi_busy_encountered(const struct riscv_batch *batch);
 
+/* TODO: The function is defined in `riscv-013.c`. This is done to reduce the
+ * diff of the commit. The intention is to move the function definition to
+ * a separate module (e.g. `riscv013-jtag-dtm.c/h`) in another commit. */
+void riscv_decode_dmi_scan(const struct target *target, int idle, const struct scan_field *field,
+		bool discard_in);
+
 #endif

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3712,7 +3712,7 @@ COMMAND_HANDLER(riscv_authdata_write)
 	return r->authdata_write(target, value, index);
 }
 
-static uint32_t riscv_get_dmi_address(const struct target *target, uint32_t dm_address)
+uint32_t riscv_get_dmi_address(const struct target *target, uint32_t dm_address)
 {
 	assert(target);
 	RISCV_INFO(r);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -440,6 +440,8 @@ void riscv_fill_dm_write(struct target *target, char *buf, uint64_t a, uint32_t 
 void riscv_fill_dm_read(struct target *target, char *buf, uint64_t a);
 int riscv_get_dmi_scan_length(struct target *target);
 
+uint32_t riscv_get_dmi_address(const struct target *target, uint32_t dm_address);
+
 int riscv_enumerate_triggers(struct target *target);
 
 int riscv_add_watchpoint(struct target *target, struct watchpoint *watchpoint);


### PR DESCRIPTION
This allows to merge the implementation in `batch.c` with the one in `riscv-013.c`.

Change-Id: Ic3821a9ce2d75a7c6e618074679595ddefb14cfc