### PR TITLE
target/riscv: Add support for external triggers

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -11476,6 +11476,11 @@ The second argument configures how OpenOCD should use the selected trigger featu
 With no parameters, prints current trigger features configuration.
 @end deffn
 
+@deffn {Command} {riscv set_external_trigger} value
+Associate the supplied external trigger with the halt group for the harts. When
+the external trigger fires the harts in the halt group will be halted.
+@end deffn
+
 @subsection RISC-V Authentication Commands
 
 The following commands can be used to authenticate to a RISC-V system. Eg.  a

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -5262,6 +5262,26 @@ COMMAND_HANDLER(handle_riscv_virt2phys_mode)
 	return ERROR_OK;
 }
 
+COMMAND_HANDLER(riscv_set_external_trigger)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	RISCV_INFO(r);
+
+	if (CMD_ARGC != 1) {
+		LOG_ERROR("Command takes exactly 1 parameter.");
+		return ERROR_COMMAND_SYNTAX_ERROR;
+	}
+	int value = atoi(CMD_ARGV[0]);
+	if (value <= 0 || value > 16) {
+		LOG_ERROR("%s is not a valid integer argument for command.", CMD_ARGV[0]);
+		return ERROR_FAIL;
+	}
+
+	r->external_trigger = value;
+
+	return ERROR_OK;
+}
+
 static const struct command_registration riscv_exec_command_handlers[] = {
 	{
 		.name = "dump_sample_buf",
@@ -5523,6 +5543,13 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 		.help = "When on (default), OpenOCD will automatically execute fence instructions in some situations. "
 			"When off, users need to take care of memory coherency themselves, for example by using "
 			"`riscv exec_progbuf` to execute fence or CMO instructions."
+	},
+	{
+		.name = "set_external_trigger",
+		.handler = riscv_set_external_trigger,
+		.mode = COMMAND_CONFIG,
+		.usage = "value",
+		.help = "Add the given external trigger to the halt group"
 	},
 	COMMAND_REGISTRATION_DONE
 };

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -191,6 +191,9 @@ struct riscv_info {
 	/* The configured approach to translate virtual addresses to physical */
 	riscv_virt2phys_mode_t virt2phys_mode;
 
+	/* Halt group may be associated with an external trigger */
+	unsigned int external_trigger;
+
 	bool triggers_enumerated;
 
 	/* Decremented every scan, and when it reaches 0 we clear the learned


### PR DESCRIPTION
Add support for associating a halt group with an external trigger via a newly exposed configuration option "riscv set_external_trigger".

Change-Id: If10c67d2e14d8bc7cd6d59011b3215fda4ff4b02