### PR TITLE
Fix esp RISC-V configs

### DIFF
--- a/tcl/target/esp32c2.cfg
+++ b/tcl/target/esp32c2.cfg
@@ -5,7 +5,7 @@
 source [find target/esp_common.cfg]
 
 # Target specific global variables
-set _CHIPNAME 					"riscv"
+set _CHIPNAME 					"esp32c2"
 set _CPUTAPID 					0x0000cc25
 set _ESP_ARCH 					"riscv"
 set _ONLYCPU					1
@@ -14,7 +14,7 @@ set _ESP_SMP_BREAK 				0
 set _ESP_EFUSE_MAC_ADDR_REG  	0x60008840
 
 # Target specific functions should be implemented for each riscv chips.
-proc riscv_wdt_disable { } {
+proc esp32c2_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -32,7 +32,7 @@ proc riscv_wdt_disable { } {
     mww 0x600080A0 0x84B00000
 }
 
-proc riscv_soc_reset { } {
+proc esp32c2_soc_reset { } {
 	global _RISCV_DMCONTROL
 
     # This procedure does "digital system reset", i.e. resets
@@ -52,7 +52,7 @@ proc riscv_soc_reset { } {
     sleep 10
     poll
     # Disable the watchdogs again
-    riscv_wdt_disable
+    esp32c2_wdt_disable
 
     # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
     # We will clean allhalted state by resuming the core.
@@ -62,7 +62,7 @@ proc riscv_soc_reset { } {
     riscv dmi_write $_RISCV_DMCONTROL 0x80000003
 }
 
-proc riscv_memprot_is_enabled { } {
+proc esp32c2_memprot_is_enabled { } {
 	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
 
 	# PMPADDR 0-1 covers entire valid IRAM range and PMPADDR 2-3 covers entire DRAM region

--- a/tcl/target/esp32c3.cfg
+++ b/tcl/target/esp32c3.cfg
@@ -5,7 +5,7 @@
 source [find target/esp_common.cfg]
 
 # Target specific global variables
-set _CHIPNAME 					"riscv"
+set _CHIPNAME 					"esp32c3"
 set _CPUTAPID 					0x00005c25
 set _ESP_ARCH					"riscv"
 set _ONLYCPU					1
@@ -14,7 +14,7 @@ set _ESP_SMP_BREAK 				0
 set _ESP_EFUSE_MAC_ADDR_REG  	0x60008844
 
 # Target specific functions should be implemented for each riscv chips.
-proc riscv_wdt_disable { } {
+proc esp32c3_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -36,7 +36,7 @@ proc riscv_wdt_disable { } {
 
 # This is almost identical with the esp32c2_soc_reset.
 # Will be refactored with the other common settings.
-proc riscv_soc_reset { } {
+proc esp32c3_soc_reset { } {
 	global _RISCV_DMCONTROL
 
     # This procedure does "digital system reset", i.e. resets
@@ -56,7 +56,7 @@ proc riscv_soc_reset { } {
     sleep 10
     poll
     # Disable the watchdogs again
-    riscv_wdt_disable
+    esp32c3_wdt_disable
 
     # Here debugger reads allresumeack and allhalted bits as set (0x330a2)
     # We will clean allhalted state by resuming the core.
@@ -66,7 +66,7 @@ proc riscv_soc_reset { } {
     riscv dmi_write $_RISCV_DMCONTROL 	0x80000003
 }
 
-proc riscv_memprot_is_enabled { } {
+proc esp32c3_memprot_is_enabled { } {
     # IRAM0 PMS lock, SENSITIVE_CORE_X_IRAM0_PMS_CONSTRAIN_0_REG
     if { [get_mmr_bit 0x600C10A8 0] != 0 } {
         return 1

--- a/tcl/target/esp32c6.cfg
+++ b/tcl/target/esp32c6.cfg
@@ -5,7 +5,7 @@
 source [find target/esp_common.cfg]
 
 # Target specific global variables
-set _CHIPNAME 					"riscv"
+set _CHIPNAME 					"esp32c6"
 set _CPUTAPID 					0x0000dc25
 set _ESP_ARCH					"riscv"
 set _ONLYCPU					1
@@ -14,7 +14,7 @@ set _ESP_SMP_BREAK 				0
 set _ESP_EFUSE_MAC_ADDR_REG  	0x600B0844
 
 # Target specific functions should be implemented for each riscv chips.
-proc riscv_wdt_disable { } {
+proc esp32c6_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -34,7 +34,7 @@ proc riscv_wdt_disable { } {
     mww 0x600b1c1c 0x40000000
 }
 
-proc riscv_soc_reset { } {
+proc esp32c6_soc_reset { } {
 	global _RISCV_DMCONTROL _RISCV_SB_CS _RISCV_SB_ADDR0 _RISCV_SB_DATA0
 
     riscv dmi_write $_RISCV_DMCONTROL 		0x80000001
@@ -59,7 +59,7 @@ proc riscv_soc_reset { } {
     # Here debugger reads dmstatus as 0x3a2
 
     # Disable the watchdogs again
-    riscv_wdt_disable
+    esp32c6_wdt_disable
 
     # Here debugger reads anyhalted and allhalted bits as set (0x3a2)
     # We will clean allhalted state by resuming the core.
@@ -69,7 +69,7 @@ proc riscv_soc_reset { } {
     riscv dmi_write $_RISCV_DMCONTROL 		0x80000003
 }
 
-proc riscv_memprot_is_enabled { } {
+proc esp32c6_memprot_is_enabled { } {
 	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
 
 	# If IRAM/DRAM split is enabled TOR address match mode is used.

--- a/tcl/target/esp32h2.cfg
+++ b/tcl/target/esp32h2.cfg
@@ -5,7 +5,7 @@
 source [find target/esp_common.cfg]
 
 # Target specific global variables
-set _CHIPNAME 					"riscv"
+set _CHIPNAME 					"esp32h2"
 set _CPUTAPID 					0x00010c25
 set _ESP_ARCH					"riscv"
 set _ONLYCPU					1
@@ -14,7 +14,7 @@ set _ESP_SMP_BREAK 				0
 set _ESP_EFUSE_MAC_ADDR_REG  	0x600B0844
 
 # Target specific functions should be implemented for each riscv chips.
-proc riscv_wdt_disable { } {
+proc esp32h2_wdt_disable { } {
     # Halt event can occur during config phase (before "init" is done).
     # Ignore it since mww commands don't work at that time.
     if { [string compare [command mode] config] == 0 } {
@@ -34,7 +34,7 @@ proc riscv_wdt_disable { } {
     #mww 0x600b1c1c 0x84B00000
 }
 
-proc riscv_soc_reset { } {
+proc esp32h2_soc_reset { } {
 	global _RISCV_DMCONTROL _RISCV_SB_CS _RISCV_SB_ADDR0 _RISCV_SB_DATA0
 
     riscv dmi_write $_RISCV_DMCONTROL 	0x80000001
@@ -59,7 +59,7 @@ proc riscv_soc_reset { } {
     # Here debugger reads dmstatus as 0x3a2
 
     # Disable the watchdogs again
-    riscv_wdt_disable
+    esp32h2_wdt_disable
 
     # Here debugger reads anyhalted and allhalted bits as set (0x3a2)
     # We will clean allhalted state by resuming the core.
@@ -69,7 +69,7 @@ proc riscv_soc_reset { } {
     riscv dmi_write $_RISCV_DMCONTROL 	0x80000003
 }
 
-proc riscv_memprot_is_enabled { } {
+proc esp32h2_memprot_is_enabled { } {
 	global _RISCV_ABS_CMD _RISCV_ABS_DATA0
 	# If IRAM/DRAM split is enabled, PMPADDR 5-6 will cover valid IRAM region and PMPADDR 7 will cover valid DRAM region
 	# Only TOR mode is used for IRAM and DRAM protections.

--- a/tcl/target/esp_common.cfg
+++ b/tcl/target/esp_common.cfg
@@ -33,6 +33,7 @@ proc set_esp_common_variables { } {
 	global _CHIPNAME _ONLYCPU _ESP_SMP_TARGET
 	global _CPUNAME_0 _CPUNAME_1 _TARGETNAME_0 _TARGETNAME_1 _TAPNAME_0 _TAPNAME_1
 	global _ESP_WDT_DISABLE _ESP_SOC_RESET _ESP_MEMPROT_IS_ENABLED
+	global _TARGET_TYPE _ESP_ARCH
 
 	# For now we support dual core at most.
 	if { $_ONLYCPU == 1 && $_ESP_SMP_TARGET == 0} {
@@ -51,6 +52,12 @@ proc set_esp_common_variables { } {
 	set _ESP_WDT_DISABLE 			"${_CHIPNAME}_wdt_disable"
 	set _ESP_SOC_RESET 				"${_CHIPNAME}_soc_reset"
 	set _ESP_MEMPROT_IS_ENABLED 	"${_CHIPNAME}_memprot_is_enabled"
+
+	if {$_ESP_ARCH == "riscv"} {
+		set _TARGET_TYPE $_ESP_ARCH
+	} else {
+		set _TARGET_TYPE $_CHIPNAME
+	}
 }
 
 proc create_esp_jtag { } {
@@ -64,11 +71,11 @@ proc create_esp_jtag { } {
 }
 
 proc create_openocd_targets  { } {
-	global _TARGETNAME_0 _TARGETNAME_1 _TAPNAME_0 _TAPNAME_1 _RTOS _CHIPNAME _ONLYCPU
+	global _TARGETNAME_0 _TARGETNAME_1 _TAPNAME_0 _TAPNAME_1 _RTOS _CHIPNAME _ONLYCPU _TARGET_TYPE
 
-	target create $_TARGETNAME_0 $_CHIPNAME -chain-position $_TAPNAME_0 -coreid 0 -rtos $_RTOS
+	target create $_TARGETNAME_0 $_TARGET_TYPE -chain-position $_TAPNAME_0 -coreid 0 -rtos $_RTOS
 	if { $_ONLYCPU != 1 } {
-		target create $_TARGETNAME_1 $_CHIPNAME -chain-position $_TAPNAME_1 -coreid 1 -rtos $_RTOS
+		target create $_TARGETNAME_1 $_TARGET_TYPE -chain-position $_TAPNAME_1 -coreid 1 -rtos $_RTOS
 		target smp $_TARGETNAME_0 $_TARGETNAME_1
 	}
 }


### PR DESCRIPTION
Seems to be broken since 6a27d9fbc, with the following error:
```
tcl//target/esp_common.cfg:69: Error: Command/target: riscv Exists
Traceback (most recent call last):
  File "tcl//target/esp32c6.cfg", line 142, in script
    create_esp_target riscv
  File "tcl//target/esp_common.cfg", line 79, in create_esp_target
    create_openocd_targets
  File "tcl//target/esp_common.cfg", line 69, in create_openocd_targets
    {target create} riscv riscv -chain-position riscv.cpu -coreid 0 -rtos hwthread
```