### PR TITLE
target/riscv: avoid `config` modification on `jim_getopt_obj()` failure

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -534,9 +534,12 @@ static int jim_configure_ebreak(struct riscv_private_config *config, struct jim_
 		/* Here a common "ebreak" action is processed, e.g:
 		 * "riscv.cpu configure -ebreak halt"
 		 */
+		int res = jim_getopt_obj(goi, NULL);
+		if (res != JIM_OK)
+			return res;
 		for (int ebreak_ctl_i = 0; ebreak_ctl_i < N_RISCV_MODE; ++ebreak_ctl_i)
 			config->dcsr_ebreak_fields[ebreak_ctl_i] = common_mode_nvp->value;
-		return jim_getopt_obj(goi, NULL);
+		return JIM_OK;
 	}
 
 	/* Here a "ebreak" action for a specific execution mode is processed, e.g:


### PR DESCRIPTION
Currently, `jim_getopt_obj()` only fails if `goi->argc` is zero, Link: https://github.com/riscv-collab/riscv-openocd/blob/41a225460c3b9a6c1f61a0777f101ff009f56007/src/helper/jim-nvp.c#L174-L185 so the check at the start of `jim_configure_ebreak()` Link: https://github.com/riscv-collab/riscv-openocd/blob/41a225460c3b9a6c1f61a0777f101ff009f56007/src/target/riscv/riscv.c#L526-L530 guarantees that the call will succeed.

However, the modification makes the code more robust and future-proof.

Change-Id: Ic8c2e057a285bf679d26e21bda138a1d2ae5d5ce