### PR TITLE
target/riscv: manage triggers available to OpenOCD for internal use

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -11524,6 +11524,21 @@ as in the mie CSR (defined in the RISC-V Privileged Spec).
 For details on this trigger type, see the RISC-V Debug Specification.
 @end deffn
 
+@deffn {Command} {riscv reserve_trigger} [index @option{on|off}]
+Manages the set of reserved triggers. Reserving a trigger results in OpenOCD
+not using it internally (e.g. skipping it when setting a watchpoint or a
+hardware breakpoint), so that the user or the application has unfettered
+control over the trigger. By default there are no reserved triggers.
+
+@enumerate
+@item @var{index} specifies the index of a trigger to reserve or free up.
+@item The second argument specifies whether the trigger should be reserved
+(@var{on}) or a prior reservation cancelled (@var{off}).
+@item If called without parameters, returns indices of reserved triggers.
+@end enumerate
+
+@end deffn
+
 @deffn {Command} {riscv itrigger clear}
 Clear the type 4 trigger that was set using @command{riscv itrigger set}.
 @end deffn

--- a/src/target/riscv/riscv-013_reg.c
+++ b/src/target/riscv/riscv-013_reg.c
@@ -44,7 +44,6 @@ static int riscv013_reg_get(struct reg *reg)
 static int riscv013_reg_set(struct reg *reg, uint8_t *buf)
 {
 	struct target *target = riscv_reg_impl_get_target(reg);
-	RISCV_INFO(r);
 
 	char *str = buf_to_hex_str(buf, reg->size);
 	LOG_TARGET_DEBUG(target, "Write 0x%s to %s (valid=%d).", str, reg->name,
@@ -56,17 +55,6 @@ static int riscv013_reg_set(struct reg *reg, uint8_t *buf)
 			riscv_supports_extension(target, 'E') &&
 			buf_get_u64(buf, 0, reg->size) == 0)
 		return ERROR_OK;
-
-	if (reg->number == GDB_REGNO_TDATA1 ||
-			reg->number == GDB_REGNO_TDATA2) {
-		r->manual_hwbp_set = true;
-		/* When enumerating triggers, we clear any triggers with DMODE set,
-		 * assuming they were left over from a previous debug session. So make
-		 * sure that is done before a user might be setting their own triggers.
-		 */
-		if (riscv_enumerate_triggers(target) != ERROR_OK)
-			return ERROR_FAIL;
-	}
 
 	if (reg->number >= GDB_REGNO_V0 && reg->number <= GDB_REGNO_V31) {
 		if (riscv013_set_register_buf(target, reg->number, buf) != ERROR_OK)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -272,9 +272,7 @@ struct riscv_info {
 	struct reg_data_type_union vector_union;
 	struct reg_data_type type_vector;
 
-	/* Set when trigger registers are changed by the user. This indicates we need
-	 * to beware that we may hit a trigger that we didn't realize had been set. */
-	bool manual_hwbp_set;
+	bool *reserved_triggers;
 
 	/* Memory access methods to use, ordered by priority, highest to lowest. */
 	int mem_access_methods[RISCV_NUM_MEM_ACCESS_METHODS];


### PR DESCRIPTION
Before the change, if the user wrote to any `tdata*` register, OpenOCD would sometimes start to disable all the triggers (by writing zeroes to `tdata1`) and re-enable them again (by witing all trigger registers to the values read before for each `tselect` value), e.g. on `step` (see `disable/enable_triggers()`).

There are a couple of issues with such approach:
1. RISC-V Debug Specification does not require custom register types to support re-enabling by such sequence of writes (e.g. some custom trigger type may require writing a custom CSR to enable it).
2. OpenOCD may still overwrite these triggers when a user asks to set a new WP.

This commit introduces `riscv reserve_trigger ...` command to explicitly mark the triggers OpenOCD should not touch.

Such approach allows to separate management of custom triggers and offload it onto the user (e.g. disable/enable such triggers by setting up an event handler on `step`-related events).

Change-Id: I3339000445185ab221368442a070f412bf44bfab