### PR TITLE
Merge up to 1173473f662bbdf6d1499654568256257eee6cdd from upstream

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -2227,7 +2227,7 @@ the port @var{number} defaults to 6666.
 When specified as "disabled", this service is not activated.
 @end deffn
 
-@deffn {Config Command} {telnet_port} [number]
+@deffn {Config Command} {telnet port} [number]
 Specify or query the
 port on which to listen for incoming telnet connections.
 This port is intended for interaction with one human through TCL commands.

--- a/src/flash/nor/atsame5.c
+++ b/src/flash/nor/atsame5.c
@@ -85,6 +85,9 @@
 #define SAME_SERIES_51		0x01
 #define SAME_SERIES_53		0x03
 #define SAME_SERIES_54		0x04
+#define PIC32CXSG_SERIES_41	0x07
+#define PIC32CXSG_SERIES_60	0x00
+#define PIC32CXSG_SERIES_61	0x02
 
 /* Device ID macros */
 #define SAMD_GET_PROCESSOR(id) (id >> 28)
@@ -148,6 +151,27 @@ static const struct samd_part same54_parts[] = {
 	{ 0x03, "SAME54N19A", 512, 192 },
 };
 
+/* See PIC32CX SG41/SG60/SG61 Family Silicon Errata and Datasheet Clarifications
+ * DS80000985G */
+/* Known PIC32CX-SG41 parts. */
+static const struct samd_part pic32cxsg41_parts[] = {
+	{ 0x00, "PIC32CX1025SG41128", 1024, 256 },
+	{ 0x01, "PIC32CX1025SG41100", 1024, 256 },
+	{ 0x02, "PIC32CX1025SG41064", 1024, 256 },
+};
+
+/* Known PIC32CX-SG60 parts. */
+static const struct samd_part pic32cxsg60_parts[] = {
+	{ 0x00, "PIC32CX1025SG60128", 1024, 256 },
+	{ 0x01, "PIC32CX1025SG60100", 1024, 256 },
+};
+
+/* Known PIC32CX-SG61 parts. */
+static const struct samd_part pic32cxsg61_parts[] = {
+	{ 0x00, "PIC32CX1025SG61128", 1024, 256 },
+	{ 0x01, "PIC32CX1025SG61100", 1024, 256 },
+};
+
 /* Each family of parts contains a parts table in the DEVSEL field of DID.  The
  * processor ID, family ID, and series ID are used to determine which exact
  * family this is and then we can use the corresponding table. */
@@ -169,6 +193,12 @@ static const struct samd_family samd_families[] = {
 		same53_parts, ARRAY_SIZE(same53_parts) },
 	{ SAMD_PROCESSOR_M4, SAMD_FAMILY_E, SAME_SERIES_54,
 		same54_parts, ARRAY_SIZE(same54_parts) },
+	{ SAMD_PROCESSOR_M4, SAMD_FAMILY_E, PIC32CXSG_SERIES_41,
+		pic32cxsg41_parts, ARRAY_SIZE(pic32cxsg41_parts) },
+	{ SAMD_PROCESSOR_M4, SAMD_FAMILY_E, PIC32CXSG_SERIES_60,
+		pic32cxsg60_parts, ARRAY_SIZE(pic32cxsg60_parts) },
+	{ SAMD_PROCESSOR_M4, SAMD_FAMILY_E, PIC32CXSG_SERIES_61,
+		pic32cxsg61_parts, ARRAY_SIZE(pic32cxsg61_parts) },
 };
 
 struct samd_info {

--- a/src/helper/binarybuffer.c
+++ b/src/helper/binarybuffer.c
@@ -57,49 +57,49 @@ void *buf_cpy(const void *from, void *_to, unsigned size)
 	return _to;
 }
 
-static bool buf_cmp_masked(uint8_t a, uint8_t b, uint8_t m)
+static bool buf_eq_masked(uint8_t a, uint8_t b, uint8_t m)
 {
-	return (a & m) != (b & m);
+	return (a & m) == (b & m);
 }
-static bool buf_cmp_trailing(uint8_t a, uint8_t b, uint8_t m, unsigned trailing)
+static bool buf_eq_trailing(uint8_t a, uint8_t b, uint8_t m, unsigned trailing)
 {
 	uint8_t mask = (1 << trailing) - 1;
-	return buf_cmp_masked(a, b, mask & m);
+	return buf_eq_masked(a, b, mask & m);
 }
 
-bool buf_cmp(const void *_buf1, const void *_buf2, unsigned size)
+bool buf_eq(const void *_buf1, const void *_buf2, unsigned size)
 {
 	if (!_buf1 || !_buf2)
-		return _buf1 != _buf2;
+		return _buf1 == _buf2;
 
 	unsigned last = size / 8;
 	if (memcmp(_buf1, _buf2, last) != 0)
-		return true;
+		return false;
 
 	unsigned trailing = size % 8;
 	if (!trailing)
-		return false;
+		return true;
 
 	const uint8_t *buf1 = _buf1, *buf2 = _buf2;
-	return buf_cmp_trailing(buf1[last], buf2[last], 0xff, trailing);
+	return buf_eq_trailing(buf1[last], buf2[last], 0xff, trailing);
 }
 
-bool buf_cmp_mask(const void *_buf1, const void *_buf2,
+bool buf_eq_mask(const void *_buf1, const void *_buf2,
 	const void *_mask, unsigned size)
 {
 	if (!_buf1 || !_buf2)
-		return _buf1 != _buf2 || _buf1 != _mask;
+		return _buf1 == _buf2 && _buf1 == _mask;
 
 	const uint8_t *buf1 = _buf1, *buf2 = _buf2, *mask = _mask;
 	unsigned last = size / 8;
 	for (unsigned i = 0; i < last; i++) {
-		if (buf_cmp_masked(buf1[i], buf2[i], mask[i]))
-			return true;
+		if (!buf_eq_masked(buf1[i], buf2[i], mask[i]))
+			return false;
 	}
 	unsigned trailing = size % 8;
 	if (!trailing)
-		return false;
-	return buf_cmp_trailing(buf1[last], buf2[last], mask[last], trailing);
+		return true;
+	return buf_eq_trailing(buf1[last], buf2[last], mask[last], trailing);
 }
 
 void *buf_set_ones(void *_buf, unsigned size)

--- a/src/helper/binarybuffer.h
+++ b/src/helper/binarybuffer.h
@@ -172,8 +172,8 @@ static inline uint64_t buf_get_u64(const uint8_t *_buffer,
  */
 uint32_t flip_u32(uint32_t value, unsigned width);
 
-bool buf_cmp(const void *buf1, const void *buf2, unsigned size);
-bool buf_cmp_mask(const void *buf1, const void *buf2,
+bool buf_eq(const void *buf1, const void *buf2, unsigned size);
+bool buf_eq_mask(const void *buf1, const void *buf2,
 		const void *mask, unsigned size);
 
 /**

--- a/src/jtag/core.c
+++ b/src/jtag/core.c
@@ -881,9 +881,9 @@ static int jtag_check_value_inner(uint8_t *captured, uint8_t *in_check_value,
 	int compare_failed;
 
 	if (in_check_mask)
-		compare_failed = buf_cmp_mask(captured, in_check_value, in_check_mask, num_bits);
+		compare_failed = !buf_eq_mask(captured, in_check_value, in_check_mask, num_bits);
 	else
-		compare_failed = buf_cmp(captured, in_check_value, num_bits);
+		compare_failed = !buf_eq(captured, in_check_value, num_bits);
 
 	if (compare_failed) {
 		char *captured_str, *in_check_value_str;

--- a/src/rtos/rtos_nuttx_stackings.h
+++ b/src/rtos/rtos_nuttx_stackings.h
@@ -5,6 +5,15 @@
 
 #include "rtos.h"
 
+/* Used to index the list of retrieved symbols. See nuttx_symbol_list for the order. */
+enum nuttx_symbol_vals {
+	NX_SYM_READYTORUN = 0,
+	NX_SYM_PIDHASH,
+	NX_SYM_NPIDHASH,
+	NX_SYM_TCB_INFO,
+	NX_SYM_REG_OFFSETS,
+};
+
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m;
 extern const struct rtos_register_stacking nuttx_stacking_cortex_m_fpu;
 extern const struct rtos_register_stacking nuttx_riscv_stacking;

--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -1838,18 +1838,9 @@ static int gdb_breakpoint_watchpoint_packet(struct connection *connection,
 						return ERROR_FAIL;
 				}
 				retval = breakpoint_add(target, address, size, bp_type);
-				if (retval == ERROR_NOT_IMPLEMENTED) {
-					/* Send empty reply to report that breakpoints of this type are not supported */
-					gdb_put_packet(connection, "", 0);
-				} else if (retval != ERROR_OK) {
-					retval = gdb_error(connection, retval);
-					if (retval != ERROR_OK)
-						return retval;
-				} else
-					gdb_put_packet(connection, "OK", 2);
 			} else {
-				breakpoint_remove(target, address);
-				gdb_put_packet(connection, "OK", 2);
+				assert(packet[0] == 'z');
+				retval = breakpoint_remove(target, address);
 			}
 			break;
 		case 2:
@@ -1858,26 +1849,26 @@ static int gdb_breakpoint_watchpoint_packet(struct connection *connection,
 		{
 			if (packet[0] == 'Z') {
 				retval = watchpoint_add(target, address, size, wp_type, 0, WATCHPOINT_IGNORE_DATA_VALUE_MASK);
-				if (retval == ERROR_NOT_IMPLEMENTED) {
-					/* Send empty reply to report that watchpoints of this type are not supported */
-					gdb_put_packet(connection, "", 0);
-				} else if (retval != ERROR_OK) {
-					retval = gdb_error(connection, retval);
-					if (retval != ERROR_OK)
-						return retval;
-				} else
-					gdb_put_packet(connection, "OK", 2);
 			} else {
-				watchpoint_remove(target, address);
-				gdb_put_packet(connection, "OK", 2);
+				assert(packet[0] == 'z');
+				retval = watchpoint_remove(target, address);
 			}
 			break;
 		}
 		default:
+		{
+			retval = ERROR_NOT_IMPLEMENTED;
 			break;
+		}
 	}
 
-	return ERROR_OK;
+	if (retval == ERROR_NOT_IMPLEMENTED) {
+		/* Send empty reply to report that watchpoints of this type are not supported */
+		return gdb_put_packet(connection, "", 0);
+	}
+	if (retval != ERROR_OK)
+		return gdb_error(connection, retval);
+	return gdb_put_packet(connection, "OK", 2);
 }
 
 /* print out a string and allocate more space as needed,

--- a/src/server/startup.tcl
+++ b/src/server/startup.tcl
@@ -113,3 +113,9 @@ proc "tcl_trace" {state} {
 	echo "DEPRECATED! use 'tcl trace' not 'tcl_trace'"
 	eval tcl trace $state
 }
+
+lappend _telnet_autocomplete_skip "telnet_port"
+proc "telnet_port" {args} {
+	echo "DEPRECATED! use 'telnet port', not 'telnet_port'"
+	eval telnet port $args
+}

--- a/src/server/telnet_server.c
+++ b/src/server/telnet_server.c
@@ -967,7 +967,6 @@ int telnet_init(char *banner)
 	return ERROR_OK;
 }
 
-/* daemon configuration command telnet_port */
 COMMAND_HANDLER(handle_telnet_port_command)
 {
 	return CALL_COMMAND_HANDLER(server_pipe_command, &telnet_port);
@@ -978,6 +977,19 @@ COMMAND_HANDLER(handle_exit_command)
 	return ERROR_COMMAND_CLOSE_CONNECTION;
 }
 
+static const struct command_registration telnet_subcommand_handlers[] = {
+	{
+		.name = "port",
+		.handler = handle_telnet_port_command,
+		.mode = COMMAND_CONFIG,
+		.help = "Specify port on which to listen "
+			"for incoming telnet connections.  "
+			"Read help on 'gdb port'.",
+		.usage = "[port_num]",
+	},
+	COMMAND_REGISTRATION_DONE
+};
+
 static const struct command_registration telnet_command_handlers[] = {
 	{
 		.name = "exit",
@@ -987,13 +999,11 @@ static const struct command_registration telnet_command_handlers[] = {
 		.help = "exit telnet session",
 	},
 	{
-		.name = "telnet_port",
-		.handler = handle_telnet_port_command,
+		.name = "telnet",
+		.chain = telnet_subcommand_handlers,
 		.mode = COMMAND_CONFIG,
-		.help = "Specify port on which to listen "
-			"for incoming telnet connections.  "
-			"Read help on 'gdb port'.",
-		.usage = "[port_num]",
+		.help = "telnet commands",
+		.usage = "",
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/svf/svf.c
+++ b/src/svf/svf.c
@@ -932,7 +932,7 @@ static int svf_check_tdo(void)
 		index_var = svf_check_tdo_para[i].buffer_offset;
 		len = svf_check_tdo_para[i].bit_len;
 		if ((svf_check_tdo_para[i].enabled)
-				&& buf_cmp_mask(&svf_tdi_buffer[index_var], &svf_tdo_buffer[index_var],
+				&& !buf_eq_mask(&svf_tdi_buffer[index_var], &svf_tdo_buffer[index_var],
 				&svf_mask_buffer[index_var], len)) {
 			LOG_ERROR("tdo check error at line %d",
 				svf_check_tdo_para[i].line_num);

--- a/src/target/armv8.h
+++ b/src/target/armv8.h
@@ -213,6 +213,8 @@ struct armv8_common {
 	/* True if OpenOCD provides pointer auth related info to GDB */
 	bool enable_pauth;
 
+	bool sticky_reset;
+
 	/* last run-control command issued to this target (resume, halt, step) */
 	enum run_control_op last_run_control_op;
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -357,8 +357,8 @@ static void select_dmi(struct target *target)
 		select_dmi_via_bscan(target);
 		return;
 	}
-	if (buf_cmp(target->tap->cur_instr, select_dbus.out_value,
-				target->tap->ir_length) == 0)
+	if (buf_eq(target->tap->cur_instr, select_dbus.out_value,
+				target->tap->ir_length))
 		return;
 	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
 }


### PR DESCRIPTION
1ae6b07b45198618c3f0975fd49de59cf6c04e7a replaced `buf_cmp()` with `buf_eq()`, so a96a0a4e3993de7f7169a306aa0202e0f3e26f4f needs to be adjusted.