### PR TITLE
target/riscv: stop using register_get/set for 0.11 targets

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1584,8 +1584,6 @@ static int examine(struct target *target)
 		return result;
 
 	target_set_examined(target);
-	for (size_t i = 0; i < 32; ++i)
-		reg_cache_set(target, i, -1);
 	LOG_INFO("Examined RISCV core; XLEN=%d, misa=0x%" PRIx64,
 			riscv_xlen(target), r->misa);
 


### PR DESCRIPTION
Caching is somewhat handled in `riscv-011.c`. Handling it additionaly in `riscv.c` may cause problems. Sice there is no simulator that supports RISC-V Debug Specification v0.11, so it is not feaseable to automate testing.
This commit separates 0.11 register accesses and unlocks further development in this area.

Change-Id: I73ff17ef85106c4ababa38319f446f6c384a1750