### PR TITLE
target/riscv: check other TAPs in `select_dmi()`

### DIFF
--- a/src/jtag/jtag.h
+++ b/src/jtag/jtag.h
@@ -151,6 +151,7 @@ const char *jtag_tap_name(const struct jtag_tap *tap);
 struct jtag_tap *jtag_tap_by_string(const char *dotted_name);
 struct jtag_tap *jtag_tap_by_jim_obj(Jim_Interp *interp, Jim_Obj *obj);
 struct jtag_tap *jtag_tap_by_position(unsigned int abs_position);
+/* FIXME: "jtag_tap_next_enabled()" should accept a const pointer. */
 struct jtag_tap *jtag_tap_next_enabled(struct jtag_tap *p);
 unsigned int jtag_tap_count_enabled(void);
 unsigned int jtag_tap_count(void);


### PR DESCRIPTION
If some other TAP is not in BYPASS, an IR scan is needed to select BYPASS on that TAP.

Change-Id: Iae425a415109b1a853db3718762661877eea56e8