### PR TITLE
Fix `riscv013_invalidate_cached_progbuf()`

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -5282,8 +5282,7 @@ static int riscv013_invalidate_cached_progbuf(struct target *target)
 	}
 
 	LOG_TARGET_DEBUG(target, "Invalidating progbuf cache");
-	for (unsigned int i = 0; i < 15; i++)
-		dm->progbuf_cache[i] = 0;
+	memset(dm->progbuf_cache, 0, sizeof(dm->progbuf_cache));
 	return ERROR_OK;
 }
 


### PR DESCRIPTION
Fix for this issue:

- https://github.com/riscv-collab/riscv-openocd/issues/1139

Using `memset()` instead of manual loop to zeroize the whole array since `memset()` is used elsewhere for similar purposes and is more reliable (no miscounting elements).