### PR TITLE
fix confusing status messages during resume

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1709,15 +1709,26 @@ static int oldriscv_step(struct target *target, int current, uint32_t address,
 	return tt->step(target, current, address, handle_breakpoints);
 }
 
-static int old_or_new_riscv_step(struct target *target, int current,
-		target_addr_t address, int handle_breakpoints)
+static int riscv_openocd_step_impl(struct target *target, int current,
+		target_addr_t address, int handle_breakpoints, int handle_callbacks);
+
+static int old_or_new_riscv_step_impl(struct target *target, int current,
+		target_addr_t address, int handle_breakpoints, int handle_callbacks)
 {
 	RISCV_INFO(r);
 	LOG_TARGET_DEBUG(target, "handle_breakpoints=%d", handle_breakpoints);
 	if (!r->get_hart_state)
 		return oldriscv_step(target, current, address, handle_breakpoints);
 	else
-		return riscv_openocd_step(target, current, address, handle_breakpoints);
+		return riscv_openocd_step_impl(target, current, address, handle_breakpoints,
+			handle_callbacks);
+}
+
+static int old_or_new_riscv_step(struct target *target, int current,
+		target_addr_t address, int handle_breakpoints)
+{
+	return old_or_new_riscv_step_impl(target, current, address,
+		handle_breakpoints, true /* handle callbacks*/);
 }
 
 static int riscv_examine(struct target *target)
@@ -2091,7 +2102,8 @@ static int resume_prep(struct target *target, int current,
 		/* To be able to run off a trigger, we perform a step operation and then
 		 * resume. If handle_breakpoints is true then step temporarily disables
 		 * pending breakpoints so we can safely perform the step. */
-		if (old_or_new_riscv_step(target, current, address, handle_breakpoints) != ERROR_OK)
+		if (old_or_new_riscv_step_impl(target, current, address, handle_breakpoints,
+				false /* callbacks are not called */) != ERROR_OK)
 			return ERROR_FAIL;
 	}
 
@@ -3294,8 +3306,8 @@ int riscv_openocd_poll(struct target *target)
 	return ERROR_OK;
 }
 
-int riscv_openocd_step(struct target *target, int current,
-	target_addr_t address, int handle_breakpoints)
+static int riscv_openocd_step_impl(struct target *target, int current,
+	target_addr_t address, int handle_breakpoints, int handle_callbacks)
 {
 	LOG_TARGET_DEBUG(target, "stepping hart");
 
@@ -3361,12 +3373,23 @@ _exit:
 
 	if (success) {
 		target->state = TARGET_RUNNING;
-		target_call_event_callbacks(target, TARGET_EVENT_RESUMED);
+		if (handle_callbacks)
+			target_call_event_callbacks(target, TARGET_EVENT_RESUMED);
+
 		target->state = TARGET_HALTED;
 		target->debug_reason = DBG_REASON_SINGLESTEP;
-		target_call_event_callbacks(target, TARGET_EVENT_HALTED);
+		if (handle_callbacks)
+			target_call_event_callbacks(target, TARGET_EVENT_HALTED);
 	}
+
 	return success ? ERROR_OK : ERROR_FAIL;
+}
+
+int riscv_openocd_step(struct target *target, int current,
+	target_addr_t address, int handle_breakpoints)
+{
+	return riscv_openocd_step_impl(target, current, address, handle_breakpoints,
+		true /* handle_callbacks */);
 }
 
 /* Command Handlers */


### PR DESCRIPTION
Recently, (after b503fdef02f) OpenOCD started to notify user about hart state updates. This causes confusion in some cases since some internal updates to the hart state should not be visible to the user as these are implementation details. For example situation like this:

```
> reset halt
JTAG tap: riscv.tap tap/device found: 0xdeadbeef ...
> resume
[riscv.cpu0] Found 4 triggers
riscv.cpu0 halted due to single-step.
[riscv.cpu1] Found 4 triggers
riscv.cpu1 halted due to single-step.
[riscv.cpu2] Found 4 triggers
riscv.cpu2 halted due to single-step.
[riscv.cpu3] Found 4 triggers
riscv.cpu3 halted due to single-step.
```
likely confuse people.

There is no issue with the resume functionality. It`s just that resume internally causes single-step that causes hart state to change.

This commit disable calling of user-specified (and default) callbacks during the "hidden" step operation disabling these confusing messages

Change-Id: I3412a089e2abdcd315d86cec7ee732fdd18c1601