### PR TITLE
target/riscv: pass `jtag_tap` instead of `target`

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -288,7 +288,8 @@ int riscv_batch_run_from(struct riscv_batch *batch, size_t start_idx,
 	unsigned int delay = 0 /* to silence maybe-uninitialized */;
 	for (size_t i = start_idx; i < batch->used_scans; ++i) {
 		if (bscan_tunnel_ir_width != 0)
-			riscv_add_bscan_tunneled_scan(batch->target, batch->fields + i, batch->bscan_ctxt + i);
+			riscv_add_bscan_tunneled_scan(batch->target->tap, batch->fields + i,
+							batch->bscan_ctxt + i);
 		else
 			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
 

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -308,7 +308,7 @@ static void increase_dbus_busy_delay(struct target *target)
 			info->dtmcontrol_idle, info->dbus_busy_delay,
 			info->interrupt_high_delay);
 
-	dtmcontrol_scan(target, DTMCONTROL_DBUS_RESET, NULL /* discard value */);
+	dtmcs_scan(target->tap, DTMCONTROL_DBUS_RESET, NULL /* discard value */);
 }
 
 static void increase_interrupt_high_delay(struct target *target)
@@ -1458,7 +1458,7 @@ static int examine(struct target *target)
 {
 	/* Don't need to select dbus, since the first thing we do is read dtmcontrol. */
 	uint32_t dtmcontrol;
-	if (dtmcontrol_scan(target, 0, &dtmcontrol) != ERROR_OK || dtmcontrol == 0) {
+	if (dtmcs_scan(target->tap, 0, &dtmcontrol) != ERROR_OK || dtmcontrol == 0) {
 		LOG_ERROR("Could not scan dtmcontrol. Check JTAG connectivity/board power.");
 		return ERROR_FAIL;
 	}

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -432,14 +432,14 @@ extern struct scan_field select_dtmcontrol;
 extern struct scan_field select_dbus;
 extern struct scan_field select_idcode;
 
-int dtmcontrol_scan(struct target *target, uint32_t out, uint32_t *in_ptr);
+int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr);
 
 extern struct scan_field *bscan_tunneled_select_dmi;
 extern uint32_t bscan_tunneled_select_dmi_num_fields;
 typedef enum { BSCAN_TUNNEL_NESTED_TAP, BSCAN_TUNNEL_DATA_REGISTER } bscan_tunnel_type_t;
 extern uint8_t bscan_tunnel_ir_width;
 
-void select_dmi_via_bscan(struct target *target);
+void select_dmi_via_bscan(struct jtag_tap *tap);
 
 /*** OpenOCD Interface */
 int riscv_openocd_poll(struct target *target);
@@ -495,7 +495,7 @@ void riscv_semihosting_init(struct target *target);
 
 enum semihosting_result riscv_semihosting(struct target *target, int *retval);
 
-void riscv_add_bscan_tunneled_scan(struct target *target, const struct scan_field *field,
+void riscv_add_bscan_tunneled_scan(struct jtag_tap *tap, const struct scan_field *field,
 		riscv_bscan_tunneled_scan_context_t *ctxt);
 
 int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);


### PR DESCRIPTION
For some functions, passing `target` is excessive. The corresponding `tap` provides all the necessary data.

Change-Id: Ie5836024a15222bda7c2b727f5dbaac38f459b3c