### PR TITLE
target/riscv: use breakpoint_hw_set/watchpoint_set to properly initialize bp/wp descriptor

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -1415,6 +1415,7 @@ static int riscv_add_breakpoint(struct target *target, struct breakpoint *breakp
 					TARGET_PRIxADDR, breakpoint->length, breakpoint->address);
 			return ERROR_FAIL;
 		}
+		breakpoint->is_set = true;
 
 	} else if (breakpoint->type == BKPT_HARD) {
 		struct trigger trigger;
@@ -1422,12 +1423,13 @@ static int riscv_add_breakpoint(struct target *target, struct breakpoint *breakp
 		int const result = add_trigger(target, &trigger);
 		if (result != ERROR_OK)
 			return result;
+
+		int trigger_idx = find_first_trigger_by_id(target, breakpoint->unique_id);
+		breakpoint_hw_set(breakpoint, trigger_idx);
 	} else {
 		LOG_TARGET_INFO(target, "OpenOCD only supports hardware and software breakpoints.");
 		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}
-
-	breakpoint->is_set = true;
 	return ERROR_OK;
 }
 
@@ -1521,7 +1523,9 @@ int riscv_add_watchpoint(struct target *target, struct watchpoint *watchpoint)
 	int result = add_trigger(target, &trigger);
 	if (result != ERROR_OK)
 		return result;
-	watchpoint->is_set = true;
+
+	int trigger_idx = find_first_trigger_by_id(target, watchpoint->unique_id);
+	watchpoint_set(watchpoint, trigger_idx);
 
 	return ERROR_OK;
 }


### PR DESCRIPTION
This fixes the following issue:

```
> bp 0x80000008 4 hw
[riscv.cpu0] Found 4 triggers
breakpoint set at 0x80000008
> bp                
Hardware breakpoint(IVA): addr=0x80000008, len=0x4, num=1651340654
```

`num` is initialized for RISC-V targets.

Also see https://review.openocd.org/c/openocd/+/8181 for a discussion