### PR TITLE
target/riscv: vector CSRs are optional

### DIFF
--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -397,6 +397,14 @@ static bool gdb_regno_exist(const struct target *target, uint32_t regno)
 		case CSR_FRM:
 		case CSR_FCSR:
 			return riscv_supports_extension(target, 'F');
+		case CSR_VSTART:
+		case CSR_VXSAT:
+		case CSR_VXRM:
+		case CSR_VL:
+		case CSR_VCSR:
+		case CSR_VTYPE:
+		case CSR_VLENB:
+			return vlenb_exists(target);
 		case CSR_SCOUNTEREN:
 		case CSR_SSTATUS:
 		case CSR_STVEC:


### PR DESCRIPTION
This is a fix to a mistake made in
ea7e17491d56ced52ab803949b23aa9579bb3c57.

The newly introduced `gdb_regno_exist()` function was missing a part regarding vector CSRs:
https://github.com/riscv-collab/riscv-openocd/pull/1022/commits/ea7e17491d56ced52ab803949b23aa9579bb3c57#diff-b4aa16f9e42cb8f0934baa7c8e0ec9c70a369bef98b99b26ae2e896c8aa95d6aL6163-L6171

Change-Id: I0361ea4dce8df5be748e2c6e7e6838029d3a7120