### PR TITLE
target/riscv: re-apply patch do stop avoid warnings when a non-existent CSR is hidden

### DIFF
--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -730,7 +730,7 @@ int riscv_reg_impl_expose_csrs(const struct target *target)
 			struct reg * const reg = riscv_reg_impl_cache_entry(target, regno);
 			const unsigned int csr_number = regno - GDB_REGNO_CSR0;
 			if (reg->exist) {
-				LOG_TARGET_WARNING(target,
+				LOG_TARGET_DEBUG(target,
 						"Not exposing CSR %d: register already exists.",
 						csr_number);
 				continue;


### PR DESCRIPTION
the original fix was introduced in https://github.com/riscv-collab/riscv-openocd/commit/b201a5db23c0db34c0e10fd1c7c08fc73a5ec3fc but was lost in https://github.com/riscv-collab/riscv-openocd/commit/3883b03aaafef5e1eff423664f7ea2e1d8f14ba4