### PR TITLE
Align RISC-V target header file include guards with OpenOCD coding style guide

### DIFF
--- a/src/target/riscv/asm.h
+++ b/src/target/riscv/asm.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef TARGET__RISCV__ASM_H
-#define TARGET__RISCV__ASM_H
+#ifndef OPENOCD_TARGET_RISCV_ASM_H
+#define OPENOCD_TARGET_RISCV_ASM_H
 
 #include "riscv.h"
 
@@ -37,4 +37,4 @@ static uint32_t store(const struct target *target, unsigned int src,
 	return 0; /* Silence -Werror=return-type */
 }
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_ASM_H */

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef TARGET__RISCV__SCANS_H
-#define TARGET__RISCV__SCANS_H
+#ifndef OPENOCD_TARGET_RISCV_BATCH_H
+#define OPENOCD_TARGET_RISCV_BATCH_H
 
 #include "target/target.h"
 #include "jtag/jtag.h"
@@ -216,4 +216,4 @@ bool riscv_batch_was_batch_busy(const struct riscv_batch *batch);
 void riscv_log_dmi_scan(const struct target *target, int idle, const struct scan_field *field,
 		bool discard_in);
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_BATCH_H */

--- a/src/target/riscv/debug_defines.h
+++ b/src/target/riscv/debug_defines.h
@@ -3,8 +3,8 @@
  * https://github.com/riscv/riscv-debug-spec/ (40b9a05)
  */
 
-#ifndef DEBUG_DEFINES_H
-#define DEBUG_DEFINES_H
+#ifndef OPENOCD_TARGET_RISCV_DEBUG_DEFINES_H
+#define OPENOCD_TARGET_RISCV_DEBUG_DEFINES_H
 #define DTM_IDCODE                          0x01
 /*
  * Identifies the release version of this part.
@@ -3153,4 +3153,5 @@ typedef struct {
 	struct riscv_debug_reg_field_list_t (* const get_fields_head)(riscv_debug_reg_ctx_t context);
 } riscv_debug_reg_info_t;
 riscv_debug_reg_info_t get_riscv_debug_reg_info(enum riscv_debug_reg_ordinal reg_ordinal);
-#endif
+
+#endif /* OPENOCD_TARGET_RISCV_DEBUG_DEFINES_H */

--- a/src/target/riscv/debug_reg_printer.h
+++ b/src/target/riscv/debug_reg_printer.h
@@ -1,5 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
+#ifndef OPENOCD_TARGET_RISCV_DEBUG_REG_PRINTER_H
+#define OPENOCD_TARGET_RISCV_DEBUG_REG_PRINTER_H
+
 #include "debug_defines.h"
 
 enum riscv_debug_reg_show {
@@ -33,3 +36,5 @@ enum riscv_debug_reg_show {
 unsigned int riscv_debug_reg_to_s(char *buf, enum riscv_debug_reg_ordinal reg_ordinal,
 		riscv_debug_reg_ctx_t context, uint64_t value,
 		enum riscv_debug_reg_show show);
+
+#endif /* OPENOCD_TARGET_RISCV_DEBUG_REG_PRINTER_H */

--- a/src/target/riscv/field_helpers.h
+++ b/src/target/riscv/field_helpers.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef FIELD_HELPERS_H
-#define FIELD_HELPERS_H
+#ifndef OPENOCD_TARGET_RISCV_FIELD_HELPERS_H
+#define OPENOCD_TARGET_RISCV_FIELD_HELPERS_H
 
 #include <stdint.h>
 #include <assert.h>
@@ -44,4 +44,4 @@ static inline uint32_t field_value32(uint32_t mask, uint32_t val)
 	return set_field32(0, mask, val);
 }
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_FIELD_HELPERS_H */

--- a/src/target/riscv/gdb_regs.h
+++ b/src/target/riscv/gdb_regs.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef TARGET__RISCV__GDB_REGS_H
-#define TARGET__RISCV__GDB_REGS_H
+#ifndef OPENOCD_TARGET_RISCV_GDB_REGS_H
+#define OPENOCD_TARGET_RISCV_GDB_REGS_H
 
 #include "encoding.h"
 
@@ -125,4 +125,4 @@ enum gdb_regno {
 	GDB_REGNO_COUNT
 };
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_GDB_REGS_H */

--- a/src/target/riscv/opcodes.h
+++ b/src/target/riscv/opcodes.h
@@ -1,5 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
+#ifndef OPENOCD_TARGET_RISCV_OPCODES_H
+#define OPENOCD_TARGET_RISCV_OPCODES_H
+
 #include "encoding.h"
 
 #define ZERO	0
@@ -339,3 +342,4 @@ static uint32_t vslide1down_vx(unsigned int vd, unsigned int vs2,
 	return ((vm & 1) << 25) | inst_rs2(vs2) | inst_rs1(rs1) | inst_rd(vd) | MATCH_VSLIDE1DOWN_VX;
 }
 
+#endif /* OPENOCD_TARGET_RISCV_OPCODES_H */

--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef TARGET__RISCV__PROGRAM_H
-#define TARGET__RISCV__PROGRAM_H
+#ifndef OPENOCD_TARGET_RISCV_PROGRAM_H
+#define OPENOCD_TARGET_RISCV_PROGRAM_H
 
 #include "riscv.h"
 
@@ -77,4 +77,4 @@ int riscv_program_ebreak(struct riscv_program *p);
 
 int riscv_program_addi(struct riscv_program *p, enum gdb_regno d, enum gdb_regno s, int16_t i);
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_PROGRAM_H */

--- a/src/target/riscv/riscv-011.h
+++ b/src/target/riscv/riscv-011.h
@@ -12,4 +12,4 @@ int riscv011_get_register(struct target *target, riscv_reg_t *value,
 int riscv011_set_register(struct target *target, enum gdb_regno regid,
 		riscv_reg_t value);
 
-#endif /*OPENOCD_TARGET_RISCV_RISCV_011_H*/
+#endif /* OPENOCD_TARGET_RISCV_RISCV_011_H */

--- a/src/target/riscv/riscv-011_reg.h
+++ b/src/target/riscv/riscv-011_reg.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef OPENOCD_TARGET_RISCV_RISCV_REG_011_H
-#define OPENOCD_TARGET_RISCV_RISCV_REG_011_H
+#ifndef OPENOCD_TARGET_RISCV_RISCV_011_REG_H
+#define OPENOCD_TARGET_RISCV_RISCV_011_REG_H
 
 #include "target/target.h"
 
@@ -16,4 +16,4 @@
  */
 int riscv011_reg_init_all(struct target *target);
 
-#endif /*OPENOCD_TARGET_RISCV_RISCV_REG_011_H*/
+#endif /* OPENOCD_TARGET_RISCV_RISCV_011_REG_H */

--- a/src/target/riscv/riscv-013.h
+++ b/src/target/riscv/riscv-013.h
@@ -20,4 +20,4 @@ int riscv013_set_register(struct target *target, enum gdb_regno rid,
 int riscv013_set_register_buf(struct target *target, enum gdb_regno regno,
 		const uint8_t *value);
 
-#endif /*OPENOCD_TARGET_RISCV_RISCV_013_H*/
+#endif /* OPENOCD_TARGET_RISCV_RISCV_013_H */

--- a/src/target/riscv/riscv-013_reg.h
+++ b/src/target/riscv/riscv-013_reg.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef OPENOCD_TARGET_RISCV_RISCV_REG_013_H
-#define OPENOCD_TARGET_RISCV_RISCV_REG_013_H
+#ifndef OPENOCD_TARGET_RISCV_RISCV_013_REG_H
+#define OPENOCD_TARGET_RISCV_RISCV_013_REG_H
 
 #include "target/target.h"
 #include "gdb_regs.h"
@@ -28,4 +28,4 @@ int riscv013_reg_init_all(struct target *target);
  */
 int riscv013_reg_save(struct target *target, enum gdb_regno regid);
 
-#endif /*OPENOCD_TARGET_RISCV_RISCV_REG_013_H*/
+#endif /* OPENOCD_TARGET_RISCV_RISCV_013_REG_H */

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
-#ifndef RISCV_H
-#define RISCV_H
+#ifndef OPENOCD_TARGET_RISCV_RISCV_H
+#define OPENOCD_TARGET_RISCV_RISCV_H
 
 struct riscv_program;
 
@@ -437,4 +437,4 @@ int riscv_write_by_any_size(struct target *target, target_addr_t address, uint32
 int riscv_interrupts_disable(struct target *target, uint64_t ie_mask, uint64_t *old_mstatus);
 int riscv_interrupts_restore(struct target *target, uint64_t old_mstatus);
 
-#endif
+#endif /* OPENOCD_TARGET_RISCV_RISCV_H */


### PR DESCRIPTION
Addresses this issue:

- https://github.com/riscv-collab/riscv-openocd/issues/1097

Note that `encoding.h` has not been changed in this repo as it is programatically generated elsewhere, so the include guard would need to be changed there if possible/appropriate

- https://github.com/riscv-collab/riscv-openocd/blob/f5f5f6dd2aeeccc94f0d61a3eaaa07fd8c379473/src/target/riscv/encoding.h#L5-L8