### PR TITLE
target/riscv: added translation drivers

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -11356,16 +11356,18 @@ This command can be used to change the memory access methods if the default
 behavior is not suitable for a particular target.
 @end deffn
 
-@deffn {Command} {riscv set_enable_virtual} on|off
-When on, memory accesses are performed on physical or virtual memory depending
-on the current system configuration. When off (default), all memory accessses are performed
-on physical memory.
-@end deffn
-
-@deffn {Command} {riscv set_enable_virt2phys} on|off
-When on (default), memory accesses are performed on physical or virtual memory
-depending on the current satp configuration. When off, all memory accessses are
-performed on physical memory.
+@deffn {Command} {riscv virt2phys_mode} [@option{hw}|@option{sw}|@option{off}]
+Configure how OpenOCD translates virtual addresses to physical:
+@itemize @bullet
+@item @option{sw} - OpenOCD translates virtual addresses explicitly by
+traversing the page table entries (by performing physical memory accesses to
+read the respective entries). This is the default mode.
+@item @option{hw} - Virtual addresses are translated implicitly by hardware.
+(Virtual memory access will fail with an error if the hardware doesn't
+support the necessary functionality.)
+@item @option{off} - Virtual addresses are not translated (identity mapping is assumed).
+@end itemize
+Returns current translation mode if called without arguments.
 @end deffn
 
 @deffn {Command} {riscv resume_order} normal|reversed

--- a/src/target/riscv/Makefile.am
+++ b/src/target/riscv/Makefile.am
@@ -26,3 +26,5 @@ noinst_LTLIBRARIES += %D%/libriscv.la
        %D%/riscv_semihosting.c \
        %D%/debug_defines.c \
        %D%/debug_reg_printer.c
+
+STARTUP_TCL_SRCS += %D%/startup.tcl

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1974,11 +1974,11 @@ static int examine(struct target *target)
 				info->impebreak);
 	}
 
-	if (info->progbufsize < 4 && riscv_enable_virtual) {
-		LOG_TARGET_ERROR(target, "set_enable_virtual is not available on this target. It "
-				"requires a program buffer size of at least 4. (progbufsize=%d) "
-				"Use `riscv set_enable_virtual off` to continue."
-					, info->progbufsize);
+	if (info->progbufsize < 4 && riscv_virt2phys_mode_is_hw(target)) {
+		LOG_TARGET_ERROR(target, "software address translation "
+				"is not available on this target. It requires a "
+				"program buffer size of at least 4. (progbufsize=%d) "
+				"Use `riscv set_enable_virtual off` to continue.", info->progbufsize);
 	}
 
 	/* Don't call any riscv_* functions until after we've counted the number of
@@ -3054,7 +3054,8 @@ static int read_sbcs_nonbusy(struct target *target, uint32_t *sbcs)
 
 static int modify_privilege(struct target *target, uint64_t *mstatus, uint64_t *mstatus_old)
 {
-	if (riscv_enable_virtual && has_sufficient_progbuf(target, 5)) {
+	if (riscv_virt2phys_mode_is_hw(target)
+			&& has_sufficient_progbuf(target, 5)) {
 		/* Read DCSR */
 		uint64_t dcsr;
 		if (register_read_direct(target, &dcsr, GDB_REGNO_DCSR) != ERROR_OK)
@@ -4259,7 +4260,8 @@ read_memory_progbuf(struct target *target, target_addr_t address,
 	if (modify_privilege(target, &mstatus, &mstatus_old) != ERROR_OK)
 		return MEM_ACCESS_FAILED_PRIV_MOD_FAILED;
 
-	const bool mprven = riscv_enable_virtual && get_field(mstatus, MSTATUS_MPRV);
+	const bool mprven = riscv_virt2phys_mode_is_hw(target)
+			&& get_field(mstatus, MSTATUS_MPRV);
 	const struct memory_access_info access = {
 		.target_address = address,
 		.increment = increment,
@@ -4831,7 +4833,8 @@ write_memory_progbuf(struct target *target, target_addr_t address,
 	if (modify_privilege(target, &mstatus, &mstatus_old) != ERROR_OK)
 		return MEM_ACCESS_FAILED_PRIV_MOD_FAILED;
 
-	const bool mprven = riscv_enable_virtual && get_field(mstatus, MSTATUS_MPRV);
+	const bool mprven = riscv_virt2phys_mode_is_hw(target)
+			&& get_field(mstatus, MSTATUS_MPRV);
 
 	int result = write_memory_progbuf_inner(target, address, size, count, buffer, mprven);
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -57,6 +57,14 @@ typedef enum riscv_mem_access_method {
 	RISCV_MEM_ACCESS_MAX_METHODS_NUM
 } riscv_mem_access_method_t;
 
+typedef enum riscv_virt2phys_mode {
+	RISCV_VIRT2PHYS_MODE_HW,
+	RISCV_VIRT2PHYS_MODE_SW,
+	RISCV_VIRT2PHYS_MODE_OFF
+} riscv_virt2phys_mode_t;
+
+const char *riscv_virt2phys_mode_to_str(riscv_virt2phys_mode_t mode);
+
 enum riscv_halt_reason {
 	RISCV_HALT_INTERRUPT,
 	RISCV_HALT_EBREAK,
@@ -164,6 +172,9 @@ struct riscv_info {
 	/* The unique id of the trigger that caused the most recent halt. If the
 	 * most recent halt was not caused by a trigger, then this is -1. */
 	int64_t trigger_hit;
+
+	/* The configured approach to translate virtual addresses to physical */
+	riscv_virt2phys_mode_t virt2phys_mode;
 
 	bool triggers_enumerated;
 
@@ -331,10 +342,11 @@ typedef struct {
 	unsigned pa_ppn_mask[PG_MAX_LEVEL];
 } virt2phys_info_t;
 
+bool riscv_virt2phys_mode_is_hw(const struct target *target);
+bool riscv_virt2phys_mode_is_sw(const struct target *target);
+
 /* Wall-clock timeout for a command/access. Settable via RISC-V Target commands.*/
 int riscv_get_command_timeout_sec(void);
-
-extern bool riscv_enable_virtual;
 
 /* Everything needs the RISC-V specific info structure, so here's a nice macro
  * that provides that. */

--- a/src/target/riscv/startup.tcl
+++ b/src/target/riscv/startup.tcl
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+lappend _telnet_autocomplete_skip "riscv set_enable_virtual"
+proc {riscv set_enable_virtual} on_off {
+	echo {DEPRECATED! use 'riscv virt2phys_mode' not 'riscv set_enable_virtual'}
+	foreach t [target names] {
+		if {[$t cget -type] ne "riscv"} { continue }
+		switch -- [$t riscv virt2phys_mode] {
+			off -
+			hw {
+				switch -- $on_off {
+					on  {$t riscv virt2phys_mode hw}
+					off {$t riscv virt2phys_mode off}
+				}
+			}
+			sw {
+				if {$on_off eq "on"} {
+					error {Can't enable virtual while translation mode is SW}
+				}
+			}
+		}
+	}
+	return {}
+}
+
+lappend _telnet_autocomplete_skip "riscv set_enable_virt2phys"
+proc {riscv set_enable_virt2phys} on_off {
+	echo {DEPRECATED! use 'riscv virt2phys_mode' not 'riscv set_enable_virt2phys'}
+	foreach t [target names] {
+		if {[$t cget -type] ne "riscv"} { continue }
+		switch -- [riscv virt2phys_mode] {
+			off -
+			sw {
+				switch -- $on_off {
+					on  {riscv virt2phys_mode sw}
+					off {riscv virt2phys_mode off}
+				}
+			}
+			hw {
+				if {$on_off eq "on"} {
+					error {Can't enable virt2phys while translation mode is HW}
+				}
+			}
+		}
+	}
+	return {}
+}
+
+proc riscv {cmd args} {
+	tailcall "riscv $cmd" {*}$args
+}


### PR DESCRIPTION
Existing flags: 'enable_virtual' and 'enable_virt2phys' were replaced with explicit translation drivers. Motivation:

(1) Having 'enable_virtual' and 'enable_virt2phys' flags set simultaneously may cause double address translation which is unacceptable

(2) Flags were global for all targets which is wrong too