### PR TITLE
target/riscv: remove duplicate of progbufsize field

### DIFF
--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -183,8 +183,8 @@ int riscv_program_ebreak(struct riscv_program *p)
 {
 	struct target *target = p->target;
 	RISCV_INFO(r);
-	if (p->instruction_count == riscv_progbuf_size(p->target) &&
-			r->impebreak) {
+	if (p->instruction_count == riscv_progbuf_size(target) &&
+			r->get_impebreak(target)) {
 		return ERROR_OK;
 	}
 	return riscv_program_insert(p, ebreak());

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -2356,6 +2356,16 @@ static int riscv011_authdata_write(struct target *target, uint32_t value, unsign
 	return ERROR_OK;
 }
 
+static bool riscv011_get_impebreak(const struct target *target)
+{
+	return false;
+}
+
+static unsigned int riscv011_get_progbufsize(const struct target *target)
+{
+	return 0;
+}
+
 static int init_target(struct command_context *cmd_ctx,
 		struct target *target)
 {
@@ -2365,6 +2375,8 @@ static int init_target(struct command_context *cmd_ctx,
 	generic_info->authdata_read = &riscv011_authdata_read;
 	generic_info->authdata_write = &riscv011_authdata_write;
 	generic_info->print_info = &riscv011_print_info;
+	generic_info->get_impebreak = &riscv011_get_impebreak;
+	generic_info->get_progbufsize = &riscv011_get_progbufsize;
 
 	generic_info->version_specific = calloc(1, sizeof(riscv011_info_t));
 	if (!generic_info->version_specific)

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -5569,7 +5569,7 @@ static enum riscv_halt_reason riscv_halt_reason(struct target *target)
 size_t riscv_progbuf_size(struct target *target)
 {
 	RISCV_INFO(r);
-	return r->progbuf_size;
+	return r->get_progbufsize(target);
 }
 
 int riscv_write_progbuf(struct target *target, int index, riscv_insn_t insn)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -167,12 +167,6 @@ struct riscv_info {
 	 * most recent halt was not caused by a trigger, then this is -1. */
 	int64_t trigger_hit;
 
-	/* The number of entries in the program buffer. */
-	int progbuf_size;
-
-	/* This hart contains an implicit ebreak at the end of the program buffer. */
-	bool impebreak;
-
 	bool triggers_enumerated;
 
 	/* Decremented every scan, and when it reaches 0 we clear the learned
@@ -235,6 +229,9 @@ struct riscv_info {
 
 	int (*dmi_read)(struct target *target, uint32_t *value, uint32_t address);
 	int (*dmi_write)(struct target *target, uint32_t address, uint32_t value);
+
+	bool (*get_impebreak)(const struct target *target);
+	unsigned int (*get_progbufsize)(const struct target *target);
 
 	/* Get the DMI address of target's DM's register.
 	 * The function should return the passed address


### PR DESCRIPTION
Remove duplicate of progbufsize field
* removed `progbuf_size`  field from `riscv_info`; added getter
* moved `impebreak` field from `riscv_info` to 'riscv013_info' as implementation dependent field; added getter