### PR TITLE
riscv-013: Remove unused typedef slot_t

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -101,12 +101,6 @@ typedef enum {
 	DMI_STATUS_BUSY = DTM_DMI_OP_BUSY
 } dmi_status_t;
 
-typedef enum slot {
-	SLOT0,
-	SLOT1,
-	SLOT_LAST,
-} slot_t;
-
 /*** Debug Bus registers. ***/
 
 /* TODO: CMDERR_* defines can removed */


### PR DESCRIPTION
Code cleanup: "slot_t" is unused in riscv013 - remove it.

Change-Id: I9d5a0cf8446a180b1d13a9ce2c86d904b946cf28