### PR TITLE
fix expose_csr for CSR with address "0"

### DIFF
--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -56,7 +56,6 @@ static const char * const default_reg_names[GDB_REGNO_COUNT] = {
 	[GDB_REGNO_T5] = "t5",
 	[GDB_REGNO_T6] = "t6",
 	[GDB_REGNO_PC] = "pc",
-	[GDB_REGNO_CSR0] = "csr0",
 	[GDB_REGNO_PRIV] = "priv",
 	[GDB_REGNO_FT0] = "ft0",
 	[GDB_REGNO_FT1] = "ft1",
@@ -196,7 +195,8 @@ const char *riscv_reg_gdb_regno_name(const struct target *target, enum gdb_regno
 	}
 	if (regno >= GDB_REGNO_CSR0 && regno <= GDB_REGNO_CSR4095) {
 		init_custom_csr_names(target);
-		info->reg_names[regno] = init_reg_name_with_prefix("csr", regno - GDB_REGNO_CSR0);
+		if (!info->reg_names[regno])
+			info->reg_names[regno] = init_reg_name_with_prefix("csr", regno - GDB_REGNO_CSR0);
 		return info->reg_names[regno];
 	}
 	assert(!"Encountered uninitialized entry in reg_names table");


### PR DESCRIPTION
This change is a quick-and-dirty workaround for the problem when user
wants to expose CSR with address "0" and instead of user-specified name
"csr0" was used.

The problem looks as follows:

riscv013_reg_examine_all eventually calls init_cache_entry for all CSRs.
init_cache_entry eventually results in a call to riscv_reg_gdb_regno_name.

Then in case of non-standard CSRs we have the following logic:

```
// NULL when regno == 0, since names are not generated yet
if (info->reg_names[regno])
    return info->reg_names[regno]
...
if (regno >= GDB_REGNO_CSR0 && regno <= GDB_REGNO_CSR4095) {
    // generate names for all exposed CSRs (the function
    // lazy-initializes all the required names)
    init_custom_csr_names(target);
    // And here we have an error, since we overwrite the name generated
    // by init_custom_csr_names
    info->reg_names[regno] = init_reg_name_with_prefix("csr", regno - GDB_REGNO_CSR0);
...
```

The error happens because when initially this function is called with
regno = 0, the first condition false, so we have to go and generate all
the names.