### PR TITLE
target/riscv: only update mstatus.*ie bits with set_maskisr steponly

### DIFF
--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -503,7 +503,4 @@ void riscv_add_bscan_tunneled_scan(struct jtag_tap *tap, const struct scan_field
 int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
 int riscv_write_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
 
-int riscv_interrupts_disable(struct target *target, uint64_t ie_mask, uint64_t *old_mstatus);
-int riscv_interrupts_restore(struct target *target, uint64_t old_mstatus);
-
 #endif /* OPENOCD_TARGET_RISCV_RISCV_H */


### PR DESCRIPTION
With "set_maskisr steponly" setting, OpenOCD can alter the program behaviour when stepping over instructions modifying mstatus. The original value of mstatus is restored after step, discarding any changes that were made. This patch limits the differences to the interrupt enable bits.

To eliminate any influence of OpenOCD on the program state, we would need to decode the stepped instruction and also detect exceptions. Therefore the patch for that is very extensive, but even this small improvement should help in many cases.