### PR TITLE
target/riscv: Ensure other TAPs are in BYPASS for batch DR scan

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -157,6 +157,8 @@ int riscv_batch_run_from(struct riscv_batch *batch, size_t start_idx,
 	LOG_TARGET_DEBUG(batch->target, "Running batch of scans [%zu, %zu)",
 			start_idx, batch->used_scans);
 
+	select_dmi(batch->target);
+
 	for (size_t i = start_idx; i < batch->used_scans; ++i) {
 		if (bscan_tunnel_ir_width != 0)
 			riscv_add_bscan_tunneled_scan(batch->target, batch->fields + i, batch->bscan_ctxt + i);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -435,7 +435,7 @@ void riscv_log_dmi_scan(const struct target *target, int idle, const struct scan
 
 /*** Utility functions. ***/
 
-static void select_dmi(struct target *target)
+void select_dmi(struct target *target)
 {
 	if (bscan_tunnel_ir_width != 0) {
 		select_dmi_via_bscan(target);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -378,6 +378,7 @@ extern int bscan_tunnel_ir_width;
 
 int dtmcontrol_scan_via_bscan(struct target *target, uint32_t out, uint32_t *in_ptr);
 void select_dmi_via_bscan(struct target *target);
+void select_dmi(struct target *target);
 
 /*** OpenOCD Interface */
 int riscv_openocd_poll(struct target *target);


### PR DESCRIPTION
In configurations with multiple TAPs and targets it is necessary to ensure that the TAPs other than the one chosen for the batch are in BYPASS. This can be done by doing an IR scan which will ensure that all other than the active TAP are in BYPASS.

Make the select_dmi function non-static and use it from the batch code to avoid duplication.

This resolves an assertion when running with a configuration with multiple TAPs:

src/jtag/drivers/driver.c:156: interface_jtag_add_dr_scan: Assertion `active == tap' failed.