### PR TITLE
target/riscv: reg cache entry is initialized before access

### DIFF
--- a/src/target/riscv/riscv-011_reg.c
+++ b/src/target/riscv/riscv-011_reg.c
@@ -38,7 +38,9 @@ static const struct reg_arch_type *riscv011_gdb_regno_reg_type(uint32_t regno)
 
 static int riscv011_init_reg(struct target *target, uint32_t regno)
 {
-	return riscv_reg_impl_init_one(target, regno, riscv011_gdb_regno_reg_type(regno));
+	return riscv_reg_impl_init_cache_entry(target, regno,
+			riscv_reg_impl_gdb_regno_exist(target, regno),
+			riscv011_gdb_regno_reg_type(regno));
 }
 
 int riscv011_reg_init_all(struct target *target)

--- a/src/target/riscv/riscv-013.h
+++ b/src/target/riscv/riscv-013.h
@@ -19,5 +19,9 @@ int riscv013_set_register(struct target *target, enum gdb_regno rid,
 		riscv_reg_t value);
 int riscv013_set_register_buf(struct target *target, enum gdb_regno regno,
 		const uint8_t *value);
+uint32_t riscv013_access_register_command(struct target *target, uint32_t number,
+		unsigned int size, uint32_t flags);
+int riscv013_execute_abstract_command(struct target *target, uint32_t command,
+		uint32_t *cmderr);
 
 #endif /* OPENOCD_TARGET_RISCV_RISCV_013_H */

--- a/src/target/riscv/riscv-013_reg.c
+++ b/src/target/riscv/riscv-013_reg.c
@@ -9,6 +9,7 @@
 #include "riscv_reg.h"
 #include "riscv_reg_impl.h"
 #include "riscv-013.h"
+#include "debug_defines.h"
 #include <helper/time_support.h>
 
 static int riscv013_reg_get(struct reg *reg)
@@ -85,33 +86,196 @@ static int riscv013_reg_set(struct reg *reg, uint8_t *buf)
 
 static const struct reg_arch_type *riscv013_gdb_regno_reg_type(uint32_t regno)
 {
-	static const struct reg_arch_type riscv011_reg_type = {
+	static const struct reg_arch_type riscv013_reg_type = {
 		.get = riscv013_reg_get,
 		.set = riscv013_reg_set
 	};
-	return &riscv011_reg_type;
+	return &riscv013_reg_type;
 }
 
-static int riscv013_init_reg(struct target *target, uint32_t regno)
+static int init_cache_entry(struct target *target, uint32_t regno)
 {
-	return riscv_reg_impl_init_one(target, regno, riscv013_gdb_regno_reg_type(regno));
+	struct reg * const reg = riscv_reg_impl_cache_entry(target, regno);
+	if (riscv_reg_impl_is_initialized(reg))
+		return ERROR_OK;
+	return riscv_reg_impl_init_cache_entry(target, regno,
+			riscv_reg_impl_gdb_regno_exist(target, regno),
+			riscv013_gdb_regno_reg_type(regno));
 }
 
-int riscv013_reg_init_all(struct target *target)
+/**
+ * Some registers are optional (e.g. "misa"). For such registers it is first
+ * assumed they exist (via "assume_reg_exist()"), then the read is attempted
+ * (via the usual "riscv_reg_get()") and if the read fails, the register is
+ * marked as non-existing (via "riscv_reg_impl_set_exist()").
+ */
+static int assume_reg_exist(struct target *target, uint32_t regno)
 {
-	if (riscv_reg_impl_init_cache(target) != ERROR_OK)
+	return riscv_reg_impl_init_cache_entry(target, regno,
+			/* exist */ true, riscv013_gdb_regno_reg_type(regno));
+}
+
+static int examine_xlen(struct target *target)
+{
+	RISCV_INFO(r);
+	unsigned int cmderr;
+
+	const uint32_t command = riscv013_access_register_command(target,
+			GDB_REGNO_S0, /* size */ 64, AC_ACCESS_REGISTER_TRANSFER);
+	int res = riscv013_execute_abstract_command(target, command, &cmderr);
+	if (res == ERROR_OK) {
+		r->xlen = 64;
+		return ERROR_OK;
+	}
+	if (res == ERROR_TIMEOUT_REACHED)
 		return ERROR_FAIL;
+	r->xlen = 32;
+
+	return ERROR_OK;
+}
+
+static int examine_vlenb(struct target *target)
+{
+	RISCV_INFO(r);
+
+	/* Reading "vlenb" requires "mstatus.vs" to be set, so "mstatus" should
+	 * be accessible.*/
+	int res = init_cache_entry(target, GDB_REGNO_MSTATUS);
+	if (res != ERROR_OK)
+		return res;
+
+	res = assume_reg_exist(target, GDB_REGNO_VLENB);
+	if (res != ERROR_OK)
+		return res;
+
+	riscv_reg_t vlenb_val;
+	if (riscv_reg_get(target, &vlenb_val, GDB_REGNO_VLENB) != ERROR_OK) {
+		if (riscv_supports_extension(target, 'V'))
+			LOG_TARGET_WARNING(target, "Couldn't read vlenb; vector register access won't work.");
+		r->vlenb = 0;
+		return riscv_reg_impl_set_exist(target, GDB_REGNO_VLENB, false);
+	}
+	/* As defined by RISC-V V extension specification:
+	 * https://github.com/riscv/riscv-v-spec/blob/2f68ef7256d6ec53e4d2bd7cb12862f406d64e34/v-spec.adoc?plain=1#L67-L72 */
+	const unsigned int vlen_max = 65536;
+	const unsigned int vlenb_max = vlen_max / 8;
+	if (vlenb_val > vlenb_max) {
+		LOG_TARGET_WARNING(target, "'vlenb == %" PRIu64
+				"' is greater than maximum allowed by specification (%u); vector register access won't work.",
+				vlenb_val, vlenb_max);
+		r->vlenb = 0;
+		return ERROR_OK;
+	}
+	assert(vlenb_max <= UINT_MAX);
+	r->vlenb = (unsigned int)vlenb_val;
+
+	LOG_TARGET_INFO(target, "Vector support with vlenb=%u", r->vlenb);
+	return ERROR_OK;
+}
+
+static int examine_misa(struct target *target)
+{
+	RISCV_INFO(r);
+
+	int res = init_cache_entry(target, GDB_REGNO_MISA);
+	if (res != ERROR_OK)
+		return res;
+
+	res = riscv_reg_get(target, &r->misa, GDB_REGNO_MISA);
+	if (res != ERROR_OK)
+		return res;
+
+	return ERROR_OK;
+}
+
+static int examine_mtopi(struct target *target)
+{
+	RISCV_INFO(r);
+
+	/* Assume the registers exist */
+	r->mtopi_readable = true;
+	r->mtopei_readable = true;
+
+	int res = assume_reg_exist(target, GDB_REGNO_MTOPI);
+	if (res != ERROR_OK)
+		return res;
+	res = assume_reg_exist(target, GDB_REGNO_MTOPEI);
+	if (res != ERROR_OK)
+		return res;
+
+	riscv_reg_t value;
+	if (riscv_reg_get(target, &value, GDB_REGNO_MTOPI) != ERROR_OK) {
+		r->mtopi_readable = false;
+		r->mtopei_readable = false;
+	} else if (riscv_reg_get(target, &value, GDB_REGNO_MTOPEI) != ERROR_OK) {
+		LOG_TARGET_INFO(target, "S?aia detected without IMSIC");
+		r->mtopei_readable = false;
+	} else {
+		LOG_TARGET_INFO(target, "S?aia detected with IMSIC");
+	}
+	res = riscv_reg_impl_set_exist(target, GDB_REGNO_MTOPI, r->mtopi_readable);
+	if (res != ERROR_OK)
+		return res;
+
+	return riscv_reg_impl_set_exist(target, GDB_REGNO_MTOPEI, r->mtopei_readable);
+}
+
+/**
+ * This function assumes target's DM to be initialized (target is able to
+ * access DMs registers, execute program buffer, etc.)
+ */
+int riscv013_reg_examine_all(struct target *target)
+{
+	RISCV_INFO(r);
+
+	int res = riscv_reg_impl_init_cache(target);
+	if (res != ERROR_OK)
+		return res;
 
 	init_shared_reg_info(target);
 
+	assert(target->state == TARGET_HALTED);
+
+	res = examine_xlen(target);
+	if (res != ERROR_OK)
+		return res;
+
+	/* Reading CSRs may clobber "s0", "s1", so it should be possible to
+	 * save them in cache. */
+	res = init_cache_entry(target, GDB_REGNO_S0);
+	if (res != ERROR_OK)
+		return res;
+	res = init_cache_entry(target, GDB_REGNO_S1);
+	if (res != ERROR_OK)
+		return res;
+
+	res = examine_misa(target);
+	if (res != ERROR_OK)
+		return res;
+
+	/* Display this as early as possible to help people who are using
+	 * really slow simulators. */
+	LOG_TARGET_DEBUG(target, " XLEN=%d, misa=0x%" PRIx64, riscv_xlen(target), r->misa);
+
+	res = examine_vlenb(target);
+	if (res != ERROR_OK)
+		return res;
+
 	riscv_reg_impl_init_vector_reg_type(target);
 
-	for (uint32_t regno = 0; regno < target->reg_cache->num_regs; ++regno)
-		if (riscv013_init_reg(target, regno) != ERROR_OK)
-			return ERROR_FAIL;
+	res = examine_mtopi(target);
+	if (res != ERROR_OK)
+		return res;
 
-	if (riscv_reg_impl_expose_csrs(target) != ERROR_OK)
-		return ERROR_FAIL;
+	for (uint32_t regno = 0; regno < target->reg_cache->num_regs; ++regno) {
+		res = init_cache_entry(target, regno);
+		if (res != ERROR_OK)
+			return res;
+	}
+
+	res = riscv_reg_impl_expose_csrs(target);
+	if (res != ERROR_OK)
+		return res;
 
 	riscv_reg_impl_hide_csrs(target);
 

--- a/src/target/riscv/riscv-013_reg.h
+++ b/src/target/riscv/riscv-013_reg.h
@@ -13,10 +13,11 @@
  */
 
 /**
- * Init initialize register cache. After this function all registers can be
- * safely accessed via functions described here and in `riscv_reg.h`.
+ * This function assumes target is halted.
+ * After this function all registers can be safely accessed via functions
+ * described here and in `riscv_reg.h`.
  */
-int riscv013_reg_init_all(struct target *target);
+int riscv013_reg_examine_all(struct target *target);
 
 /**
  * This function is used to save the value of a register in cache. The register

--- a/src/target/riscv/riscv_reg_impl.h
+++ b/src/target/riscv/riscv_reg_impl.h
@@ -13,7 +13,7 @@
  * This file describes the helpers to use during register cache initialization
  * of a RISC-V target. Each cache entry proceedes through the following stages:
  *  - not allocated before `riscv_reg_impl_init_cache()`
- *  - not initialized before the call to `riscv_reg_impl_init_one()` with appropriate regno.
+ *  - not initialized before the call to `riscv_reg_impl_init_cache_entry()` with appropriate regno.
  *  - initialized until `riscv_reg_free_all()` is called.
  */
 static inline bool riscv_reg_impl_is_initialized(const struct reg *reg)
@@ -37,8 +37,18 @@ static inline bool riscv_reg_impl_is_initialized(const struct reg *reg)
 int riscv_reg_impl_init_cache(struct target *target);
 
 /** Initialize register. */
-int riscv_reg_impl_init_one(struct target *target, uint32_t regno,
-		const struct reg_arch_type *reg_type);
+int riscv_reg_impl_init_cache_entry(struct target *target, uint32_t regno,
+		bool exist, const struct reg_arch_type *reg_type);
+
+/**
+ * For most registers, returns whether they exist or not.
+ * For some registers the "exist" bit should be set explicitly.
+ */
+bool riscv_reg_impl_gdb_regno_exist(const struct target *target, uint32_t regno);
+
+/** Mark register as existing or not. */
+int riscv_reg_impl_set_exist(const struct target *target,
+		uint32_t regno, bool exist);
 
 /** Return the entry in the register cache of the target. */
 struct reg *riscv_reg_impl_cache_entry(const struct target *target,


### PR DESCRIPTION
* Register file examination is separated.
* Allow to access registers through cache as early as possible to re-use general register access interface and propely track state of the register.
* Reduces the number of operations: S0 and S1 are saved/restored only when needed (targets without abstract CSR access).

Change-Id: I2e205ae4e88733a5c792f8a35cf30325c68d96b2