### PR TITLE
target/riscv: restrict BSCAN-related commands to before-`init`

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -11354,10 +11354,15 @@ Display/set the current core displayed in GDB. This is needed only if
 @code{riscv smp} was used.
 @end deffn
 
-@deffn {Command} {riscv use_bscan_tunnel} value
+@deffn {Command} {riscv use_bscan_tunnel} width [type]
 Enable or disable use of a BSCAN tunnel to reach the Debug Module. Supply the
-width of the DM transport TAP's instruction register to enable. Supply a
-value of 0 to disable.
+@var{width} of the DM transport TAP's instruction register to enable. The
+@var{width} should fit into 7 bits. Supply a value of 0 to disable.
+Pass a second argument (optional) to indicate Bscan Tunnel Type:
+@enumerate
+@item 0:(default) NESTED_TAP
+@item 1: DATA_REGISTER
+@end enumerate
 
 This BSCAN tunnel interface is specific to SiFive IP. Anybody may implement
 it, but currently there is no good documentation on it. In a nutshell, this

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -365,7 +365,7 @@ extern struct scan_field select_idcode;
 extern struct scan_field *bscan_tunneled_select_dmi;
 extern uint32_t bscan_tunneled_select_dmi_num_fields;
 typedef enum { BSCAN_TUNNEL_NESTED_TAP, BSCAN_TUNNEL_DATA_REGISTER } bscan_tunnel_type_t;
-extern int bscan_tunnel_ir_width;
+extern uint8_t bscan_tunnel_ir_width;
 
 int dtmcontrol_scan_via_bscan(struct target *target, uint32_t out, uint32_t *in_ptr);
 void select_dmi_via_bscan(struct target *target);


### PR DESCRIPTION
Logically, BSCAN tunneling is used to establish a connection, therefore it should be set up before the communication starts (i.e. before `init`).

Moreover, current implementation does not support changing `bscan_tunnel_ir_width` after `init`. This is evident by RISC-V handler of the `init` itself.
Link: https://github.com/riscv-collab/riscv-openocd/blob/9a23c9e67978f77d9166102cefc7b537b714b561/src/target/riscv/riscv.c#L467-L481

Change-Id: I817c6a996f7f7171b2286e181daf1092bd358f69