### PR TITLE
target/riscv: Mismatch napot when mcontrol.maskmax is zero

### DIFF
--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -154,6 +154,9 @@ struct riscv_info {
 	/* record the tinfo of each trigger */
 	unsigned int trigger_tinfo[RISCV_MAX_TRIGGERS];
 
+	/* record the tdata1.maskmax of each trigger */
+	unsigned int trigger_maskmax[RISCV_MAX_TRIGGERS];
+
 	/* For each physical trigger contains:
 	 * -1: the hwbp is available
 	 * -4: The trigger is used by the itrigger command


### PR DESCRIPTION
Reference release specification (https://github.com/riscv/riscv-debug-spec/blob/release/riscv-debug-release.pdf), in section 5.2.9 introduce maskmx：
A value of 0 indicates that only exact value matches are supported (one byte range).

so. when tdata1.type=2, napot is unsupported, `try_setup_single_match_trigger` should skip `match=1` .