### PR TITLE
Fix data types around opcodes.h and program.{c,h}

### DIFF
--- a/src/target/riscv/opcodes.h
+++ b/src/target/riscv/opcodes.h
@@ -18,18 +18,18 @@
 #define MAX_VREG_NUM 31
 #define MAX_CSR_NUM 4095
 
-#define MIN_INT12 ((int16_t)(-0x800))
-#define MAX_INT12 ((int16_t)0x7ff)
+#define MIN_INT12 (-0x800)
+#define MAX_INT12 0x7ff
 
-#define MIN_INT13 ((int16_t)(-0x1000))
-#define MAX_INT13 ((int16_t)0xfff)
+#define MIN_INT13 (-0x1000)
+#define MAX_INT13 0xfff
 
-#define MIN_INT21 ((int16_t)(-0x100000))
-#define MAX_INT21 ((int16_t)0xfffff)
+#define MIN_INT21 (-0x100000)
+#define MAX_INT21 0xfffff
 
-#define MAX_UINT5 ((uint8_t)0x1f)
-#define MAX_UINT11 ((uint16_t)0x7ff)
-#define MAX_UINT12 ((uint16_t)0xfff)
+#define MAX_UINT5 0x1f
+#define MAX_UINT11 0x7ff
+#define MAX_UINT12 0xfff
 
 static uint32_t bits(uint32_t value, unsigned int hi, unsigned int lo)
 {

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -21,7 +21,7 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 	p->instruction_count = 0;
 
 	for (size_t i = 0; i < RISCV_MAX_PROGBUF_SIZE; ++i)
-		p->progbuf[i] = -1;
+		p->progbuf[i] = (uint32_t)(-1);
 
 	p->execution_result = RISCV_PROGBUF_EXEC_RESULT_NOT_EXECUTED;
 	return ERROR_OK;
@@ -48,7 +48,7 @@ int riscv_program_exec(struct riscv_program *p, struct target *t)
 	if (riscv_program_ebreak(p) != ERROR_OK) {
 		LOG_TARGET_ERROR(t, "Unable to insert ebreak into program buffer");
 		for (size_t i = 0; i < riscv_progbuf_size(p->target); ++i)
-			LOG_TARGET_ERROR(t, "ram[%02x]: DASM(0x%08" PRIx32 ") [0x%08" PRIx32 "]",
+			LOG_TARGET_ERROR(t, "progbuf[%02x]: DASM(0x%08" PRIx32 ") [0x%08" PRIx32 "]",
 					(int)i, p->progbuf[i], p->progbuf[i]);
 		return ERROR_FAIL;
 	}
@@ -70,27 +70,27 @@ int riscv_program_exec(struct riscv_program *p, struct target *t)
 	return ERROR_OK;
 }
 
-int riscv_program_sdr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_sdr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, sd(d, b, offset));
 }
 
-int riscv_program_swr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_swr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, sw(d, b, offset));
 }
 
-int riscv_program_shr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_shr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, sh(d, b, offset));
 }
 
-int riscv_program_sbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_sbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, sb(d, b, offset));
 }
 
-int riscv_program_store(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset,
+int riscv_program_store(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset,
 		unsigned int size)
 {
 	switch (size) {
@@ -107,27 +107,27 @@ int riscv_program_store(struct riscv_program *p, enum gdb_regno d, enum gdb_regn
 	return ERROR_FAIL;
 }
 
-int riscv_program_ldr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_ldr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, ld(d, b, offset));
 }
 
-int riscv_program_lwr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_lwr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, lw(d, b, offset));
 }
 
-int riscv_program_lhr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_lhr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, lh(d, b, offset));
 }
 
-int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset)
+int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset)
 {
 	return riscv_program_insert(p, lb(d, b, offset));
 }
 
-int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int offset,
+int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t offset,
 		unsigned int size)
 {
 	switch (size) {
@@ -144,13 +144,13 @@ int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno
 	return ERROR_FAIL;
 }
 
-int riscv_program_csrrsi(struct riscv_program *p, enum gdb_regno d, unsigned int z, enum gdb_regno csr)
+int riscv_program_csrrsi(struct riscv_program *p, enum gdb_regno d, uint8_t z, enum gdb_regno csr)
 {
 	assert(csr >= GDB_REGNO_CSR0 && csr <= GDB_REGNO_CSR4095);
 	return riscv_program_insert(p, csrrsi(d, z, csr - GDB_REGNO_CSR0));
 }
 
-int riscv_program_csrrci(struct riscv_program *p, enum gdb_regno d, unsigned int z, enum gdb_regno csr)
+int riscv_program_csrrci(struct riscv_program *p, enum gdb_regno d, uint8_t z, enum gdb_regno csr)
 {
 	assert(csr >= GDB_REGNO_CSR0 && csr <= GDB_REGNO_CSR4095);
 	return riscv_program_insert(p, csrrci(d, z, csr - GDB_REGNO_CSR0));
@@ -164,7 +164,7 @@ int riscv_program_csrr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno
 
 int riscv_program_csrw(struct riscv_program *p, enum gdb_regno s, enum gdb_regno csr)
 {
-	assert(csr >= GDB_REGNO_CSR0);
+	assert(csr >= GDB_REGNO_CSR0 && csr <= GDB_REGNO_CSR4095);
 	return riscv_program_insert(p, csrrw(GDB_REGNO_ZERO, s, csr - GDB_REGNO_CSR0));
 }
 

--- a/src/target/riscv/program.c
+++ b/src/target/riscv/program.c
@@ -20,7 +20,7 @@ int riscv_program_init(struct riscv_program *p, struct target *target)
 	p->target = target;
 	p->instruction_count = 0;
 
-	for (size_t i = 0; i < RISCV_MAX_PROGBUF_SIZE; ++i)
+	for (unsigned int i = 0; i < RISCV013_MAX_PROGBUF_SIZE; ++i)
 		p->progbuf[i] = (uint32_t)(-1);
 
 	p->execution_result = RISCV_PROGBUF_EXEC_RESULT_NOT_EXECUTED;
@@ -47,9 +47,9 @@ int riscv_program_exec(struct riscv_program *p, struct target *t)
 
 	if (riscv_program_ebreak(p) != ERROR_OK) {
 		LOG_TARGET_ERROR(t, "Unable to insert ebreak into program buffer");
-		for (size_t i = 0; i < riscv_progbuf_size(p->target); ++i)
+		for (unsigned int i = 0; i < riscv_progbuf_size(p->target); ++i)
 			LOG_TARGET_ERROR(t, "progbuf[%02x]: DASM(0x%08" PRIx32 ") [0x%08" PRIx32 "]",
-					(int)i, p->progbuf[i], p->progbuf[i]);
+					i, p->progbuf[i], p->progbuf[i]);
 		return ERROR_FAIL;
 	}
 
@@ -198,8 +198,8 @@ int riscv_program_insert(struct riscv_program *p, riscv_insn_t i)
 {
 	if (p->instruction_count >= riscv_progbuf_size(p->target)) {
 		LOG_TARGET_ERROR(p->target, "Unable to insert program into progbuf, "
-			"capacity would be exceeded (progbufsize=%d).",
-			(int)riscv_progbuf_size(p->target));
+			"capacity would be exceeded (progbufsize=%u).",
+			riscv_progbuf_size(p->target));
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -52,22 +52,22 @@ int riscv_program_insert(struct riscv_program *p, riscv_insn_t i);
 /* Helpers to assemble various instructions.  Return 0 on success.  These might
  * assemble into a multi-instruction sequence that overwrites some other
  * register, but those will be properly saved and restored. */
-int riscv_program_ldr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
-int riscv_program_lwr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
-int riscv_program_lhr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
-int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int o);
-int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int o,
+int riscv_program_ldr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int16_t o);
+int riscv_program_lwr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int16_t o);
+int riscv_program_lhr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int16_t o);
+int riscv_program_lbr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno a, int16_t o);
+int riscv_program_load(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t o,
 		unsigned int s);
 
-int riscv_program_sdr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);
-int riscv_program_swr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);
-int riscv_program_shr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);
-int riscv_program_sbr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int o);
-int riscv_program_store(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int o,
+int riscv_program_sdr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int16_t o);
+int riscv_program_swr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int16_t o);
+int riscv_program_shr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int16_t o);
+int riscv_program_sbr(struct riscv_program *p, enum gdb_regno s, enum gdb_regno a, int16_t o);
+int riscv_program_store(struct riscv_program *p, enum gdb_regno d, enum gdb_regno b, int16_t o,
 		unsigned int s);
 
-int riscv_program_csrrsi(struct riscv_program *p, enum gdb_regno d, unsigned int z, enum gdb_regno csr);
-int riscv_program_csrrci(struct riscv_program *p, enum gdb_regno d, unsigned int z, enum gdb_regno csr);
+int riscv_program_csrrsi(struct riscv_program *p, enum gdb_regno d, uint8_t z, enum gdb_regno csr);
+int riscv_program_csrrci(struct riscv_program *p, enum gdb_regno d, uint8_t z, enum gdb_regno csr);
 int riscv_program_csrr(struct riscv_program *p, enum gdb_regno d, enum gdb_regno csr);
 int riscv_program_csrw(struct riscv_program *p, enum gdb_regno s, enum gdb_regno csr);
 

--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -5,9 +5,7 @@
 
 #include "riscv.h"
 
-#define RISCV_MAX_PROGBUF_SIZE 32
-#define RISCV_REGISTER_COUNT 32
-#define RISCV_DSCRATCH_COUNT 2
+#define RISCV013_MAX_PROGBUF_SIZE 16
 
 typedef enum {
 	RISCV_PROGBUF_EXEC_RESULT_NOT_EXECUTED,
@@ -23,10 +21,10 @@ typedef enum {
 struct riscv_program {
 	struct target *target;
 
-	uint32_t progbuf[RISCV_MAX_PROGBUF_SIZE];
+	uint32_t progbuf[RISCV013_MAX_PROGBUF_SIZE];
 
 	/* Number of 32-bit instructions in the program. */
-	size_t instruction_count;
+	unsigned int instruction_count;
 
 	/* execution result of the program */
 	/* TODO: remove this field. We should make it a parameter to riscv_program_exec */

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -5338,7 +5338,7 @@ static enum riscv_halt_reason riscv013_halt_reason(struct target *target)
 
 static int riscv013_write_progbuf(struct target *target, unsigned int index, riscv_insn_t data)
 {
-	assert(index < RISCV_MAX_PROGBUF_SIZE);
+	assert(index < RISCV013_MAX_PROGBUF_SIZE);
 
 	dm013_info_t *dm = get_dm(target);
 	if (!dm)

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -4962,7 +4962,7 @@ static int write_memory_progbuf_fill_progbuf(struct target *target, uint32_t siz
 	if (riscv_program_store(&program, GDB_REGNO_S1, GDB_REGNO_S0, 0, size) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (riscv_program_addi(&program, GDB_REGNO_S0, GDB_REGNO_S0, size) != ERROR_OK)
+	if (riscv_program_addi(&program, GDB_REGNO_S0, GDB_REGNO_S0, (int16_t)size) != ERROR_OK)
 		return ERROR_FAIL;
 
 	if (riscv_program_ebreak(&program) != ERROR_OK)
@@ -5338,9 +5338,12 @@ static enum riscv_halt_reason riscv013_halt_reason(struct target *target)
 
 static int riscv013_write_progbuf(struct target *target, unsigned int index, riscv_insn_t data)
 {
+	assert(index < RISCV_MAX_PROGBUF_SIZE);
+
 	dm013_info_t *dm = get_dm(target);
 	if (!dm)
 		return ERROR_FAIL;
+
 	if (dm->progbuf_cache[index] != data) {
 		if (dm_write(target, DM_PROGBUF0 + index, data) != ERROR_OK)
 			return ERROR_FAIL;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -6048,7 +6048,7 @@ static enum riscv_halt_reason riscv_halt_reason(struct target *target)
 	return r->halt_reason(target);
 }
 
-size_t riscv_progbuf_size(struct target *target)
+unsigned int riscv_progbuf_size(struct target *target)
 {
 	RISCV_INFO(r);
 	return r->get_progbufsize(target);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -6054,11 +6054,10 @@ size_t riscv_progbuf_size(struct target *target)
 	return r->get_progbufsize(target);
 }
 
-int riscv_write_progbuf(struct target *target, int index, riscv_insn_t insn)
+int riscv_write_progbuf(struct target *target, unsigned int index, riscv_insn_t insn)
 {
 	RISCV_INFO(r);
-	r->write_progbuf(target, index, insn);
-	return ERROR_OK;
+	return r->write_progbuf(target, index, insn);
 }
 
 riscv_insn_t riscv_read_progbuf(struct target *target, int index)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -476,7 +476,7 @@ int riscv_get_hart_state(struct target *target, enum riscv_hart_state *state);
 size_t riscv_progbuf_size(struct target *target);
 
 riscv_insn_t riscv_read_progbuf(struct target *target, int index);
-int riscv_write_progbuf(struct target *target, int index, riscv_insn_t insn);
+int riscv_write_progbuf(struct target *target, unsigned int index, riscv_insn_t insn);
 int riscv_execute_progbuf(struct target *target, uint32_t *cmderr);
 
 void riscv_fill_dm_nop(const struct target *target, uint8_t *buf);

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -473,7 +473,7 @@ int riscv_get_hart_state(struct target *target, enum riscv_hart_state *state);
 
 /* These helper functions let the generic program interface get target-specific
  * information. */
-size_t riscv_progbuf_size(struct target *target);
+unsigned int riscv_progbuf_size(struct target *target);
 
 riscv_insn_t riscv_read_progbuf(struct target *target, int index);
 int riscv_write_progbuf(struct target *target, unsigned int index, riscv_insn_t insn);


### PR DESCRIPTION
- Fix and clean-up data types in `opcodes.h` and `program.{c,h}`. Some of the changes were prompted by `-Wconversion`, others come from manual code inspection.

- Remove commented code from `opcodes.h` (unused for very long time).

- Add assertions to `opcodes.h` to check that instruction immediates (and other fields) don't exceed their range.

Change-Id: I7fc7c30ac2fdb00a93158d63d1379e7f16b1d168