### PR TITLE
RISC-V Semihosting 3 of 3: Warn if encountered but disabled

### DIFF
--- a/src/target/riscv/riscv_semihosting.c
+++ b/src/target/riscv/riscv_semihosting.c
@@ -110,11 +110,6 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 	struct semihosting *semihosting = target->semihosting;
 	assert(semihosting);
 
-	if (!semihosting->is_active) {
-		LOG_TARGET_DEBUG(target, "Semihosting outcome: NONE (semihosting not enabled)");
-		return SEMIHOSTING_NONE;
-	}
-
 	riscv_reg_t pc;
 	int result = riscv_reg_get(target, &pc, GDB_REGNO_PC);
 	if (result != ERROR_OK) {
@@ -122,11 +117,28 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 		return SEMIHOSTING_ERROR;
 	}
 
-	bool sequence_found;
+	bool sequence_found = false;
 	*retval = riscv_semihosting_detect_magic_sequence(target, pc, &sequence_found);
 	if (*retval != ERROR_OK) {
 		LOG_TARGET_DEBUG(target, "Semihosting outcome: ERROR (during magic seq. detection)");
 		return SEMIHOSTING_ERROR;
+	}
+
+	if (!semihosting->is_active) {
+		if (sequence_found) {
+			// If semihositing is encountered but disabled, provide an additional hint to the user.
+			LOG_TARGET_WARNING(target, "RISC-V semihosting call encountered in the program "
+				"but semihosting is disabled!");
+			LOG_TARGET_WARNING(target, "The target will remain halted (PC = 0x%" TARGET_PRIxADDR ").", pc);
+			LOG_TARGET_WARNING(target, "Hint: Restart your debug session and enable semihosting "
+				"by command 'arm semihosting enable'.");
+			// TODO: This can be improved: The ebreak halt cause detection and riscv_semihosting() call
+			// can be added also to "arm semihosting enable", which would allow the user to continue
+			// without restart of the debug session.
+		}
+
+		LOG_TARGET_DEBUG(target, "Semihosting outcome: NONE (semihosting not enabled)");
+		return SEMIHOSTING_NONE;
 	}
 
 	if (!sequence_found) {
@@ -135,7 +147,7 @@ enum semihosting_result riscv_semihosting(struct target *target, int *retval)
 	}
 
 	/* Otherwise we have a semihosting call (and semihosting is enabled).
-	 * Proceed with the semihosting. */
+	 * Proceed with the handling of semihosting. */
 
 	/*
 	 * Perform semihosting call if we are not waiting on a fileio


### PR DESCRIPTION
If semihosting is disabled but there is a semihosting request encountered in the program, provide a clear hint to the user what happened and what can be done about it.
