### PR TITLE
target/riscv: reset delays during batch scans

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -89,7 +89,8 @@ bool riscv_batch_full(struct riscv_batch *batch)
 	return riscv_batch_available_scans(batch) == 0;
 }
 
-int riscv_batch_run(struct riscv_batch *batch)
+int riscv_batch_run(struct riscv_batch *batch, bool resets_delays,
+		size_t reset_delays_after)
 {
 	if (batch->used_scans == 0) {
 		LOG_TARGET_DEBUG(batch->target, "Ignoring empty batch.");
@@ -104,7 +105,9 @@ int riscv_batch_run(struct riscv_batch *batch)
 		else
 			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
 
-		if (batch->idle_count > 0)
+		const bool delays_were_reset = resets_delays
+			&& (i >= reset_delays_after);
+		if (batch->idle_count > 0 && !delays_were_reset)
 			jtag_add_runtest(batch->idle_count, TAP_IDLE);
 	}
 

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -55,8 +55,15 @@ void riscv_batch_free(struct riscv_batch *batch);
 /* Checks to see if this batch is full. */
 bool riscv_batch_full(struct riscv_batch *batch);
 
-/* Executes this scan batch. */
-int riscv_batch_run(struct riscv_batch *batch);
+/* Executes this batch of JTAG DTM DMI scans.
+ *
+ * If resets_delays is true, the algorithm will stop inserting idle cycles
+ * (JTAG Run-Test Idle) after "reset_delays_after" number of scans is
+ * performed.  This is useful for stress-testing of RISC-V algorithms in
+ * OpenOCD that are based on batches.
+ */
+int riscv_batch_run(struct riscv_batch *batch, bool resets_delays,
+		size_t reset_delays_after);
 
 /* Adds a DM register write to this batch. */
 void riscv_batch_add_dm_write(struct riscv_batch *batch, uint64_t address, uint32_t data,

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -450,6 +450,7 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 	LOG_TARGET_DEBUG(target, "riscv_init_target()");
 	RISCV_INFO(info);
 	info->cmd_ctx = cmd_ctx;
+	info->reset_delays_wait = -1;
 
 	select_dtmcontrol.num_bits = target->tap->ir_length;
 	select_dbus.num_bits = target->tap->ir_length;
@@ -3850,10 +3851,8 @@ COMMAND_HANDLER(riscv_reset_delays)
 {
 	int wait = 0;
 
-	if (CMD_ARGC > 1) {
-		LOG_ERROR("Command takes at most one argument");
+	if (CMD_ARGC > 1)
 		return ERROR_COMMAND_SYNTAX_ERROR;
-	}
 
 	if (CMD_ARGC == 1)
 		COMMAND_PARSE_NUMBER(int, CMD_ARGV[0], wait);
@@ -6455,7 +6454,7 @@ int riscv_init_registers(struct target *target)
 	return ERROR_OK;
 }
 
-void riscv_add_bscan_tunneled_scan(struct target *target, struct scan_field *field,
+void riscv_add_bscan_tunneled_scan(struct target *target, const struct scan_field *field,
 					riscv_bscan_tunneled_scan_context_t *ctxt)
 {
 	jtag_add_ir_scan(target->tap, &select_user4, TAP_IDLE);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -454,7 +454,7 @@ void riscv_semihosting_init(struct target *target);
 
 enum semihosting_result riscv_semihosting(struct target *target, int *retval);
 
-void riscv_add_bscan_tunneled_scan(struct target *target, struct scan_field *field,
+void riscv_add_bscan_tunneled_scan(struct target *target, const struct scan_field *field,
 		riscv_bscan_tunneled_scan_context_t *ctxt);
 
 int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);


### PR DESCRIPTION
Prior to the commit, it was impossible to get a `dmi.busy` responce on a scan in a batch that was not the first scan in the batch.

Change-Id: Ib0714ecaf7d2e11878140d16d9aa6152ff20f1e9