### PR TITLE
Move FD_SETSIZE to configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,15 +37,13 @@ DISTCLEANFILES += jimtcl/jsmn/jsmn.o
 endif
 
 # common flags used in openocd build
-AM_CFLAGS = $(GCC_WARNINGS)\
-			  -DFD_SETSIZE=128
+AM_CFLAGS = $(GCC_WARNINGS)
 
 AM_CPPFLAGS = $(HOST_CPPFLAGS)\
 			  -I$(top_srcdir)/src \
 			  -I$(top_builddir)/src \
 			  -DPKGDATADIR=\"$(pkgdatadir)\" \
-			  -DBINDIR=\"$(bindir)\"\
-			  -DFD_SETSIZE=128
+			  -DBINDIR=\"$(bindir)\"
 
 if INTERNAL_JIMTCL
 AM_CPPFLAGS += -I$(top_srcdir)/jimtcl \

--- a/configure.ac
+++ b/configure.ac
@@ -436,7 +436,7 @@ AS_CASE([$host],
     # In case enable_buspirate=auto, make sure it will not be built.
     enable_buspirate=no
 
-    AC_SUBST([HOST_CPPFLAGS], [-D__USE_MINGW_ANSI_STDIO])
+    AC_SUBST([HOST_CPPFLAGS], ["-D__USE_MINGW_ANSI_STDIO -DFD_SETSIZE=128"])
   ],
   [*darwin*], [
     is_darwin=yes


### PR DESCRIPTION
The commit from the pull request #644 sets the macro FD_SETSIZE to 128 for every host OS, while it is needed on Windows only. Note that this macro has a much higher value on other OS and after this commit it get reduced to 128 only.

Since in configure.ac is already present a hook to change the compile defines for Windows, move there also FD_SETSIZE.

I have pushed in upstream OpenOCD the patch https://review.openocd.org/c/openocd/+/8503 that, together with this pull request, aligns the two repositories on this topic.
I will wait for review and eventual merge of this pull request before merging the corresponding patch upstream. Of course, the review process is open upstream too.
Hope this helps the sync between the two repositories.