### PR TITLE
target/riscv: clean-up register invalidation

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1136,7 +1136,7 @@ static int execute_resume(struct target *target, bool step)
 	}
 
 	target->state = TARGET_RUNNING;
-	register_cache_invalidate(target->reg_cache);
+	riscv_reg_cache_invalidate_all(target);
 
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2728,6 +2728,13 @@ static int handle_became_unavailable(struct target *target,
 		enum riscv_hart_state previous_riscv_state)
 {
 	RISCV013_INFO(info);
+
+	if (riscv_reg_cache_any_dirty(target, LOG_LVL_WARNING))
+		LOG_TARGET_WARNING(target, "Discarding values of dirty registers "
+				"(due to target becoming unavailable).");
+
+	riscv_reg_cache_invalidate_all(target);
+
 	info->dcsr_ebreak_is_set = false;
 	return ERROR_OK;
 }
@@ -5434,6 +5441,8 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 
 	if (riscv_reg_flush_all(target) != ERROR_OK)
 		return ERROR_FAIL;
+
+	riscv_reg_cache_invalidate_all(target);
 
 	dm013_info_t *dm = get_dm(target);
 	/* Issue the resume command, and then wait for the current hart to resume. */

--- a/src/target/riscv/riscv_reg.h
+++ b/src/target/riscv/riscv_reg.h
@@ -22,6 +22,17 @@ void riscv_reg_free_all(struct target *target);
 /** Write all dirty registers to the target. */
 int riscv_reg_flush_all(struct target *target);
 /**
+ * Check whether there are any dirty registers in the OpenOCD's register cache.
+ * In addition, all dirty registers will be reported to the log using the
+ * supplied "log_level".
+ */
+bool riscv_reg_cache_any_dirty(const struct target *target, int log_level);
+/**
+ * Invalidate all registers - forget their cached register values.
+ * WARNING: If a register was dirty, its walue will be silently lost!
+ */
+void riscv_reg_cache_invalidate_all(struct target *target);
+/**
  * Set the register value. For cacheable registers, only the cache is updated
  * (write-back mode).
  */


### PR DESCRIPTION
* Registers were not invalidated if the hart became unavailable.
* Improved logging in the case register invalidation involves loss of information.

Change-Id: Icfb5e190dd6dcb1a97e4d314d802466cab7a01e4