### PR TITLE
CI: Run the "snapshot" action only on the main branch

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,7 +2,10 @@
 
 # Copyright (C) 2020 by Tarek BOUCHKATI <tarek.bouchkati@gmail.com>
 
-on: push
+on:
+  push:
+    branches:
+      - riscv
 
 name: OpenOCD Snapshot
 


### PR DESCRIPTION
Make sure that the "snapshot" action only runs when pushing changes to the main branch - "riscv". No need to run it for individual commits under side-branches.

Change-Id: I5877a3b5635fc6053af7718e38a4d5a093e02744