### PR TITLE
target/riscv: support deprecated user interrupt registers

### DIFF
--- a/src/target/riscv/encoding_extras.h
+++ b/src/target/riscv/encoding_extras.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/*
+ * This file contains additional constants and macros in the same format as the generated
+ * encoding.h header. These are intended to supplement the headers contents, which are up-to-date
+ * with latest RISC-V specifications, with support for select features that were deprecated,
+ * but already have existing hardware implementations.
+ */
+
+#ifndef RISCV_ENCODING_EXTRAS_H
+#define RISCV_ENCODING_EXTRAS_H
+#define CSR_USTATUS 0x0
+#define CSR_UIE 0x4
+#define CSR_UTVEC 0x5
+#define CSR_USCRATCH 0x40
+#define CSR_UEPC 0x41
+#define CSR_UCAUSE 0x42
+#define CSR_UTVAL 0x43
+#define CSR_UIP 0x44
+#endif // RISCV_ENCODING_EXTRAS_H
+
+#ifdef DECLARE_CSR
+DECLARE_CSR(ustatus, CSR_USTATUS)
+DECLARE_CSR(uie, CSR_UIE)
+DECLARE_CSR(utvec, CSR_UTVEC)
+DECLARE_CSR(uscratch, CSR_USCRATCH)
+DECLARE_CSR(uepc, CSR_UEPC)
+DECLARE_CSR(ucause, CSR_UCAUSE)
+DECLARE_CSR(utval, CSR_UTVAL)
+DECLARE_CSR(uip, CSR_UIP)
+#endif // DECLARE_CSR

--- a/src/target/riscv/gdb_regs.h
+++ b/src/target/riscv/gdb_regs.h
@@ -3,7 +3,7 @@
 #ifndef OPENOCD_TARGET_RISCV_GDB_REGS_H
 #define OPENOCD_TARGET_RISCV_GDB_REGS_H
 
-#include "encoding.h"
+#include "riscv_encoding.h"
 
 /* gdb's register list is defined in riscv_gdb_reg_names gdb/riscv-tdep.c in
  * its source tree. We must interpret the numbers the same here. */

--- a/src/target/riscv/riscv_encoding.h
+++ b/src/target/riscv/riscv_encoding.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/*
+ * This file combines generated encoding.h and manually-written encoding_extras.h headers.
+ */
+
+#include "encoding.h"
+#include "encoding_extras.h"

--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -56,7 +56,6 @@ static const char * const default_reg_names[GDB_REGNO_COUNT] = {
 	[GDB_REGNO_T5] = "t5",
 	[GDB_REGNO_T6] = "t6",
 	[GDB_REGNO_PC] = "pc",
-	[GDB_REGNO_CSR0] = "csr0",
 	[GDB_REGNO_PRIV] = "priv",
 	[GDB_REGNO_FT0] = "ft0",
 	[GDB_REGNO_FT1] = "ft1",
@@ -92,7 +91,7 @@ static const char * const default_reg_names[GDB_REGNO_COUNT] = {
 	[GDB_REGNO_FT11] = "ft11",
 
 	#define DECLARE_CSR(csr_name, number)[(number) + GDB_REGNO_CSR0] = #csr_name,
-	#include "encoding.h"
+	#include "riscv_encoding.h"
 	#undef DECLARE_CSR
 };
 
@@ -368,7 +367,7 @@ static bool is_known_standard_csr(unsigned int csr_num)
 {
 	static const bool is_csr_in_buf[GDB_REGNO_CSR4095 - GDB_REGNO_CSR0 + 1] = {
 		#define DECLARE_CSR(csr_name, number)[number] = true,
-		#include "encoding.h"
+		#include "riscv_encoding.h"
 		#undef DECLARE_CSR
 	};
 	assert(csr_num < ARRAY_SIZE(is_csr_in_buf));
@@ -433,6 +432,15 @@ bool riscv_reg_impl_gdb_regno_exist(const struct target *target, uint32_t regno)
 			 * mideleg registers should not exist." */
 			return riscv_supports_extension(target, 'S') ||
 				riscv_supports_extension(target, 'N');
+		case CSR_USTATUS:
+		case CSR_UIE:
+		case CSR_UTVEC:
+		case CSR_USCRATCH:
+		case CSR_UEPC:
+		case CSR_UCAUSE:
+		case CSR_UTVAL:
+		case CSR_UIP:
+			return riscv_supports_extension(target, 'N');
 
 		case CSR_PMPCFG1:
 		case CSR_PMPCFG3:


### PR DESCRIPTION
Adds manually-written encoding header with the defines for these registers, as the extension was dropped and the defines removed from the generated encoding.h header.

Only affects targets with N extension bit in the misa register.