### PR TITLE
target/riscv: bug in wait_for_idle() and in register_read_progbuf()

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1367,7 +1367,9 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 	return register_read_abstract(target, value, GDB_REGNO_S0) != ERROR_OK;
 }
 
-
+/**
+ * Reads a general-purpose register (GPR) via the program buffer.
+ */
 static int gpr_read_progbuf(struct target *target, uint64_t *value,
 		enum gdb_regno number)
 {

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -572,6 +572,12 @@ static int wait_for_idle(struct target *target, uint32_t *abstractcs)
 				"potentially unrecoverable error detected - could not read abstractcs");
 			return ERROR_FAIL;
 		}
+			//clear abstractcs and return ERROR_OK otherwise
+		else{
+			
+			*abstractcs = 0;
+			return ERROR_OK;
+		}
 
 		if (get_field(*abstractcs, DM_ABSTRACTCS_BUSY) == 0) {
 			dm->abstract_cmd_maybe_busy = false;
@@ -1361,6 +1367,17 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 	return register_read_abstract(target, value, GDB_REGNO_S0) != ERROR_OK;
 }
 
+
+static int gpr_read_progbuf(struct target *target, uint64_t *value,
+		enum gdb_regno number)
+{
+	assert(target->state == TARGET_HALTED);
+	assert(number >= GDB_REGNO_ZERO && number <= GDB_REGNO_XPR31);
+
+	/* Use abstract commands to read the GPR directly. */
+	return register_read_abstract(target, value, number) != ERROR_OK;
+}
+
 /**
  * This function reads a register by writing a program to program buffer and
  * executing it.
@@ -1374,6 +1391,9 @@ static int register_read_progbuf(struct target *target, uint64_t *value,
 		return fpr_read_progbuf(target, value, number);
 	else if (number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095)
 		return csr_read_progbuf(target, value, number);
+
+	else if (number >= GDB_REGNO_ZERO && number <= GDB_REGNO_XPR31)
+		return gpr_read_progbuf(target, value, number);
 
 	LOG_TARGET_ERROR(target, "Unexpected read of %s via program buffer.",
 			riscv_reg_gdb_regno_name(target, number));


### PR DESCRIPTION
lately i have been trying to interface with the Cheshire core from PULP. However:

1. openocd was stuck in a loop waiting for dm_read to return ERROR_OK in https://github.com/AbdelkadirChantar/riscv-openocd/blob/76ddef0b7b74afdd489a9cb9387640dccf6aa012/src/target/riscv/riscv-013.c#L552 
which  **prevents proper connection:** 


> Open On-Chip Debugger 0.12.0+dev-04253-gfa7e2351c-dirty (2025-03-04-13:40)
> Licensed under GNU GPL v2
> For bug reports, read
> 	http://openocd.org/doc/doxygen/bugs.html
> Warning: This version of OpenOCD does not support address translation. To debug on virtual addresses, please update to the latest version.
> Info : clock speed 1000 kHz
> Info : JTAG tap: riscv.cpu tap/device found: 0x1c5e5db3 (mfg: 0x6d9 (PULP Platform), part: 0xc5e5, ver: 0x1)
> Info : [riscv.cpu] datacount=2 progbufsize=8 // stuck here


After 2 minutes time out I got:

`Error: [riscv.cpu] Timed out after 120s waiting for busy to go low (abstractcs=0x8001002). Increase the timeout with riscv set_command_timeout_sec.
`
I considered adding the following else case that returns ERROR_OK and reset asbtractcs when dm.read was successful:

https://github.com/AbdelkadirChantar/riscv-openocd/blob/76ddef0b7b74afdd489a9cb9387640dccf6aa012/src/target/riscv/riscv-013.c#L576-L580

which results in a **successful connection**.

2. After fixing this, an attempt to connect to gdb returns 

> Could not read registers; remote failure reply 'E0E'
> (gdb) 
> 
immediately causing openocd to disconnect:

> Ready for Remote Connections.
> Info : tcl server disabled
> Info : telnet server disabled
> Info : accepting 'gdb' connection on tcp/3333
> riscv.cpu halted due to debug-request.
> **Error: [riscv.cpu] Unexpected read of zero via program buffer.**
> GDB detached; ending debugging session.
> shutdown command invoked
> Info : dropped 'gdb' connection

The error was coming from **register_read_progbuf()**. Apparantely, this function is receiving GDB_REGNO=8, but there was no handling for such range which is the range of general purpose registers GPRs. Thus no function read this register.
adding an elseif case for gprs range (0-31), 
https://github.com/AbdelkadirChantar/riscv-openocd/blob/76ddef0b7b74afdd489a9cb9387640dccf6aa012/src/target/riscv/riscv-013.c#L1397-L1398

yields a successful connection to gdb, loading an elf and halting the core properly. 