### PR TITLE
Bump GitHub actions to latest versions

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -10,7 +10,7 @@ jobs:
       BUILD_DIR: ../build
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
       - name: Checkout Base

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -11,7 +11,7 @@ jobs:
       CC: clang
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install required packages (apt-get)
         run: |
           sudo apt-get update
@@ -30,7 +30,7 @@ jobs:
       CC: gcc
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure environment
         run: |
           TAG=$(git rev-parse --short HEAD)
@@ -55,7 +55,7 @@ jobs:
           make install
           tar zcvf ${{ env.NAME }}.tgz -C /tmp ${{ env.NAME }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.NAME }}
           path: ${{ env.NAME }}.tgz

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install autotools-dev autoconf automake libtool pkg-config cmake texinfo texlive g++-mingw-w64-i686
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - run: ./bootstrap
       - name: Prepare libusb1
         env:
@@ -102,11 +102,11 @@ jobs:
           echo "IS_PRE_RELEASE=$IS_PRE_RELEASE" >> $GITHUB_ENV
           echo "ARTIFACT_PATH=$PWD/$ARTIFACT" >> $GITHUB_ENV
       - name: Publish OpenOCD packaged for windows
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}
       - name: Delete 'latest' Release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        uses: dev-drprasad/delete-tag-and-release@v1.1
         with:
           delete_release: true
           tag_name: ${{ env.RELEASE_NAME }}

--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: Test debug (Ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install packages
         run: |
@@ -47,14 +47,14 @@ jobs:
 
       - name: Get the toolchain from cache (if available)
         id: cache-toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /opt/riscv/toolchain
           key: "toolchain-${{env.TOOLCHAIN_URL}}"
 
       - name: Get spike from cache (if available)
         id: cache-spike
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /opt/riscv/spike
           key: "spike-${{env.SPIKE_COMMIT}}"
@@ -130,7 +130,7 @@ jobs:
       - name: Archive test logs
         # Proceed even if there was a failed test
         if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs
           path: riscv-tests/debug/logs


### PR DESCRIPTION
Bump GitHub actions to latest versions to address this:

* https://github.com/riscv-collab/riscv-openocd/issues/1048

If there are any issues with any of this please let me know.
Thanks.