### PR TITLE
add support for 64-bit system profiling

### DIFF
--- a/src/target/cortex_m.h
+++ b/src/target/cortex_m.h
@@ -332,7 +332,8 @@ int cortex_m_remove_watchpoint(struct target *target, struct watchpoint *watchpo
 void cortex_m_enable_breakpoints(struct target *target);
 void cortex_m_enable_watchpoints(struct target *target);
 void cortex_m_deinit_target(struct target *target);
-int cortex_m_profiling(struct target *target, uint32_t *samples,
+int cortex_m_profiling(struct target *target, uint32_t *samples, uint32_t* sample_address_hi32,
+	bool with_range, uint64_t start_address, uint64_t end_address,
 	uint32_t max_num_samples, uint32_t *num_samples, uint32_t seconds);
 
 #endif /* OPENOCD_TARGET_CORTEX_M_H */

--- a/src/target/openrisc/or1k.c
+++ b/src/target/openrisc/or1k.c
@@ -1200,7 +1200,8 @@ static int or1k_checksum_memory(struct target *target, target_addr_t address,
 	return ERROR_FAIL;
 }
 
-static int or1k_profiling(struct target *target, uint32_t *samples,
+static int or1k_profiling(struct target *target, uint32_t *samples, uint32_t *sample_address_hi32,
+		bool with_range, uint64_t start_address, uint64_t end_address,
 		uint32_t max_num_samples, uint32_t *num_samples, uint32_t seconds)
 {
 	struct timeval timeout, now;
@@ -1233,7 +1234,9 @@ static int or1k_profiling(struct target *target, uint32_t *samples,
 			return retval;
 		}
 
-		samples[sample_count++] = reg_value;
+		if (!with_range || (reg_value >= start_address && reg_value < end_address)) {
+			samples[sample_count++] = reg_value;
+		}
 
 		gettimeofday(&now, NULL);
 		if ((sample_count >= max_num_samples) || timeval_compare(&now, &timeout) > 0) {

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3194,7 +3194,7 @@ static int riscv_arch_state(struct target *target)
 	assert(target->state == TARGET_HALTED);
 	const bool semihosting_active = target->semihosting &&
 		target->semihosting->is_active;
-	LOG_USER("%s halted due to %s.%s",
+	LOG_DEBUG("%s halted due to %s.%s",
 			target_name(target),
 			debug_reason_name(target),
 			semihosting_active ? " Semihosting is active." : "");

--- a/src/target/target.h
+++ b/src/target/target.h
@@ -787,8 +787,9 @@ void target_handle_md_output(struct command_invocation *cmd,
 	struct target *target, target_addr_t address, unsigned size,
 	unsigned count, const uint8_t *buffer, bool include_address);
 
-int target_profiling_default(struct target *target, uint32_t *samples, uint32_t
-		max_num_samples, uint32_t *num_samples, uint32_t seconds);
+int target_profiling_default(struct target *target, uint32_t *samples, uint32_t *sample_address_hi32,
+		bool with_range, uint64_t start_address, uint64_t end_address,
+		uint32_t max_num_samples, uint32_t *num_samples, uint32_t seconds);
 
 #define ERROR_TARGET_INVALID	(-300)
 #define ERROR_TARGET_INIT_FAILED (-301)

--- a/src/target/target_type.h
+++ b/src/target/target_type.h
@@ -297,7 +297,8 @@ struct target_type {
 
 	/* do target profiling
 	 */
-	int (*profiling)(struct target *target, uint32_t *samples,
+	int (*profiling)(struct target *target, uint32_t *samples, uint32_t *sample_address_hi32,
+			bool with_range, uint64_t start_address, uint64_t end_address,
 			uint32_t max_num_samples, uint32_t *num_samples, uint32_t seconds);
 
 	/* Return the number of address bits this target supports. This will


### PR DESCRIPTION
Hello riscv-collab!

Current profile implementation looks outdated and doesn't support 64-bit systems, so I've implemented this support for my purposes and want to share it.

To store 64-bit addresses I used the same uint32_t samples array do keep lower 32-bits of each sample address, and higher 32-bit of address is passed though a separate sample_address_hi32 pointer. The latter does not store 32 bit word for every sample but only stores a single uint32_t for all samples assuming that all samples fit into a single 32-bit slice and have equal higher 32 bits. Bigger slice will not fit into reasonable buckets array anyway.

I've also added start_address and end_address arguments to collection function arguments, so it can filter out samples that are not interesting and make sure that sample_address_hi32 calculated properly.

Please review the proposed change and accept it if it looks useful. I'm not sure if it should go to riscv repo or to the original openocd repo, I've not found the guidelines on how to choose between them.