### PR TITLE
src/target/riscv: error out of the `examine()` in case `abits` is zero

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1956,6 +1956,11 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 	}
 
+	if (info->abits == 0) {
+		LOG_TARGET_ERROR(target,
+				"dtmcs.abits is zero. Check JTAG connectivity/board power");
+		return ERROR_FAIL;
+	}
 	if (info->abits < RISCV013_DTMCS_ABITS_MIN) {
 		/* The requirement for minimum DMI address width of 7 bits is part of
 		 * the RISC-V Debug spec since Jan-20-2017 (commit 03df6ee7). However,


### PR DESCRIPTION
The spec requires `abits` to be no less then 7 ( [3.1. Debug Module Interface (DMI)]):
> The DMI uses between 7 and 32 address bits

Commit a450a7d4966a19c48b2543810f5b8370af6383e5 ("Fix data types around batch.{c,h}") introduced a check that issues a warning if `abits` is less then 7. The reason it's a warning and not an error -- on Spike `abits` is 6.

However, if the examination is to proceed when `abits` is zero, an assert in `get_dmi_scan_length()` will trigger when attempting to communicate over DMI.
Link: https://github.com/JanMatCodasip/riscv-openocd/blob/a450a7d4966a19c48b2543810f5b8370af6383e5/src/target/riscv/batch.c#L25

It's impossible to communicate over DMI with `abits == 0`, so an error is returned instead of a warning in this case.

Change-Id: Ice4622adccfc8304b37bc678253cc19d8ac1457e