### PR TITLE
Revert "target/riscv: re-apply patch do stop avoid warnings when a no… …n-existent CSR is hidden"

### DIFF
--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -756,7 +756,7 @@ void riscv_reg_impl_hide_csrs(const struct target *target)
 			struct reg * const reg = riscv_reg_impl_cache_entry(target, regno);
 			const unsigned int csr_number = regno - GDB_REGNO_CSR0;
 			if (!reg->exist) {
-				LOG_TARGET_WARNING(target,
+				LOG_TARGET_DEBUG(target,
 						"Not hiding CSR %d: register does not exist.",
 						csr_number);
 				continue;

--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -730,7 +730,7 @@ int riscv_reg_impl_expose_csrs(const struct target *target)
 			struct reg * const reg = riscv_reg_impl_cache_entry(target, regno);
 			const unsigned int csr_number = regno - GDB_REGNO_CSR0;
 			if (reg->exist) {
-				LOG_TARGET_DEBUG(target,
+				LOG_TARGET_WARNING(target,
 						"Not exposing CSR %d: register already exists.",
 						csr_number);
 				continue;


### PR DESCRIPTION
This PR fixes the issue with #1118 by reverting commit https://github.com/riscv-collab/riscv-openocd/commit/e56dc61697e91cf7273476ec3126078692a5e387 and re-applying https://github.com/riscv-collab/riscv-openocd/commit/b201a5db23c0db34c0e10fd1c7c08fc73a5ec3fc

The reverted commit claims to be the same as https://github.com/riscv-collab/riscv-openocd/commit/b201a5db23c0db34c0e10fd1c7c08fc73a5ec3fc, but it's not -- it changes the warning in `riscv_reg_impl_expose_csrs()` instead of the one in `riscv_reg_impl_hide_csrs()`.