### PR TITLE
target/riscv/riscv-011.c: fix access to non-existent register

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1771,10 +1771,10 @@ static riscv_error_t handle_halt_routine(struct target *target)
 					reg = S0;
 					break;
 				case 31:
-					reg = CSR_DPC;
+					reg = GDB_REGNO_DPC;
 					break;
 				case 32:
-					reg = CSR_DCSR;
+					reg = GDB_REGNO_DCSR;
 					break;
 				default:
 					assert(0);
@@ -1808,8 +1808,8 @@ static riscv_error_t handle_halt_routine(struct target *target)
 	}
 
 	/* TODO: get rid of those 2 variables and talk to the cache directly. */
-	info->dpc = reg_cache_get(target, CSR_DPC);
-	info->dcsr = reg_cache_get(target, CSR_DCSR);
+	info->dpc = reg_cache_get(target, GDB_REGNO_DPC);
+	info->dcsr = reg_cache_get(target, GDB_REGNO_DCSR);
 
 	cache_invalidate(target);
 


### PR DESCRIPTION
`reg` is a number in register cache, as evident by the following call to
`reg_cache_set()`. `CSR_DCSR` is `GDB_REGNO_DCSR - 65`. This results in
setting cache value for another register, which does not exist, and
causes a segfault if all non-existent registers are not allocated a
value (`reg->value == NULL`).