### PR TITLE
target/riscv: dont set mcause and mstatus as cachable

### DIFF
--- a/src/target/riscv/riscv_reg_impl.h
+++ b/src/target/riscv/riscv_reg_impl.h
@@ -204,9 +204,7 @@ static inline bool riscv_reg_impl_gdb_regno_cacheable(enum gdb_regno regno,
 		case GDB_REGNO_MISA:
 		case GDB_REGNO_DCSR:
 		case GDB_REGNO_DSCRATCH0:
-		case GDB_REGNO_MSTATUS:
 		case GDB_REGNO_MEPC:
-		case GDB_REGNO_MCAUSE:
 		case GDB_REGNO_SATP:
 			/*
 			 * WARL registers might not contain the value we just wrote, but


### PR DESCRIPTION
With CLIC extension (smclic), mcause and mstatus CSRs share mirrored fields for mpp and mpie. Therefore, neither can be assumed cacheable.

CLIC spec available - https://github.com/riscv/riscv-fast-interrupt

Implemented e.g. in esp32c5 or Codasip's L110