### PR TITLE
.github/workflows: check git revisions instead of a diff

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -23,10 +23,4 @@ jobs:
             sudo apt-get install patchutils python3-ply python3-git
       - name: Run checkpatch
         run: |
-            git diff --patch FETCH_HEAD \
-            | filterdiff \
-                -x "a/src/jtag/drivers/libjaylink/*" \
-                -x "a/tools/git2cl/*" \
-                -x "a/.github/*" \
-                -x "a/HACKING" \
-            | ./tools/scripts/checkpatch.pl --no-signoff -
+            ./tools/scripts/checkpatch.pl --no-signoff --git FETCH_HEAD..HEAD


### PR DESCRIPTION
When running on diff, Checkpatch ignores `Checkpatch-ignore` directives in the commit message.

Change-Id: Ib296d5e972408973fb381fafc51f59569a01d1f0