### PR TITLE
target/riscv: clear `abstract_cmd_maybe_busy` after commands

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -630,6 +630,15 @@ static int abstract_cmd_batch_check_and_clear_cmderr(struct target *target,
 		if (res != ERROR_OK)
 			goto clear_cmderr;
 	}
+
+	dm013_info_t * const dm = get_dm(target);
+	if (!dm) {
+		LOG_ERROR("BUG: Target %s is not assigned to any RISC-V debug module",
+				target_name(target));
+		return ERROR_FAIL;
+	}
+	dm->abstract_cmd_maybe_busy = false;
+
 	*cmderr = get_field32(abstractcs, DM_ABSTRACTCS_CMDERR);
 	if (*cmderr == CMDERR_NONE)
 		return ERROR_OK;


### PR DESCRIPTION
If a sufficient delay was used before reading `abstractcs` during the batch execution, `dm->abstract_cmd_maybe_busy` was not cleared and the following call to `wait_for_idle_if_needed()` (e.g. on `resume`), would result in a call to `wait_for_idle()` performing a redundant read of `abstractcs`.
While this is not a bug, it impedes the performance.

Change-Id: I9d234ef6d53af96c60892d71247c10e631dfcc3b