### PR TITLE
target/riscv: detailed error messages for cases when resume operation fails

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -5385,7 +5385,9 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 		LOG_TARGET_ERROR(target, "Hart is not halted!");
 		return ERROR_FAIL;
 	}
-	LOG_TARGET_DEBUG(target, "resuming (for step?=%d)", step);
+
+	LOG_TARGET_DEBUG(target, "resuming (operation=%s)",
+		step ? "single-step" : "resume");
 
 	if (riscv_reg_flush_all(target) != ERROR_OK)
 		return ERROR_FAIL;
@@ -5418,16 +5420,26 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 		return ERROR_OK;
 	}
 
-	dm_write(target, DM_DMCONTROL, dmcontrol);
+	LOG_TARGET_ERROR(target, "Failed to %s. dmstatus=0x%08x",
+		step ? "single-step" : "resume", dmstatus);
 
-	LOG_TARGET_ERROR(target, "unable to resume");
+	dm_write(target, DM_DMCONTROL, dmcontrol);
+	LOG_TARGET_ERROR(target,
+		"  cancelling the resume request (dmcontrol.resumereq <- 0)");
+
 	if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 		return ERROR_FAIL;
-	LOG_TARGET_ERROR(target, "  dmstatus=0x%08x", dmstatus);
+
+	LOG_TARGET_ERROR(target, "  dmstatus after cancellation=0x%08x", dmstatus);
 
 	if (step) {
-		LOG_TARGET_ERROR(target, "  was stepping, halting");
-		riscv_halt(target);
+		LOG_TARGET_ERROR(target,
+			"  trying to recover from a failed single-step, by requesting halt");
+		if (riscv_halt(target) == ERROR_OK)
+			LOG_TARGET_ERROR(target, "  halt completed after failed single-step");
+		else
+			LOG_TARGET_ERROR(target, "  could not halt, something is wrong with the taget");
+		// TODO: returning ERROR_OK is questionable, this code needs to be revised
 		return ERROR_OK;
 	}
 


### PR DESCRIPTION
This change aims to provide more context in case if resume operation fails. Before the change messages were quite confusing.