### PR TITLE
riscv-011: Don't trigger semihosting before the target is examined

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -1889,8 +1889,16 @@ static int handle_halt(struct target *target, bool announce)
 
 	if (target->debug_reason == DBG_REASON_BREAKPOINT) {
 		int retval;
-		if (riscv_semihosting(target, &retval) != 0)
-			return retval;
+		/* Hotfix: Don't try to handle semihosting before the target is marked as examined. */
+		/* TODO: The code should be rearranged so that:
+		 * - Semihosting is not attempted before the target is examined.
+		 * - When the target is already halted on a semihosting magic sequence
+		 *   at the time when OpenOCD connects to it, this semihosting attempt
+		 *   gets handled right after the examination.
+		 */
+		if (target_was_examined(target))
+			if (riscv_semihosting(target, &retval) != SEMIHOSTING_NONE)
+				return retval;
 	}
 
 	if (announce)


### PR DESCRIPTION
In riscv-011 target, the `handle_halt()` function, and thus also `riscv_semihosting()`, can get called from within `examine()` before the examination is actually complete.

The chain of the function calls is:

- examine() -> riscv011_poll() -> poll_target() -> handle_halt() -> riscv_semihosting()

If the target is already halted due to a breakpoint (dcsr.cause = SWBP) at the time OpenOCD connects to it, semihosting will be attempted before completing the examination, and the examination will fail.

This issue was observed on HiFive1 Rev A01.

The fix is to handle semihosting only after the target got successfully examined.

Change-Id: Iccfa0da35d47a430d8674131ebd2eb8e5e2922c0