### PR TITLE
fix incorrect parsing of names for custom csr registers

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4164,12 +4164,16 @@ static int parse_reg_ranges_impl(struct list_head *ranges, char *args,
 			}
 
 			const char * const reg_name_in = equals + 1;
-			*name_buffer = calloc(1, strlen(reg_name_in) + strlen(reg_type) + 2);
+			const size_t reg_type_len = strlen(reg_type);
+			/* format is: <reg_type>_<reg_name_in>\0 */
+			*name_buffer = calloc(1, strlen(reg_name_in) + reg_type_len + 2);
 			name = *name_buffer;
 			if (!name) {
 				LOG_ERROR("Out of memory");
 				return ERROR_FAIL;
 			}
+			strcpy(name, reg_type);
+			name[reg_type_len] = '_';
 
 			unsigned int scanned_chars;
 			char *scan_dst = name + strlen(reg_type) + 1;


### PR DESCRIPTION
this commit fixes a regression introduced in
https://github.com/riscv-collab/riscv-openocd/commit/ba8c1eef5a32193d9b5dc80d681a4f18d1d94f11.

The regression was caused by removal of these lines:

```
-                       /* Register prefix: "csr_" or "custom_" */
-                       strcpy(name, reg_type);
-                       name[strlen(reg_type)] = '_';
```

causing all CSR names with custom names to be parsed as empty strings.