### PR TITLE
target/riscv: do not emit warnings when a non-existent CSR is hidden

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -6885,7 +6885,7 @@ static void hide_csrs(const struct target *target)
 			struct reg * const reg = get_reg_cache_entry(target, regno);
 			const unsigned int csr_number = regno - GDB_REGNO_CSR0;
 			if (!reg->exist) {
-				LOG_TARGET_WARNING(target,
+				LOG_TARGET_DEBUG(target,
 						"Not hiding CSR %d: register does not exist.",
 						csr_number);
 				continue;


### PR DESCRIPTION
hide_csrs should not emit warnings on an attempt to hide non-exitents CSR. hide_csrs funcitonality is intended to be used for scenarios when we don`t want certain groups of registers to be available in GDB. Typically this is needed to simplify integration with various IDE. In such scenarious it may be impractical/unfeseable to figure out which register is present on a target. So reporting a situation when a user wants to hide a non-existent register creates way too much noise. This commit reduces severity of relevant debug message to LOG_TARGET_DEBUG