### PR TITLE
target: riscv: convert 'unsigned' to 'unsigned int'

### DIFF
--- a/src/target/riscv/opcodes.h
+++ b/src/target/riscv/opcodes.h
@@ -194,26 +194,26 @@ static uint32_t fld(unsigned int dest, unsigned int base, uint16_t offset)
 	return imm_i(offset) | inst_rs1(base) | inst_rd(dest) | MATCH_FLD;
 }
 
-static uint32_t fmv_x_w(unsigned dest, unsigned src) __attribute__ ((unused));
-static uint32_t fmv_x_w(unsigned dest, unsigned src)
+static uint32_t fmv_x_w(unsigned int dest, unsigned int src) __attribute__ ((unused));
+static uint32_t fmv_x_w(unsigned int dest, unsigned int src)
 {
 	return inst_rs1(src) | inst_rd(dest) | MATCH_FMV_X_W;
 }
 
-static uint32_t fmv_x_d(unsigned dest, unsigned src) __attribute__ ((unused));
-static uint32_t fmv_x_d(unsigned dest, unsigned src)
+static uint32_t fmv_x_d(unsigned int dest, unsigned int src) __attribute__ ((unused));
+static uint32_t fmv_x_d(unsigned int dest, unsigned int src)
 {
 	return inst_rs1(src) | inst_rd(dest) | MATCH_FMV_X_D;
 }
 
-static uint32_t fmv_w_x(unsigned dest, unsigned src) __attribute__ ((unused));
-static uint32_t fmv_w_x(unsigned dest, unsigned src)
+static uint32_t fmv_w_x(unsigned int dest, unsigned int src) __attribute__ ((unused));
+static uint32_t fmv_w_x(unsigned int dest, unsigned int src)
 {
 	return inst_rs1(src) | inst_rd(dest) | MATCH_FMV_W_X;
 }
 
-static uint32_t fmv_d_x(unsigned dest, unsigned src) __attribute__ ((unused));
-static uint32_t fmv_d_x(unsigned dest, unsigned src)
+static uint32_t fmv_d_x(unsigned int dest, unsigned int src) __attribute__ ((unused));
+static uint32_t fmv_d_x(unsigned int dest, unsigned int src)
 {
 	return inst_rs1(src) | inst_rd(dest) | MATCH_FMV_D_X;
 }

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -30,7 +30,7 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 
 int riscv_program_write(struct riscv_program *program)
 {
-	for (unsigned i = 0; i < program->instruction_count; ++i) {
+	for (unsigned int i = 0; i < program->instruction_count; ++i) {
 		LOG_TARGET_DEBUG(program->target, "progbuf[%02x] = DASM(0x%08x)",
 				i, program->progbuf[i]);
 		if (riscv_write_progbuf(program->target, i, program->progbuf[i]) != ERROR_OK)

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -443,7 +443,7 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 	 * While somewhat nonintuitive, this is an efficient way to get the data.
 	 */
 
-	unsigned i = 0;
+	unsigned int i = 0;
 	do {
 		status = dbus_scan(target, &address_in, &value, DBUS_OP_READ, address, 0);
 		if (status == DBUS_STATUS_BUSY)
@@ -464,7 +464,7 @@ static uint64_t dbus_read(struct target *target, uint16_t address)
 static void dbus_write(struct target *target, uint16_t address, uint64_t value)
 {
 	dbus_status_t status = DBUS_STATUS_BUSY;
-	unsigned i = 0;
+	unsigned int i = 0;
 	while (status == DBUS_STATUS_BUSY && i++ < 256) {
 		status = dbus_scan(target, NULL, NULL, DBUS_OP_WRITE, address, value);
 		if (status == DBUS_STATUS_BUSY)
@@ -625,13 +625,13 @@ static void scans_add_read(scans_t *scans, slot_t slot, bool set_interrupt)
 }
 
 static uint32_t scans_get_u32(scans_t *scans, unsigned int index,
-		unsigned first, unsigned num)
+		unsigned int first, unsigned int num)
 {
 	return buf_get_u32(scans->in + scans->scan_size * index, first, num);
 }
 
 static uint64_t scans_get_u64(scans_t *scans, unsigned int index,
-		unsigned first, unsigned num)
+		unsigned int first, unsigned int num)
 {
 	return buf_get_u64(scans->in + scans->scan_size * index, first, num);
 }
@@ -663,7 +663,7 @@ static int read_bits(struct target *target, bits_t *result)
 	riscv011_info_t *info = get_info(target);
 
 	do {
-		unsigned i = 0;
+		unsigned int i = 0;
 		do {
 			status = dbus_scan(target, &address_in, &value, DBUS_OP_READ, 0, 0);
 			if (status == DBUS_STATUS_BUSY) {
@@ -1257,7 +1257,7 @@ static int register_write(struct target *target, unsigned int number,
 		int result = update_mstatus_actual(target);
 		if (result != ERROR_OK)
 			return result;
-		unsigned i = 0;
+		unsigned int i = 0;
 		if ((info->mstatus_actual & MSTATUS_FS) == 0) {
 			info->mstatus_actual = set_field(info->mstatus_actual, MSTATUS_FS, 1);
 			cache_set_load(target, i++, S0, SLOT1);
@@ -1318,7 +1318,7 @@ int riscv011_get_register(struct target *target, riscv_reg_t *value,
 		int result = update_mstatus_actual(target);
 		if (result != ERROR_OK)
 			return result;
-		unsigned i = 0;
+		unsigned int i = 0;
 		if ((info->mstatus_actual & MSTATUS_FS) == 0) {
 			info->mstatus_actual = set_field(info->mstatus_actual, MSTATUS_FS, 1);
 			cache_set_load(target, i++, S0, SLOT1);
@@ -1522,7 +1522,7 @@ static int examine(struct target *target)
 	/* 0x00000000  0x00000000:00000003  0x00000000:00000003:ffffffff:ffffffff */
 	cache_set32(target, 4, sw(S1, ZERO, DEBUG_RAM_START + 4));
 	cache_set_jump(target, 5);
-	for (unsigned i = 6; i < info->dramsize; i++)
+	for (unsigned int i = 6; i < info->dramsize; i++)
 		cache_set32(target, i, i * 0x01020304);
 
 	cache_write(target, 0, false);
@@ -1553,7 +1553,7 @@ static int examine(struct target *target)
 	LOG_DEBUG("Discovered XLEN is %d", riscv_xlen(target));
 
 	if (read_remote_csr(target, &r->misa, CSR_MISA) != ERROR_OK) {
-		const unsigned old_csr_misa = 0xf10;
+		const unsigned int old_csr_misa = 0xf10;
 		LOG_WARNING("Failed to read misa at 0x%x; trying 0x%x.", CSR_MISA,
 				old_csr_misa);
 		if (read_remote_csr(target, &r->misa, old_csr_misa) != ERROR_OK) {
@@ -1632,7 +1632,7 @@ static riscv_error_t handle_halt_routine(struct target *target)
 
 	unsigned int dbus_busy = 0;
 	unsigned int interrupt_set = 0;
-	unsigned result = 0;
+	unsigned int result = 0;
 	uint64_t value = 0;
 	reg_cache_set(target, 0, 0);
 	/* The first scan result is the result from something old we don't care
@@ -2004,7 +2004,7 @@ static int read_memory(struct target *target, target_addr_t address,
 	cache_write(target, CACHE_NO_READ, false);
 
 	riscv011_info_t *info = get_info(target);
-	const unsigned max_batch_size = 256;
+	const unsigned int max_batch_size = 256;
 	scans_t *scans = scans_new(target, max_batch_size);
 	if (!scans)
 		return ERROR_FAIL;
@@ -2162,7 +2162,7 @@ static int write_memory(struct target *target, target_addr_t address,
 	if (setup_write_memory(target, size) != ERROR_OK)
 		return ERROR_FAIL;
 
-	const unsigned max_batch_size = 256;
+	const unsigned int max_batch_size = 256;
 	scans_t *scans = scans_new(target, max_batch_size);
 	if (!scans)
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -3298,7 +3298,7 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 				GDB_REGNO_PC,
 				GDB_REGNO_MSTATUS, GDB_REGNO_MEPC, GDB_REGNO_MCAUSE,
 			};
-			for (unsigned i = 0; i < ARRAY_SIZE(regnums); i++) {
+			for (unsigned int i = 0; i < ARRAY_SIZE(regnums); i++) {
 				enum gdb_regno regno = regnums[i];
 				riscv_reg_t reg_value;
 				if (riscv_reg_get(target, &reg_value, regno) != ERROR_OK)
@@ -3393,8 +3393,8 @@ static int riscv_checksum_memory(struct target *target,
 
 	static const uint8_t *crc_code;
 
-	unsigned xlen = riscv_xlen(target);
-	unsigned crc_code_size;
+	unsigned int xlen = riscv_xlen(target);
+	unsigned int crc_code_size;
 	if (xlen == 32) {
 		crc_code = riscv32_crc_code;
 		crc_code_size = sizeof(riscv32_crc_code);
@@ -3957,8 +3957,8 @@ static int parse_ranges(struct list_head *ranges, const char *tcl_arg, const cha
 	/* For backward compatibility, allow multiple parameters within one TCL argument, separated by ',' */
 	char *arg = strtok(args, ",");
 	while (arg) {
-		unsigned low = 0;
-		unsigned high = 0;
+		unsigned int low = 0;
+		unsigned int high = 0;
 		char *name = NULL;
 
 		char *dash = strchr(arg, '-');
@@ -5578,7 +5578,7 @@ static int riscv_step_rtos_hart(struct target *target)
 bool riscv_supports_extension(const struct target *target, char letter)
 {
 	RISCV_INFO(r);
-	unsigned num;
+	unsigned int num;
 	if (letter >= 'a' && letter <= 'z')
 		num = letter - 'a';
 	else if (letter >= 'A' && letter <= 'Z')
@@ -5588,7 +5588,7 @@ bool riscv_supports_extension(const struct target *target, char letter)
 	return r->misa & BIT(num);
 }
 
-unsigned riscv_xlen(const struct target *target)
+unsigned int riscv_xlen(const struct target *target)
 {
 	RISCV_INFO(r);
 	return r->xlen;

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -245,7 +245,7 @@ struct riscv_info {
 	int (*read_memory)(struct target *target, target_addr_t address,
 			uint32_t size, uint32_t count, uint8_t *buffer, uint32_t increment);
 
-	unsigned (*data_bits)(struct target *target);
+	unsigned int (*data_bits)(struct target *target);
 
 	COMMAND_HELPER((*print_info), struct target *target);
 
@@ -320,15 +320,15 @@ typedef struct {
 typedef struct {
 	const char *name;
 	int level;
-	unsigned va_bits;
+	unsigned int va_bits;
 	/* log2(PTESIZE) */
-	unsigned pte_shift;
-	unsigned vpn_shift[PG_MAX_LEVEL];
-	unsigned vpn_mask[PG_MAX_LEVEL];
-	unsigned pte_ppn_shift[PG_MAX_LEVEL];
-	unsigned pte_ppn_mask[PG_MAX_LEVEL];
-	unsigned pa_ppn_shift[PG_MAX_LEVEL];
-	unsigned pa_ppn_mask[PG_MAX_LEVEL];
+	unsigned int pte_shift;
+	unsigned int vpn_shift[PG_MAX_LEVEL];
+	unsigned int vpn_mask[PG_MAX_LEVEL];
+	unsigned int pte_ppn_shift[PG_MAX_LEVEL];
+	unsigned int pte_ppn_mask[PG_MAX_LEVEL];
+	unsigned int pa_ppn_shift[PG_MAX_LEVEL];
+	unsigned int pa_ppn_mask[PG_MAX_LEVEL];
 } virt2phys_info_t;
 
 /* Wall-clock timeout for a command/access. Settable via RISC-V Target commands.*/
@@ -381,7 +381,7 @@ int riscv_openocd_step(
 bool riscv_supports_extension(const struct target *target, char letter);
 
 /* Returns XLEN for the given (or current) hart. */
-unsigned riscv_xlen(const struct target *target);
+unsigned int riscv_xlen(const struct target *target);
 
 /* Returns VLENB for the given (or current) hart. */
 unsigned int riscv_vlenb(const struct target *target);


### PR DESCRIPTION
This is only for coding-style rework.

In upstream OpenOCD all 'unsigned' has already been converted to 'unsigned int' and there are two patches pending for merge to extend the conversion to the risc-v code:
https://review.openocd.org/c/openocd/+/8483
https://review.openocd.org/c/openocd/+/8484

This patch for the risc-v fork runs the same conversion, in the hope to simplify the alignment between the fork and the upstream.

Conversion done with
	checkpatch --fix-inplace -types UNSPECIFIED_INT

Change-Id: I62fad88dd33716c24154d44c5a23ae2c0f7c4a4c