### PR TITLE
Initial version of proposal for the new riscv transport and adapter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,6 +281,11 @@ AC_ARG_ENABLE([rshim],
   AS_HELP_STRING([--enable-rshim], [Enable building the rshim driver]),
   [build_rshim=$enableval], [build_rshim=no])
 
+AC_ARG_ENABLE([riscv],
+  AS_HELP_STRING([--enable-riscv], [Enable RISC-V support]),
+  [build_riscv=$enableval],[build_riscv=no])
+AM_CONDITIONAL([RISCV], [test "x$enable_riscv" = "xyes"])
+
 AC_ARG_ENABLE([dmem],
   AS_HELP_STRING([--enable-dmem], [Enable building the dmem driver]),
   [build_dmem=$enableval], [build_dmem=no])

--- a/script_server_simulator/dmi_socket_responder.py
+++ b/script_server_simulator/dmi_socket_responder.py
@@ -1,0 +1,399 @@
+import socket
+import struct
+import time
+# import ipdb
+import binascii
+import threading
+
+HOST = 'localhost'
+PORT = 5555
+
+# Commands
+READ_COMMAND = 0x00
+WRITE_COMMAND = 0x01
+
+# Response codes
+RESPONSE_OK = 0x00
+RESPONSE_ERROR = 0x01
+
+      
+# --- Simulated Register State ---
+misa = 0x800000000014112d  # Match Spike’s value
+NUM_GPRS = 32  # 32 general-purpose registers in RISC-V
+
+gprs = [0] * NUM_GPRS
+
+dcsr = 0x40000003
+dpc = 0 
+mstatus = 0xA00000200 
+
+
+# --- DMI Registers (RISC-V Debug Spec 0.13) ---
+# These are the essential registers for basic functionality
+DMI_DMCONTROL = 0x10  # Debug Module Control
+DMI_DMSTATUS = 0x11  # Debug Module Status
+DMI_HARTINFO = 0x12  # Hart Information
+DMI_ABSTRACTCS = 0x16  # Abstract Control and Status
+DMI_COMMAND = 0x17  # Abstract Command
+DMI_ABSTRACTAUTO = 0x18  # Abstract Autoincrement
+DMI_DATA0 = 0x04  # Data register 0 (for abstract commands)
+DMI_DATA1 = 0x05  # Data register 1 (for abstract commands)
+DMI_PROGBUF0 = 0x20  # Program Buffer 0 (for program buffer access)
+DMI_SBCS = 0x38 # System Bus Access Control and Status
+DMI_DCSR = 0x7B0
+DMI_MSTATUS = 0x300
+
+DMI_DTMCS_OFFSET_DEBUG = 0x0000
+
+# This needs to be changed, a temp hack to reply to the OpenOCD, probably some issue with 
+# the kernel buffer, but it works somehow. Some clearing of the buffer is needed, or 
+# better managing of the messages, either by size, or by some delimiter of the message.
+DMI_TEST = 0x10040000
+
+dmi_mem = {
+    DMI_TEST: 0x0041,
+    DMI_DTMCS_OFFSET_DEBUG: 0x0000, # 0x00000000 is the default value for all registers, 0x0000 is the address offset for the DTMCS register
+    DMI_DMCONTROL: 0x0001,  # Initially, let's say the hart is running
+    DMI_DMSTATUS: 0x0202,  # Indicate all harts are running, version 0.13 (version=2)
+    DMI_HARTINFO: 0x0000,  # No hartsel, 1 data register
+    DMI_ABSTRACTCS: 0x02000002,  # datacount=2, progbufsize=2
+    DMI_COMMAND: 0x0000,  # No command active
+    DMI_ABSTRACTAUTO: 0x0000,  # No auto-increment
+    DMI_DATA0: 0x0000,
+    DMI_DATA1: 0x0000,
+    DMI_PROGBUF0: 0x0000,
+    DMI_SBCS: 0x0000,
+}
+
+# This is a hack to clear the kernel buffer
+# It is necessary because the kernel buffer is not cleared by the socket
+# and it can cause problems with the DMI protocol  in some cases, so better be safe
+def clear_kernel_buffer(sock):
+    sock.setblocking(False)
+    
+    try:
+        while True:
+            data = sock.recv(4096)
+            if not data:
+                break
+    except BlockingIOError:
+        pass
+    finally:
+        sock.setblocking(True)
+
+def handle_dmi_read(address, conn):
+    """Handles DMI read requests."""
+    # ipdb.set_trace()
+
+    # COUNTERS
+    if not hasattr(handle_dmi_read, "dmi_status_counter"):
+        handle_dmi_read.dmi_status_counter = [0]
+    if not hasattr(handle_dmi_read, "dmi_dmcontrol_counter"):
+        handle_dmi_read.dmi_dmcontrol_counter = [0]
+
+    if address in dmi_mem:
+        data = dmi_mem[address]
+        print(f"DMI Read: Addr=0x{address:02X}, Data=0x{data:08X}")
+        # ipdb.set_trace()
+        if address == DMI_DTMCS_OFFSET_DEBUG:
+            # clear_kernel_buffer(conn)
+            data = 0x61
+            print(f"  DTMCS offset debug: Returning: 0x{data:08X}")
+        elif address == DMI_ABSTRACTCS:
+            data = 0x02000002  # datacount=2, progbufsize=2
+        # elif address == DMI_DMSTATUS:
+        #     data = 0x400282  # Simplified: halted, resumeack
+
+        elif address == DMI_DMCONTROL:
+            print(f"******************** Counter DMI_CONTROL is: {handle_dmi_read.dmi_dmcontrol_counter[0]}")
+            if handle_dmi_read.dmi_dmcontrol_counter[0] == 2:
+                data = 0x40  # Example: Set dmactive (bit 31) and dmireset (bit 0)
+            else:
+                data = 0x41
+            handle_dmi_read.dmi_dmcontrol_counter[0] += 1
+            print(f"  DTMCONTROL read! Returning: 0x{data:08X}")
+
+        elif address == DMI_DMSTATUS:
+            print(f"  DMI_DMSTATUS read! Current value: 0x{data:08X}")
+            # Define field values
+            version = 0x2             # version 0.13 (4 bits)
+            confstrptrvalid = 0x0
+            hasresethaltreq = 1
+            authbusy = 0
+            authenticated = 1
+            anyhalted = 1
+            allhalted = 1
+            anyrunning = 0
+            allrunning = 0
+            anyunavail = 1
+            allunavail = 0
+            anynonexistent = 0
+            allnonexistent = 1
+            anyresumeack = 1
+            allresumeack = 1
+            anyhavereset = 0
+            allhavereset = 0
+            impebreak = 0x0
+
+            # construct the 32-bit data value
+            data = (version & 0x0f) | \
+                ((confstrptrvalid & 0x01) << 4) | \
+                ((hasresethaltreq & 0x01) << 5) | \
+                ((authbusy & 0x01) << 6) | \
+                ((authenticated & 0x01) << 7) | \
+                ((anyhalted & 0x01) << 8) | \
+                ((allhalted & 0x01) << 9) | \
+                ((anyrunning & 0x01) << 10) | \
+                ((allrunning & 0x01) << 11) | \
+                ((anyunavail & 0x01) << 12) | \
+                ((allunavail & 0x01) << 13) | \
+                ((anynonexistent & 0x01) << 14) | \
+                ((allnonexistent & 0x01) << 15) | \
+                ((anyresumeack & 0x01) << 16) | \
+                ((allresumeack & 0x01) << 17) | \
+                ((anyhavereset & 0x01) << 18) | \
+                ((allhavereset & 0x01) << 19) | \
+                ((impebreak & 0x03) << 20) | \
+                (0 << 31)  # bit 31 is fixed to 0
+            handle_dmi_read.dmi_status_counter[0] += 1
+            if handle_dmi_read.dmi_status_counter[0] == 0:
+                data = 0x400C82 # This is what spike simulator returns later when halting the hart
+            if handle_dmi_read.dmi_status_counter[0] >= 1 and handle_dmi_read.dmi_status_counter[0] < 10:
+                data = 0x400282
+            if handle_dmi_read.dmi_status_counter[0] > 10:
+                data = (0x2 & 0x0f) | \
+                    ((0x0 & 0x01) << 4) | \
+                    ((0x0 & 0x01) << 5) | \
+                    ((0x0 & 0x01) << 6) | \
+                    ((0x1 & 0x01) << 7) | \
+                    ((0x1 & 0x01) << 8) | \
+                    ((0x1 & 0x01) << 9) | \
+                    ((0x0 & 0x01) << 10) | \
+                    ((0x0 & 0x01) << 11) | \
+                    ((0x0 & 0x01) << 12) | \
+                    ((0x0 & 0x01) << 13) | \
+                    ((0x0 & 0x01) << 14) | \
+                    ((0x0 & 0x01) << 15) | \
+                    ((0x1 & 0x01) << 16) | \
+                    ((0x1 & 0x01) << 17) | \
+                    ((0x0 & 0x01) << 18) | \
+                    ((0x0 & 0x01) << 19) | \
+                    ((0x0 & 0x03) << 20) | \
+                    (0 << 31)  # bit 31 is fixed to 0
+            print(f"  DMI_DMSTATUS read! Constructed value: 0x{data:08X}")
+        response = struct.pack(">B", RESPONSE_OK) + struct.pack(">I", data)
+        conn.sendall(response)
+        return data
+    else:
+        print(f"DMI Read: Addr=0x{address:02X} - Not found!")
+        conn.sendall(struct.pack(">BI", RESPONSE_ERROR, 0))
+        return None
+
+def handle_dmi_write(address, data):
+    print(f"DMI Write: Addr=0x{address:02X}, Data=0x{data:08X}")
+    # ipdb.set_trace()
+    if address == DMI_DMCONTROL:
+        print(f"  DMI_DMCONTROL write! Data: 0x{data:08X}")
+        # Implement basic DMCONTROL handling (e.g., halt, resume)
+        dmi_mem[DMI_DMCONTROL] = data # Write data here
+        print(f"  DMI_DMSTATUS before modification: 0x{dmi_mem[DMI_DMSTATUS]:08X}")
+
+        DMSTATUS_ALL_RUNNING_MASK = 0x3
+        DMSTATUS_ALL_RESUMEACK_MASK = 0x3
+        DMSTATUS_ALL_HAVERESET_MASK = 0x300
+        DMSTATUS_ALL_RESUME_MASK = 0x300
+        DMSTATUS_ALL_RESET_MASK = 0x400
+        DMSTATUS_VERSION_MASK = 0x3
+        DMSTATUS_VERSION_0_13 = 0x2
+
+        if (data >> 31) & 1:
+            print("Debug request set")
+            # dmi_mem[DMI_DMSTATUS] = (dmi_mem[DMI_DMSTATUS] & ~0x3) | 0x2  # Set all running to 0 and all resumeack to 1
+            dmi_mem[DMI_DMSTATUS] &= ~(DMSTATUS_ALL_RUNNING_MASK)
+            dmi_mem[DMI_DMSTATUS] |= (DMSTATUS_ALL_RESUMEACK_MASK & 0x2)
+        if (data >> 30) & 1:
+            print("Halt request set")
+            # dmi_mem[DMI_DMSTATUS] = (dmi_mem[DMI_DMSTATUS] & ~0x300) | 0x200  # Set all resume to 0 and all have been halted to 1
+            dmi_mem[DMI_DMSTATUS] &= ~(DMSTATUS_ALL_RESUME_MASK)
+            dmi_mem[DMI_DMSTATUS] |= (DMSTATUS_ALL_HAVERESET_MASK & 0x200)
+        if (data >> 0) & 1:
+            print("Hart reset request set")
+            # dmi_mem[DMI_DMSTATUS] = (dmi_mem[DMI_DMSTATUS] & ~0x400) | 0x400  # Set all reset to 1
+            dmi_mem[DMI_DMSTATUS] |= (DMSTATUS_ALL_RESET_MASK & 0x400)
+        if (data >> 1) & 1:
+            print("Acknowledge hart reset request set")
+            # dmi_mem[DMI_DMSTATUS] = (dmi_mem[DMI_DMSTATUS] & ~0x400)  # Set all reset to 0
+            dmi_mem[DMI_DMSTATUS] &= ~(DMSTATUS_ALL_RESET_MASK)
+
+        # We need to always ensure the version field is correct:
+        dmi_mem[DMI_DMSTATUS] &= ~DMSTATUS_VERSION_MASK  # Clear version bits
+        dmi_mem[DMI_DMSTATUS] |= DMSTATUS_VERSION_0_13  # Set version to 0.13
+    elif address == DMI_COMMAND:
+        # Implement abstract command handling
+        print(f"DMI_COMMAND 0x{DMI_COMMAND} address sets the data now to {data}.")
+        dmi_mem[DMI_COMMAND] = data # Write data here
+        cmderr = execute_abstract_command(data)
+        # dmi_mem[DMI_ABSTRACTCS] = (dmi_mem[DMI_ABSTRACTCS] & ~0x7) | cmderr
+        dmi_mem[DMI_ABSTRACTCS] = (dmi_mem[DMI_ABSTRACTCS] & ~0x700) | (cmderr << 8)
+        print(f"Updated ABSTRACTCS: 0x{dmi_mem[DMI_ABSTRACTCS]:08X}")
+
+    else:
+        # ipdb.set_trace()
+        dmi_mem[address] = data  # Now data is the original value 
+        
+def execute_abstract_command(command):
+    """Executes abstract commands (simplified for this example)."""
+    global dcsr, dpc
+    command_type = (command >> 24) & 0xFF
+    print(f"Executing abstract command: 0x{command_type:02X}")
+  
+    # Access Register command as per 
+    # https://riscv.org/wp-content/uploads/2024/12/riscv-debug-release.pdf, page 22, table 3.2
+    if command_type == 0:    
+        '''
+        This command gives the debugger access to CPU registers and allows it to execute the Program
+        Buffer. It performs the following sequence of operations:
+            1. If write is clear and transfer is set, then copy data from the register specified by regno into the
+            arg0 region of data, and perform any side effects that occur when this register is read from
+            M-mode.
+            2. If write is set and transfer is set, then copy data from the arg0 region of data into the register
+            specified by regno, and perform any side effects that occur when this register is written from
+            M-mode.
+            3. If aarpostincrement is set, increment regno.
+        '''
+        # Extract parameters
+        reg_num = (command >> 0) & 0xFFFF
+        aarsize = (command >> 20) & 0x7
+        write = (command >> 23) & 0x1
+        transfer = (command >> 20) & 0x1
+
+        if transfer:
+            if write:
+                # Write to register
+                if reg_num >= 0x1000 and reg_num <= 0x101F:
+                    gprs[reg_num - 0x1000] = dmi_mem[DMI_DATA0]
+                    print(f"  Writing 0x{dmi_mem[DMI_DATA0]:08X} to GPR {reg_num - 0x1000}")
+                elif reg_num == 0x4:
+                    dpc = dmi_mem[DMI_DATA0]
+                    print(f"  Writing 0x{dmi_mem[DMI_DATA0]:08X} to DPC")
+                elif reg_num == 0x7b0:
+                    dcsr = dmi_mem[DMI_DATA0] & 0xFFFFFFFF
+                    print(f"  Writing 0x{dcsr:08X} to DCSR")
+                elif reg_num == 0x301:
+                    value = (dmi_mem[DMI_DATA1] << 32 ) | dmi_mem[DMI_DATA0]
+                    global misa
+                    misa = value
+                    # dcsr = dmi_mem[DMI_DATA0] & 0xFFFFFFFF
+                    print(f"Writing MISA: 0x{misa:016X}")
+                    # print(f"  Writing 0x{dcsr:08X} to DCSR")
+                else:
+                    print(f"  Write to register {reg_num} not implemented")
+            else:
+                # Read from register
+                if reg_num >= 0x1000 and reg_num <= 0x101F:
+                    data = gprs[reg_num - 0x1000]
+                    print(f"  Reading GPR {reg_num - 0x1000}, returning 0x00000000")
+                    dmi_mem[DMI_DATA0] = data
+                elif reg_num == 0x4:
+                    print(f"  Reading DPC, returning 0x00000000")
+                    dmi_mem[DMI_DATA0] = dpc 
+                elif reg_num == 0x7b0:
+                    print(f"  Reading DCSR, returning 0x{dcsr:08X}")
+                    dmi_mem[DMI_DATA0] = dcsr
+                elif reg_num == 0x300:
+                    dmi_mem[DMI_DATA0] = mstatus & 0xFFFFFFFF
+                    dmi_mem[DMI_DATA1] = mstatus >> 32
+                    print(f"Reading MSTATUS: 0x{mstatus:016X}")
+                    # dmi_mem[DMI_DATA0] = 0xA00000200 
+                elif reg_num == 0x301:
+                    dmi_mem[DMI_DATA0] = misa & 0xFFFFFFFF
+                    dmi_mem[DMI_DATA1] = misa >> 32
+                    # print(f"  Reading MSTATUS, returning 0xA00000200")
+                    print(f"Reading MISA: 0x{misa:016X}, DATA0=0x{dmi_mem[DMI_DATA0]:08X}, DATA1=0x{dmi_mem[DMI_DATA1]:08X}")
+                    # dmi_mem[DMI_DATA0] = 0x331008 
+                else:
+                    print(f"  Read from register {reg_num} not implemented")
+                    dmi_mem[DMI_DATA0] = 0
+                    dmi_mem[DMI_DATA1] = 0
+        return 0  # No error
+    else:
+        print(f"  Command type {command_type} not implemented")
+        return 7  # Command not implemented
+
+def main():
+    # threading.Thread(target=start_gdb_server, daemon=True).start()
+    # --- Main Server Loop ---
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((HOST, PORT))
+        s.listen()
+        print(f"Server listening on {HOST}:{PORT}")
+        while True:
+            conn, addr = s.accept()
+            with conn:
+                print(f"Connected by {addr}")
+                buffer = b''
+                while True:
+                    try:
+                        # ipdb.set_trace()
+                        data = conn.recv(1024)
+                        if not data:
+                            break
+                        print(f"Received raw data: {data.hex()}")
+                        buffer += data
+
+                        while len(buffer) >= 6:
+                            command, address, data_length = struct.unpack(">BIB", buffer[:6])
+                            print(f"Unpacked received command: 0x{command:01X}")
+                            print(f"Unpacked received address: 0x{address:04X}")
+                            print(f"Unpacked received data_length: 0x{data_length:01X}")
+                            if command == READ_COMMAND:
+                                # ipdb.set_trace()
+                                data = handle_dmi_read(address, conn)
+                                print(f"Unpacked READ data is {data}")
+                                print(f"READ COMMAND received, the whole buffer is: {buffer}")
+                                buffer = buffer[6:]
+                                # buffer = buffer[9:] # TODO: Check this one!!! Is it 6 or 9
+                                print(f"READ COMMAND received, stripped buffer is: {buffer}")
+
+                            elif command == WRITE_COMMAND:
+                                if len(buffer) < 10:
+                                    print("Waiting for full write packet")
+                                    break
+                                # ipdb.set_trace()
+                                data = struct.unpack(">I", buffer[6:10])[0]
+                                print(f"Unpacked WRITE data is {data}")
+                                handle_dmi_write(address, data)
+                                conn.sendall(struct.pack(">B", RESPONSE_OK))
+                                print(f"WRITE COMMAND received, the whole buffer is: {buffer}")
+                                buffer = buffer[10:]
+                                print(f"WRITE COMMAND received, stripped buffer is: {buffer}")
+
+                            else:
+                                print (f"Received buffer with unknown command, the whole buffer is: {buffer}")
+                                print(f"Invalid command: {command}")
+                                # conn.sendall(struct.pack(">BI", RESPONSE_ERROR, 0))
+                                buffer = buffer[10:]
+                        if not buffer:
+                            # If buffer is empty, receive at least 6 bytes
+                            received_data = conn.recv(6)
+                        else:
+                            # If buffer has some data, check for and remove stray '@'
+                            if buffer == b'@':
+                                print("Removing stray '@' from buffer")
+                                buffer = b''  # Clear the buffer
+                            # Receive at least 1 byte to make progress
+                            received_data = conn.recv(1)
+
+                        if not received_data:
+                            break  # Connection closed
+
+                        # buffer = b''
+                        # buffer += received_data
+                        buffer = received_data
+
+                    except ConnectionResetError:
+                        print("Client disconnected")
+                        break
+                buffer = b''
+
+main()

--- a/script_server_simulator/dmi_socket_responder_v2.py
+++ b/script_server_simulator/dmi_socket_responder_v2.py
@@ -1,0 +1,404 @@
+import socket
+import struct
+import time
+# import ipdb
+import binascii
+import threading
+
+HOST = 'localhost'
+PORT = 5555
+
+READ_COMMAND = 0x00
+WRITE_COMMAND = 0x01
+
+RESPONSE_OK = 0x00
+RESPONSE_ERROR = 0x01
+
+XLEN = 64
+misa = 0x800000000014112d  # RV64IMAFDCV (Example, includes 'V')
+NUM_GPRS = 32
+gprs = [0] * NUM_GPRS
+dcsr = 0x40000003  # Default initial state
+dpc = 0
+mstatus = 0xA00000200
+
+# vlenb: Vector Length in Bytes. Only valid if 'V' extension is present.
+# VLEN=128 -> vlenb=16. VLEN=512 -> vlenb=64. Let's assume VLEN=128.
+vlenb = 16 if (misa >> 21) & 1 else 0 # Check 'V' bit (bit 21) in misa
+
+mtopi = 0
+
+DMI_DATA0 = 0x04
+DMI_DATA1 = 0x05
+DMI_DMCONTROL = 0x10
+DMI_DMSTATUS = 0x11
+DMI_HARTINFO = 0x12
+DMI_ABSTRACTCS = 0x16
+DMI_COMMAND = 0x17
+DMI_ABSTRACTAUTO = 0x18
+DMI_PROGBUF0 = 0x20
+DMI_SBCS = 0x38
+
+CSR_MISA = 0x301
+CSR_MSTATUS = 0x300
+CSR_DCSR = 0x7B0
+CSR_DPC = 0x7B1
+CSR_VLENB = 0xC22
+CSR_MTOPI = 0x350
+GPR_BASE = 0x1000
+
+dmi_mem = {
+    DMI_DMCONTROL: 0x0,     # Start with hart halted, dmactive=0
+    DMI_DMSTATUS: (1 << 8) | (1 << 9) | (1 << 7) | 0x2, # 0x00000382 : set both allhalted and anyhlated
+    DMI_HARTINFO: 0x00102004, # nscratch=1(0+1), dataaccess=0(csr), datasize=2(DATA0/1), dataaddr=0x04
+    DMI_ABSTRACTCS: (0 << 8) | (0 << 12) | (2 << 0) | (2 << 24), # Should be 0x02000002 initially
+    DMI_COMMAND: 0x00000000,
+    DMI_ABSTRACTAUTO: 0x00000000,
+    DMI_DATA0: 0x00000000,
+    DMI_DATA1: 0x00000000,
+    DMI_PROGBUF0: 0x00000000,
+    DMI_SBCS: 0x00000000,
+}
+
+def update_cmderr(error_code):
+    # Preserve datacount and progbufsize when updating cmderr and busy
+    preserved_bits = dmi_mem[DMI_ABSTRACTCS] & (0xFFF | (0x1F << 24)) # Mask for datacount and progbufsize
+    dmi_mem[DMI_ABSTRACTCS] = preserved_bits | ((error_code & 0x7) << 8) # Set cmderr
+    # Clear busy bit (bit 12)
+    dmi_mem[DMI_ABSTRACTCS] &= ~(1 << 12)
+
+# --- Helper: Check if V extension is enabled in simulated misa ---
+def has_v_extension():
+    return (misa >> 21) & 1 # Check 'V' bit (bit 21)
+
+# --- Helper: Check if Smtopi extension is enabled (placeholder) ---
+def has_smtopi_extension():
+    return False # Placeholder
+
+def handle_dmi_read(address, conn):
+    """Handles DMI read requests."""
+    global dmi_mem
+    data = dmi_mem.get(address, 0) # Default to 0 if address not found
+
+    print(f"DMI Read : Addr=0x{address:02X}, Data=0x{data:08X}")
+
+    # Specific handling if needed (e.g., dynamic status)
+    if address == DMI_DMSTATUS:
+        # For now, just returning the stored value.
+        # Example: Ensure version is correct
+        data = (data & ~0xF) | 0x2 # Force version 0.13
+        print(f"  Adjusted DMI_DMSTATUS read: 0x{data:08X}")
+        dmi_mem[address] = data # Update stored value if adjusted
+
+    elif address == DMI_ABSTRACTCS:
+        print(f"  DMI_ABSTRACTCS read: 0x{data:08X}")
+
+    elif address == DMI_DATA0 or address == DMI_DATA1:
+        print(f"  DMI_DATA{address-DMI_DATA0} read: 0x{data:08X}")
+
+    response = struct.pack(">B", RESPONSE_OK) + struct.pack(">I", data)
+    conn.sendall(response)
+    return data
+
+
+def handle_dmi_write(address, data, conn):
+    """Handles DMI write requests."""
+    global dmi_mem
+    print(f"DMI Write: Addr=0x{address:04X}, Data=0x{data:08X}") # Use 04X for address
+
+    # --- Handle specific DMI register writes ---
+    if address == DMI_DMCONTROL:
+        requested_dmcontrol = data
+        print(f"  DMI_DMCONTROL write request: 0x{requested_dmcontrol:08X}")
+
+        current_dmcontrol = dmi_mem.get(DMI_DMCONTROL, 0)
+        was_active = (current_dmcontrol & 1) != 0
+
+        # Simulate state changes based on request
+        haltreq = (requested_dmcontrol >> 31) & 1
+        resumereq = (requested_dmcontrol >> 30) & 1
+        hartreset = (requested_dmcontrol >> 29) & 1
+        ackhavereset = (requested_dmcontrol >> 28) & 1
+        ndmreset_req = (requested_dmcontrol >> 1) & 1 # Check if DM reset is requested
+        dmactive_req = (requested_dmcontrol >> 0) & 1 # Check if activation is explicitly requested
+
+        new_dmcontrol_state = requested_dmcontrol
+
+        if ndmreset_req:
+            # If ndmreset is requested, DM MUST become inactive.
+            new_dmcontrol_state &= ~1 # Force dmactive (bit 0) to 0
+            print("  -> ndmreset requested, forcing dmactive=0")
+        elif not was_active and dmactive_req == 0:
+            # If the DM wasn't already active, and the first write requests
+            # dmactive=0 (like the initial examine write), force it active.
+            # This simulates the DM activating on first access.
+            new_dmcontrol_state |= 1 # Force dmactive (bit 0) to 1
+            print("  -> First access with dmactive=0 requested, forcing dmactive=1")
+        # else:
+            # Otherwise (DM was already active, or dmactive=1 was requested),
+            # respect the dmactive bit written by the debugger.
+            # Since new_dmcontrol_state started as requested_dmcontrol,
+            # dmactive is already correctly set (or cleared).
+            pass
+        # Store the potentially modified state
+        dmi_mem[DMI_DMCONTROL] = new_dmcontrol_state
+        print(f"  Simulated DMI_DMCONTROL state stored: 0x{dmi_mem[DMI_DMCONTROL]:08X}")
+
+
+        # --- Update DMSTATUS based on the *requested* control bits ---
+        status = dmi_mem.get(DMI_DMSTATUS, 0) # Get current status
+        # Clear bits that might change based on requests
+        status &= ~((1 << 9) | (1 << 11) | (1 << 17) | (1 << 19)) # Clear allhalted, allrunning, allresumeack, allhavereset
+
+        if haltreq:
+            print("  -> Halt Request")
+            status |= (1 << 9) # Set allhalted (assuming only one hart)
+            # status &= ~(1 << 11) # Clear allrunning (already cleared above)
+            # status &= ~(1 << 17) # Clear allresumeack (already cleared above)
+        elif resumereq:
+            print("  -> Resume Request")
+            # status &= ~(1 << 9) # Clear allhalted (already cleared above)
+            status |= (1 << 11) # Set allrunning
+            status |= (1 << 17) # Set allresumeack
+        else:
+            # No explicit halt or resume request in this write.
+            # Assume HALTED state, especially after reset or initial examine.
+            print("  -> No halt/resume req, ensuring HALTED state")
+            status |= (1 << 9) # Default to halted
+
+        if hartreset:
+            print("  -> Hart Reset Request")
+            status |= (1 << 19) # Set allhavereset
+        if ackhavereset:
+            print("  -> Ack Havereset")
+            pass
+            # status &= ~(1 << 19) # Clear allhavereset (already cleared above)
+
+
+        status |= (1 << 7) # authenticated
+        status = (status & ~0xF) | 0x2 # version=0.13
+
+        if (status >> 9) & 1: # If allhalted (bit 9) is set
+            status |= (1 << 8) # Set anyhalted (bit 8)
+
+        dmi_mem[DMI_DMSTATUS] = status
+        print(f"  Updated DMI_DMSTATUS: 0x{status:08X}")
+
+    elif address == DMI_COMMAND:
+        print(f"  -> Abstract Command Written: 0x{data:08X}")
+        dmi_mem[address] = data # Store the command
+        # Set busy bit in ABSTRACTCS immediately
+        dmi_mem[DMI_ABSTRACTCS] |= (1 << 12)
+        print(f"  Set Busy. ABSTRACTCS: 0x{dmi_mem[DMI_ABSTRACTCS]:08X}")
+        # Execute (this function should update cmderr and clear busy bit upon completion)
+        execute_abstract_command(data)
+        print(f"  <- Abstract Command Complete. ABSTRACTCS: 0x{dmi_mem[DMI_ABSTRACTCS]:08X}")
+
+    elif address == DMI_DATA0 or address == DMI_DATA1:
+        print(f"  -> DMI_DATA{address-DMI_DATA0} write: 0x{data:08X}")
+        dmi_mem[address] = data
+
+    else:
+        dmi_mem[address] = data
+
+    conn.sendall(struct.pack(">B", RESPONSE_OK))
+
+def execute_abstract_command(command):
+    """Executes abstract commands (simplified)."""
+    global dcsr, dpc, misa, vlenb, mtopi, mstatus, gprs, dmi_mem
+
+    command_type = (command >> 24) & 0xFF
+
+    if command_type == 0:
+        # Extract parameters from the command word
+        reg_num = command & 0xFFFF
+        write = (command >> 16) & 1 # Correct bit position for Access Reg cmd
+        transfer = (command >> 17) & 1 # Correct bit position
+        postexec = (command >> 18) & 1 # Not handled here
+        aarpostincrement = (command >> 19) & 1 # Not handled here
+        aarsize = (command >> 20) & 0x7 # 2=32bit, 3=64bit
+
+        print(f"  Abstract CMD: AccessReg: reg=0x{reg_num:04X}, write={write}, transfer={transfer}, size={aarsize}")
+
+        # Check if size matches XLEN for CSRs/GPRs (basic check)
+        expected_aarsize = 3 if XLEN == 64 else 2
+        # DCSR is always 32-bit access regardless of XLEN
+        is_dcsr_access = (reg_num == CSR_DCSR)
+
+        if transfer: # Perform the register access
+            cmderr = 0 # Assume success initially
+            data_val_low = dmi_mem.get(DMI_DATA0, 0)
+            data_val_high = dmi_mem.get(DMI_DATA1, 0)
+            data_val_64 = (data_val_high << 32) | data_val_low
+
+            if write:
+                if reg_num >= GPR_BASE and reg_num < (GPR_BASE + NUM_GPRS):
+                    gpr_index = reg_num - GPR_BASE
+                    if aarsize == expected_aarsize:
+                        gprs[gpr_index] = data_val_64 if XLEN == 64 else data_val_low
+                        print(f"    WRITE GPR{gpr_index} = 0x{gprs[gpr_index]:X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_DCSR:
+                    if aarsize == 2: # DCSR is 32-bit access
+                        dcsr = data_val_low
+                        print(f"    WRITE DCSR = 0x{dcsr:08X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_DPC:
+                     if aarsize == expected_aarsize:
+                        dpc = data_val_64 if XLEN == 64 else data_val_low
+                        print(f"    WRITE DPC = 0x{dpc:X}")
+                     else: cmderr = 2 # Size mismatch
+                # elif reg_num == CSR_MSTATUS: ...
+                else:
+                    print(f"    WRITE to unsupported/read-only register 0x{reg_num:04X}")
+                    cmderr = 4 # Not supported
+
+            else:
+                read_val_low = 0
+                read_val_high = 0
+                read_val_64 = 0
+
+                if reg_num >= GPR_BASE and reg_num < (GPR_BASE + NUM_GPRS):
+                    gpr_index = reg_num - GPR_BASE
+                    if aarsize == expected_aarsize:
+                        read_val_64 = gprs[gpr_index]
+                        print(f"    READ GPR{gpr_index} = 0x{read_val_64:X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_MISA:
+                    if aarsize == expected_aarsize:
+                        read_val_64 = misa
+                        print(f"    READ MISA = 0x{read_val_64:016X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_MSTATUS:
+                     if aarsize == expected_aarsize:
+                        read_val_64 = mstatus
+                        print(f"    READ MSTATUS = 0x{read_val_64:016X}")
+                     else: cmderr = 2
+                elif reg_num == CSR_DCSR:
+                    if aarsize == 2: # DCSR is 32-bit access
+                        read_val_64 = dcsr & 0xFFFFFFFF # Ensure 32-bit value
+                        print(f"    READ DCSR = 0x{read_val_64:08X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_DPC:
+                    if aarsize == expected_aarsize:
+                        read_val_64 = dpc
+                        print(f"    READ DPC = 0x{read_val_64:X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_VLENB:
+                    if has_v_extension():
+                        if aarsize == expected_aarsize: # vlenb size matches XLEN
+                            read_val_64 = vlenb
+                            print(f"    READ VLENB = 0x{read_val_64:X}")
+                        else: cmderr = 2
+                    else:
+                        print(f"    READ VLENB failed: V extension not present")
+                        cmderr = 4 # Not supported (or 1=busy if check takes time)
+                elif reg_num == CSR_MTOPI:
+                    # Check if Smtopi is notionally present if needed
+                    # if has_smtopi_extension():
+                    if aarsize == expected_aarsize: # mtopi size matches XLEN
+                        read_val_64 = mtopi
+                        print(f"    READ MTOPI = 0x{read_val_64:X}")
+                    else: cmderr = 2
+                    # else:
+                    #    print(f"    READ MTOPI failed: Smtopi extension not present")
+                    #    cmderr = 4 # Not supported
+                else:
+                    print(f"    READ from unsupported register 0x{reg_num:04X}")
+                    cmderr = 4 # Not supported
+
+                # Store the read value back into DMI DATA registers
+                if cmderr == 0:
+                    dmi_mem[DMI_DATA0] = read_val_64 & 0xFFFFFFFF
+                    if aarsize == 3: # 64-bit
+                         dmi_mem[DMI_DATA1] = (read_val_64 >> 32) & 0xFFFFFFFF
+                    else: # 32-bit or less
+                         dmi_mem[DMI_DATA1] = 0 # Clear DATA1 for non-64bit reads
+
+            # Update ABSTRACTCS with status and clear busy bit
+            update_cmderr(cmderr)
+            return
+
+        else: # transfer == 0
+            # Handle non-transfer commands if necessary (e.g., just execute from progbuf)
+            print("  Abstract CMD: AccessReg: non-transfer command ignored")
+            update_cmderr(0) # No error, but nothing done here
+            return
+
+    else: # Unknown command type
+        print(f"  Abstract CMD: Unsupported command type {command_type}")
+        update_cmderr(7) # Command not supported error
+        return
+
+def main():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((HOST, PORT))
+        s.listen()
+        print(f"DMI Server listening on {HOST}:{PORT}")
+        while True:
+            conn, addr = s.accept()
+            with conn:
+                print(f"Connected by {addr}")
+                buffer = b''
+                try:
+                    while True:
+                        # Read enough data for the longest possible message (WRITE)
+                        # Header (6 bytes) + Data (4 bytes) = 10 bytes
+                        # Or just Header (6 bytes) for READ
+                        chunk = conn.recv(1024)
+                        if not chunk:
+                            print("Client disconnected.")
+                            break
+                        buffer += chunk
+                        print(f"Received raw chunk: {chunk.hex()}, Buffer now: {buffer.hex()}")
+
+                        # Process complete messages from the buffer
+                        while True:
+                            if len(buffer) < 6:
+                                # Not enough data for even the header
+                                break
+
+                            # Peek at the header
+                            command, address, data_length = struct.unpack(">BIB", buffer[:6])
+                            print(f"Processing msg: Cmd={command}, Addr=0x{address:02X}, Len={data_length}")
+
+                            if command == READ_COMMAND:
+                                print(f"  Handling READ command for Addr=0x{address:04X}. (Ignoring data_length={data_length})")
+                                handle_dmi_read(address, conn)
+                                # Consume the header from the buffer
+                                buffer = buffer[6:]
+                                print(f"  READ processed. Buffer remaining: {buffer.hex()}")
+
+                            elif command == WRITE_COMMAND:
+                                expected_len = 6 + 4 # Header + 32-bit data
+                                if len(buffer) < expected_len:
+                                    # Not enough data for the full write command yet
+                                    print(f"  Waiting for more data for WRITE (need {expected_len}, have {len(buffer)})")
+                                    break # Go back to recv more data
+
+                                # Extract data
+                                write_data = struct.unpack(">I", buffer[6:10])[0]
+                                # Execute the write
+                                handle_dmi_write(address, write_data, conn)
+                                # Consume the message from the buffer
+                                buffer = buffer[expected_len:]
+                                print(f"  WRITE processed. Buffer remaining: {buffer.hex()}")
+
+                            else:
+                                print(f"Error: Invalid command received: {command}")
+                                # Consume the header (or potentially more if fixed size assumed)
+                                # and try to continue, or close connection
+                                buffer = buffer[6:] # Basic recovery: assume header size
+                                # conn.sendall(struct.pack(">BI", RESPONSE_ERROR, 0)) # Example
+
+                except ConnectionResetError:
+                    print("Client connection reset.")
+                except Exception as e:
+                    print(f"An error occurred: {e}")
+                finally:
+                    print(f"Connection from {addr} closed.")
+                    buffer = b'' # Clear buffer for next connection
+
+if __name__ == "__main__":
+    main()

--- a/script_server_simulator/dmi_socket_responder_v3.py
+++ b/script_server_simulator/dmi_socket_responder_v3.py
@@ -1,0 +1,484 @@
+import socket
+import struct
+import time
+# import ipdb
+import binascii
+import threading
+import traceback # Import traceback for detailed errors
+
+HOST = 'localhost'
+PORT = 5555
+
+READ_COMMAND = 0x00
+WRITE_COMMAND = 0x01
+
+RESPONSE_OK = 0x00
+RESPONSE_ERROR = 0x01
+
+XLEN = 64
+misa = 0x800000000014112d
+NUM_GPRS = 32
+gprs = [0] * NUM_GPRS
+dcsr = 0x40000003
+dpc = 0
+mstatus = 0xA00000200
+vlenb = 16 if (misa >> 21) & 1 else 0
+mtopi = 0
+
+# --- DMI Registers ---
+DMI_DATA0 = 0x04
+DMI_DATA1 = 0x05
+DMI_DMCONTROL = 0x10
+DMI_DMSTATUS = 0x11
+DMI_HARTINFO = 0x12
+DMI_ABSTRACTCS = 0x16
+DMI_COMMAND = 0x17
+DMI_ABSTRACTAUTO = 0x18
+DMI_PROGBUF0 = 0x20
+DMI_SBCS = 0x38
+
+# --- CSR Numbers ---
+CSR_MISA = 0x301
+CSR_MSTATUS = 0x300
+CSR_DCSR = 0x7B0
+CSR_DPC = 0x7B1
+CSR_VLENB = 0xC22
+CSR_MTOPI = 0x350
+GPR_BASE = 0x1000
+
+reset_in_progress = False
+
+dmi_mem = {
+    DMI_DMCONTROL: 0x0,
+    DMI_DMSTATUS: (1 << 8) | (1 << 9) | (1 << 7) | 0x2, # 0x00000382
+    DMI_HARTINFO: 0x00102004,
+    DMI_ABSTRACTCS: (0 << 8) | (0 << 12) | (2 << 0) | (2 << 24),
+    DMI_COMMAND: 0x00000000,
+    DMI_ABSTRACTAUTO: 0x00000000,
+    DMI_DATA0: 0x00000000,
+    DMI_DATA1: 0x00000000,
+    DMI_PROGBUF0: 0x00000000,
+    DMI_SBCS: 0x00000000,
+}
+
+def decode_abstract_command(cmd):
+    cmdtype = (cmd >> 24) & 0xff
+    if cmdtype == 0:
+        regno = cmd & 0xffff
+        write = (cmd >> 16) & 1
+        transfer = (cmd >> 17) & 1
+        postexec = (cmd >> 18) & 1
+        aarsize = (cmd >> 20) & 0x7
+        print(f"  --> AccessReg: reg=0x{regno:04x}, write={write}, transfer={transfer}, postexec={postexec}, size={aarsize}")
+    else:
+        print(f"  --> Unsupported command type: {cmdtype}")
+
+def update_cmderr(error_code):
+    global dmi_mem
+    preserved_bits = dmi_mem[DMI_ABSTRACTCS] & (0xFFF | (0x1F << 24))
+    dmi_mem[DMI_ABSTRACTCS] = preserved_bits | ((error_code & 0x7) << 8)
+    dmi_mem[DMI_ABSTRACTCS] &= ~(1 << 12)
+def decode_abstract_command(cmd):
+    cmdtype = (cmd >> 24) & 0xff
+    if cmdtype == 0:
+        regno = cmd & 0xffff
+        write = (cmd >> 16) & 1
+        transfer = (cmd >> 17) & 1
+        postexec = (cmd >> 18) & 1
+        aarsize = (cmd >> 20) & 0x7
+        print(f"  --> AccessReg: reg=0x{regno:04x}, write={write}, transfer={transfer}, postexec={postexec}, size={aarsize}")
+    else:
+        print(f"  --> Unsupported command type: {cmdtype}")
+def has_v_extension():
+    return (misa >> 21) & 1
+
+def has_smtopi_extension():
+    return False
+
+def handle_dmi_read(address, conn):
+    print(f"READ from DMI address 0x{address:02X}") 
+    """Handles DMI read requests."""
+    global dmi_mem, reset_in_progress
+    data = dmi_mem.get(address, 0)
+    final_response_data = data 
+    # Specific handling
+    if address == DMI_DMCONTROL:
+        print(f"\n===> DMCONTROL READ requested")
+        print(f"  Current simulated value: 0x{dmi_mem[DMI_DMCONTROL]:08X}")
+        print(f"  reset_in_progress = {reset_in_progress}")
+        if reset_in_progress:
+            print("  -> In reset: clearing DMCONTROL")
+            dmi_mem[DMI_DMCONTROL] = 0x0
+            reset_in_progress = False
+            final_response_data = 0x0
+        else:
+            final_response_data = dmi_mem[DMI_DMCONTROL] # Read normally if not in reset
+
+        print(f"DMI Read : Addr=0x{address:02X}, Responding with Data=0x{final_response_data:08X}")
+
+    elif address == DMI_DMSTATUS:
+        original_data = dmi_mem.get(address, 0)
+        final_response_data = (original_data & ~0xF) | 0x2 # Force version 0.13
+        print(f"DMI Read : Addr=0x{address:02X}, Original Data=0x{original_data:08X}, Adjusted Data=0x{final_response_data:08X}")
+        if final_response_data != original_data:
+             dmi_mem[address] = final_response_data # Update stored value ONLY if adjusted
+
+    elif address == DMI_ABSTRACTCS:
+        print(f"DMI Read : Addr=0x{address:02X}, Data=0x{final_response_data:08X}") # Use final_response_data
+        print(f"  DMI_ABSTRACTCS read: 0x{final_response_data:08X}")
+
+    elif address == DMI_DATA0 or address == DMI_DATA1:
+        print(f"DMI Read : Addr=0x{address:02X}, Data=0x{final_response_data:08X}") # Use final_response_data
+        print(f"  DMI_DATA{address-DMI_DATA0} read: 0x{final_response_data:08X}")
+    else:
+         print(f"DMI Read : Addr=0x{address:02X}, Data=0x{final_response_data:08X}") # Use final_response_data
+
+    # Send response back
+    try:
+        response = struct.pack(">B", RESPONSE_OK) + struct.pack(">I", final_response_data)
+        if address == DMI_DMCONTROL and not reset_in_progress: # Check if we just handled reset
+            print(f"  <<< Sending DMCONTROL reset ack response bytes: {response.hex()}")
+        elif address == DMI_DMCONTROL:
+            print(f"  <<< Sending DMCONTROL non-reset response bytes: {response.hex()}")
+        conn.sendall(response)
+    except Exception as e:
+        print(f"  !!!! EXCEPTION during DMI read response sending: {e}")
+        # Consider closing connection or handling otherwise
+    print(f"  Returning DMCONTROL: 0x{final_response_data:08X}")
+    return final_response_data # Return the value that was sent
+
+def handle_dmi_write(address, data, conn):
+    print(f"WRITE to DMI address 0x{address:02X}, data=0x{data:08X}")
+    """Handles DMI write requests."""
+    global dmi_mem, reset_in_progress
+    print(f"DMI Write: Addr=0x{address:04X}, Data=0x{data:08X}")
+    error_occurred = False
+
+    try:
+        if address == DMI_DMCONTROL:
+            print(f"\n===> DMCONTROL WRITE requested")
+            print(f"  Data being written: 0x{data:08X}")
+            if data == 0x0:
+                print("  -> Hard reset requested (DMCONTROL = 0), clearing internal state")
+                reset_in_progress = True
+                dmi_mem[DMI_DMCONTROL] = 0x0
+                try:
+                    conn.sendall(struct.pack(">B", RESPONSE_OK))
+                    print("  -> Sent RESPONSE_OK after hard reset")
+                except Exception as e:
+                    print(f"  !!!! EXCEPTION while sending response: {e}")
+                return
+
+            requested_dmcontrol = data
+            print(f"  DMI_DMCONTROL write request: 0x{requested_dmcontrol:08X}")
+
+            ndmreset_req = (requested_dmcontrol >> 1) & 1
+            if ndmreset_req:
+                print("  -> ndmreset requested, marking reset_in_progress")
+                reset_in_progress = True
+                print("  -> ndmreset requested, entering reset state")
+                # Clear DMACTIVE while entering reset
+                dmi_mem[DMI_DMCONTROL] = requested_dmcontrol & ~(1 << 0)
+                # dmi_mem[DMI_DMCONTROL] = requested_dmcontrol
+
+                status = dmi_mem.get(DMI_DMSTATUS, 0)
+                status &= ~((1 << 9) | (1 << 8) | (1 << 11) | (1 << 10))
+                status &= ~(1 << 7)
+                status = (status & ~0xF) | 0x2
+                dmi_mem[DMI_DMSTATUS] = status
+
+                print(f"  Simulated DMI_DMCONTROL state stored: 0x{dmi_mem[DMI_DMCONTROL]:08X}")
+                print(f"  Updated DMI_DMSTATUS for reset: 0x{status:08X}")
+
+            else: # Not an ndmreset request
+                if reset_in_progress:
+                    print("  !! Still in reset_in_progress, ignoring new DMCONTROL write to avoid overwriting cleared state")
+                    return 
+                current_dmcontrol = dmi_mem.get(DMI_DMCONTROL, 0)
+                was_active = (current_dmcontrol & 1) != 0
+                new_dmcontrol_state = requested_dmcontrol
+                requesting_active = (requested_dmcontrol & 1) != 0
+
+                if was_active or requesting_active:
+                    new_dmcontrol_state |= 1
+                    print("  -> Ensuring dmactive=1")
+                elif not was_active and not requesting_active:
+                   new_dmcontrol_state |= 1
+                   print("  -> First write is 0, forcing dmactive=1")
+
+                dmi_mem[DMI_DMCONTROL] = new_dmcontrol_state
+                print(f"  Simulated DMI_DMCONTROL state stored: 0x{dmi_mem[DMI_DMCONTROL]:08X}")
+
+                status = dmi_mem.get(DMI_DMSTATUS, 0)
+                status &= ~((1 << 9) | (1 << 11) | (1 << 17) | (1 << 19) | (1 << 8) | (1 << 10) | (1 << 16) | (1 << 18))
+                haltreq_active = (new_dmcontrol_state >> 31) & 1
+                resumereq_active = (new_dmcontrol_state >> 30) & 1
+                hartreset_active = (new_dmcontrol_state >> 29) & 1
+                ackhavereset_req = (requested_dmcontrol >> 28) & 1
+                dm_is_active = (new_dmcontrol_state & 1) == 1
+
+                if haltreq_active: status |= (1 << 9) | (1 << 8)
+                elif resumereq_active: status |= (1 << 11) | (1 << 10) | (1 << 17) | (1 << 16)
+                elif dm_is_active: status |= (1 << 9) | (1 << 8) # Default halted
+
+                if hartreset_active: status |= (1 << 19) | (1 << 18)
+                if ackhavereset_req: status &= ~((1 << 19) | (1 << 18))
+
+                status |= (1 << 7) # authenticated
+                status = (status & ~0xF) | 0x2 # version=0.13
+
+                if (status >> 9) & 1: status |= (1 << 8)
+
+                dmi_mem[DMI_DMSTATUS] = status
+                print(f"  Updated DMI_DMSTATUS: 0x{status:08X}")
+
+        elif address == DMI_COMMAND:
+            print(f"  -> Abstract Command Written: 0x{data:08X}")
+            decode_abstract_command(data)
+            dmi_mem[address] = data
+            dmi_mem[DMI_ABSTRACTCS] |= (1 << 12)
+            print(f"  Set Busy. ABSTRACTCS: 0x{dmi_mem[DMI_ABSTRACTCS]:08X}")
+            execute_abstract_command(data) # Forwards to function that has globals declared
+            print(f"  <- Abstract Command Complete. ABSTRACTCS: 0x{dmi_mem[DMI_ABSTRACTCS]:08X}")
+        elif address == DMI_DATA0 or address == DMI_DATA1:
+             print(f"  -> DMI_DATA{address-DMI_DATA0} write: 0x{data:08X}")
+             dmi_mem[address] = data
+
+        else:
+            dmi_mem[address] = data
+            print(f"  Stored default write to Addr=0x{address:04X}")
+
+    except Exception as e:
+        print(f"  !!!! EXCEPTION during DMI write handling: {e}")
+        traceback.print_exc() 
+        error_occurred = True
+
+    if not error_occurred:
+        print("  -> Sending RESPONSE_OK for WRITE")
+        conn.sendall(struct.pack(">B", RESPONSE_OK))
+    else:
+        print("  -> Skipping RESPONSE_OK due to internal error")
+        # Optionally: conn.close() ?
+
+def execute_abstract_command(command):
+    """Executes abstract commands (simplified)."""
+    global dcsr, dpc, misa, vlenb, mtopi, mstatus, gprs, dmi_mem
+    command_type = (command >> 24) & 0xFF
+
+    # Check for Command Type 0: Access Register
+    if command_type == 0:
+        # Extract parameters from the command word
+        reg_num = command & 0xFFFF
+        write = (command >> 16) & 1 # Correct bit position for Access Reg cmd
+        transfer = (command >> 17) & 1 # Correct bit position
+        postexec = (command >> 18) & 1 # Not handled here
+        aarpostincrement = (command >> 19) & 1 # Not handled here
+        aarsize = (command >> 20) & 0x7 # 2=32bit, 3=64bit
+
+        print(f"  Abstract CMD: AccessReg: reg=0x{reg_num:04X}, write={write}, transfer={transfer}, size={aarsize}")
+
+        # Check if size matches XLEN for CSRs/GPRs (basic check)
+        expected_aarsize = 3 if XLEN == 64 else 2
+        # DCSR is always 32-bit access regardless of XLEN
+        is_dcsr_access = (reg_num == CSR_DCSR)
+
+        if postexec:
+            inst = dmi_mem.get(DMI_PROGBUF0, 0)
+            print(f"  -> Executing postexec instruction from PROGBUF0: 0x{inst:08x}")
+
+            # Emulate simple lw/ld instruction
+            if (inst & 0x7f) == 0x03:  # LOAD
+                funct3 = (inst >> 12) & 0x7
+                rs1 = (inst >> 15) & 0x1F
+                rd = (inst >> 7) & 0x1F
+                imm = (inst >> 20) & 0xFFF
+                if imm & 0x800:
+                    imm |= ~0xFFF  # sign-extend
+
+                addr = gprs[rs1] + imm
+                print(f"    Emulated LOAD from addr=0x{addr:x} into x{rd}")
+
+                # Simulate reading from memory (add real backing store if needed)
+                mem_val = 0x12345678ABCDEF  # just dummy for now
+                if funct3 == 0x3:  # LD
+                    val = mem_val
+                elif funct3 == 0x2:  # LW
+                    val = mem_val & 0xFFFFFFFF
+                else:
+                    val = 0
+
+                gprs[rd] = val
+                print(f"    GPR[{rd}] = 0x{val:x}")
+            dmi_mem[DMI_DATA0] = gprs[rd] & 0xFFFFFFFF
+            dmi_mem[DMI_DATA1] = (gprs[rd] >> 32) & 0xFFFFFFFF
+
+        if transfer: # Perform the register access
+            cmderr = 0 # Assume success initially
+            data_val_low = dmi_mem.get(DMI_DATA0, 0)
+            data_val_high = dmi_mem.get(DMI_DATA1, 0)
+            data_val_64 = (data_val_high << 32) | data_val_low
+
+            if write:
+                if reg_num >= GPR_BASE and reg_num < (GPR_BASE + NUM_GPRS):
+                    gpr_index = reg_num - GPR_BASE
+                    if aarsize == expected_aarsize:
+                        gprs[gpr_index] = data_val_64 if XLEN == 64 else data_val_low
+                        print(f"    WRITE GPR{gpr_index} = 0x{gprs[gpr_index]:X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_DCSR:
+                    if aarsize == 2: # DCSR is 32-bit access
+                        dcsr = data_val_low
+                        print(f"    WRITE DCSR = 0x{dcsr:08X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_DPC:
+                     if aarsize == expected_aarsize:
+                        dpc = data_val_64 if XLEN == 64 else data_val_low
+                        print(f"    WRITE DPC = 0x{dpc:X}")
+                     else: cmderr = 2 # Size mismatch
+                # Add other writable CSRs if needed (MSTATUS, etc.)
+                # elif reg_num == CSR_MSTATUS: ...
+                else:
+                    print(f"    WRITE to unsupported/read-only register 0x{reg_num:04X}")
+                    cmderr = 4 # Not supported
+
+            else:
+                read_val_low = 0
+                read_val_high = 0
+                read_val_64 = 0
+
+                if reg_num >= GPR_BASE and reg_num < (GPR_BASE + NUM_GPRS):
+                    gpr_index = reg_num - GPR_BASE
+                    if aarsize == expected_aarsize:
+                        read_val_64 = gprs[gpr_index]
+                        print(f"    READ GPR{gpr_index} = 0x{read_val_64:X}")
+                    else: cmderr = 2 # Size mismatch
+                elif reg_num == CSR_MISA:
+                    if aarsize == expected_aarsize:
+                        read_val_64 = misa
+                        print(f"    READ MISA = 0x{read_val_64:016X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_MSTATUS:
+                     if aarsize == expected_aarsize:
+                        read_val_64 = mstatus
+                        print(f"    READ MSTATUS = 0x{read_val_64:016X}")
+                     else: cmderr = 2
+                elif reg_num == CSR_DCSR:
+                    if aarsize == 2: # DCSR is 32-bit access
+                        read_val_64 = dcsr & 0xFFFFFFFF # Ensure 32-bit value
+                        print(f"    READ DCSR = 0x{read_val_64:08X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_DPC:
+                    if aarsize == expected_aarsize:
+                        read_val_64 = dpc
+                        print(f"    READ DPC = 0x{read_val_64:X}")
+                    else: cmderr = 2
+                elif reg_num == CSR_VLENB:
+                    if has_v_extension():
+                        if aarsize == expected_aarsize: # vlenb size matches XLEN
+                            read_val_64 = vlenb
+                            print(f"    READ VLENB = 0x{read_val_64:X}")
+                        else: cmderr = 2
+                    else:
+                        print(f"    READ VLENB failed: V extension not present")
+                        cmderr = 4 # Not supported (or 1=busy if check takes time)
+                elif reg_num == CSR_MTOPI:
+                    # Check if Smtopi is notionally present if needed
+                    # if has_smtopi_extension():
+                    if aarsize == expected_aarsize: # mtopi size matches XLEN
+                        read_val_64 = mtopi
+                        print(f"    READ MTOPI = 0x{read_val_64:X}")
+                    else: cmderr = 2
+                    # else:
+                    #    print(f"    READ MTOPI failed: Smtopi extension not present")
+                    #    cmderr = 4 # Not supported
+                else:
+                    print(f"    READ from unsupported register 0x{reg_num:04X}")
+                    cmderr = 4 # Not supported
+
+                # Store the read value back into DMI DATA registers
+                if cmderr == 0:
+                    # Ensure dmi_mem is modified correctly
+                    dmi_mem[DMI_DATA0] = read_val_64 & 0xFFFFFFFF
+                    if aarsize == 3: # 64-bit
+                         dmi_mem[DMI_DATA1] = (read_val_64 >> 32) & 0xFFFFFFFF
+                    else: # 32-bit or less
+                         dmi_mem[DMI_DATA1] = 0 # Clear DATA1 for non-64bit reads
+
+            # Update ABSTRACTCS with status and clear busy bit
+            update_cmderr(cmderr)
+            return 
+
+        else: # transfer == 0
+            # Handle non-transfer commands if necessary (e.g., just execute from progbuf)
+            print("  Abstract CMD: AccessReg: non-transfer command ignored")
+            update_cmderr(0) # No error, but nothing done here
+            return
+
+    else: # Unknown command type
+        print(f"  Abstract CMD: Unsupported command type {command_type}")
+        update_cmderr(7) # Command not supported error
+        return
+
+def main():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) # Allow quick restart
+        s.bind((HOST, PORT))
+        s.listen()
+        print(f"DMI Server listening on {HOST}:{PORT}")
+        while True:
+            conn, addr = s.accept()
+            global reset_in_progress
+            reset_in_progress = False
+            # For now, only resetting the reset flag.
+            with conn:
+                print(f"Connected by {addr}")
+                buffer = b''
+                try:
+                    while True:
+                        chunk = conn.recv(1024)
+                        if not chunk:
+                            print("Client disconnected.")
+                            break
+                        buffer += chunk
+                        print(f"Received raw chunk: {chunk.hex()}, Buffer now: {buffer.hex()}")
+
+                        # Process complete messages from the buffer
+                        while True:
+                            if len(buffer) < 6:
+                                break
+
+                            command, address, data_length = struct.unpack(">BIB", buffer[:6])
+                            print(f"Processing msg: Cmd={command}, Addr=0x{address:02X}, Len={data_length}")
+
+                            if command == READ_COMMAND:
+                                print(f"  Handling READ command for Addr=0x{address:04X}. (Ignoring data_length={data_length})")
+                                handle_dmi_read(address, conn)
+                                buffer = buffer[6:]
+                                print(f"  READ processed. Buffer remaining: {buffer.hex()}")
+
+                            elif command == WRITE_COMMAND:
+                                expected_len = 6 + 4
+                                if len(buffer) < expected_len:
+                                    print(f"  Waiting for more data for WRITE (need {expected_len}, have {len(buffer)})")
+                                    break
+
+                                write_data = struct.unpack(">I", buffer[6:10])[0]
+                                handle_dmi_write(address, write_data, conn)
+                                buffer = buffer[expected_len:]
+                                print(f"  WRITE processed. Buffer remaining: {buffer.hex()}")
+
+                            else:
+                                print(f"Error: Invalid command received: {command}")
+                                buffer = buffer[6:]
+
+                except ConnectionResetError:
+                    print("Client connection reset.")
+                except Exception as e:
+                    print(f"An error occurred: {e}")
+                    traceback.print_exc() 
+                finally:
+                    print(f"Connection from {addr} closed.")
+                    buffer = b''
+
+if __name__ == "__main__":
+    main()

--- a/src/jtag/Makefile.am
+++ b/src/jtag/Makefile.am
@@ -17,6 +17,8 @@ include %D%/drivers/Makefile.am
 	%D%/adapter.h \
 	%D%/commands.c \
 	%D%/core.c \
+	%D%/riscv_socket_dmi.c \
+	%D%/core_communicator_wrapper.c \
 	%D%/interface.c \
 	%D%/interfaces.c \
 	%D%/tcl.c \
@@ -26,6 +28,8 @@ include %D%/drivers/Makefile.am
 	%D%/interfaces.h \
 	%D%/minidriver.h \
 	%D%/jtag.h \
+	%D%/riscv_socket_dmi.h \
+	%D%/core_communicator_wrapper.h \
 	%D%/swd.h \
 	%D%/swim.h \
 	%D%/tcl.h

--- a/src/jtag/core_communicator_wrapper.c
+++ b/src/jtag/core_communicator_wrapper.c
@@ -1,0 +1,617 @@
+#include "core_communicator_wrapper.h"
+#include "jtag.h"
+#include "target/riscv/riscv.h"
+#include "target/target.h"
+#include "transport/transport.h"
+#include "drivers/riscv_dtm/dtm.h"
+
+
+void wrapper_tap_init(struct jtag_tap *tap){
+    if (transport_is_jtag()) {
+        return jtag_tap_init(tap);
+    }
+    LOG_INFO("tap_init is only supported for JTAG. It does nothing on other transports.");
+}
+
+void wrapper_tap_free(struct jtag_tap *tap){
+    if (transport_is_jtag()){
+        return jtag_tap_init(tap);
+    }
+    LOG_INFO("tap_free is only supported for JTAG. It does nothing on other transports.");
+}
+
+struct jtag_tap *wrapper_all_taps(void){
+    if (transport_is_jtag()){
+        return jtag_all_taps();
+    }
+    LOG_INFO("all_taps is only supported for JTAG. It returns nothing on other transports.");
+    return NULL;
+}
+
+const char *wrapper_tap_name(const struct jtag_tap *tap){
+    if (transport_is_jtag()) {
+        return jtag_tap_name(tap);
+    }
+    LOG_INFO("tap_name is only supported for JTAG. It returns nothing on other transports.");
+    return NULL;
+}
+
+struct jtag_tap *wrapper_tap_by_string(const char *dotted_name){
+    if (transport_is_jtag()){
+        return jtag_tap_by_string(dotted_name);
+    }
+    LOG_INFO("tap_by_string is only supported for JTAG. It returns nothing on other transports.");
+    return NULL;
+}
+
+struct jtag_tap *wrapper_tap_by_position(unsigned int abs_position){
+    if (transport_is_jtag()){
+        return jtag_tap_by_position(abs_position);
+    }
+    LOG_INFO("tap_by_position is only supported for JTAG. It returns nothing on other transports.");
+    return NULL;
+}
+
+struct jtag_tap *wrapper_tap_next_enabled(struct jtag_tap *p){
+    if (transport_is_jtag()){
+        return jtag_tap_next_enabled(p);
+    }
+    LOG_INFO("tap_next_enabled is only supported for JTAG. It returns nothing on other transports.");
+    return NULL;
+}
+
+unsigned int wrapper_tap_count_enabled(void){
+    if (transport_is_jtag()){
+        return jtag_tap_count_enabled();
+    }
+    LOG_INFO("tap_count_enabled is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+int wrapper_register_event_callback(jtag_event_handler_t f, void *x){
+    if (transport_is_jtag()){
+        return jtag_register_event_callback(f, x);
+    }
+    LOG_INFO("register_event_callback is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+int wrapper_unregister_event_callback(jtag_event_handler_t f, void *x){
+    if (transport_is_jtag()){
+        return jtag_unregister_event_callback(f, x);
+    }
+    LOG_INFO("unregister_event_callback is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+int wrapper_call_event_callbacks(enum jtag_event event){
+    if (transport_is_jtag()){
+        return jtag_call_event_callbacks(event);
+    }
+    LOG_INFO("unregister_event_callback is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+enum reset_types wrapper_get_reset_config(void){
+    if(transport_is_jtag()){
+        return jtag_get_reset_config();
+    }
+    LOG_INFO("get_reset_config is only supported for JTAG. It returns nothing on other transports.");
+    return RESET_CNCT_UNDER_SRST; 
+}
+
+void wrapper_set_reset_config(enum reset_types type){
+    if (transport_is_jtag()){
+        return jtag_set_reset_config(type);
+    }
+    LOG_INFO("set_reset_config is only supported for JTAG. It returns nothing on other transports.");
+}
+
+void wrapper_set_nsrst_delay(unsigned int delay){
+    if (transport_is_jtag()){
+        return jtag_set_nsrst_delay(delay);
+    }
+    LOG_INFO("set_nsrst_delay is only supported for JTAG. It returns nothing on other transports.");
+}
+
+unsigned int wrapper_get_nsrst_delay(void){
+    if (transport_is_jtag()){
+        return jtag_get_nsrst_delay();
+    }
+    LOG_INFO("get_nsrst_delay is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+void wrapper_set_ntrst_delay(unsigned int delay){
+    if(transport_is_jtag()){
+        return jtag_set_ntrst_delay(delay);
+    }
+    LOG_INFO("set_ntrst_delay is only supported for JTAG. It returns nothing on other transports.");
+}
+
+unsigned int wrapper_get_ntrst_delay(void){
+    if(transport_is_jtag()){
+        return jtag_get_ntrst_delay();
+    }
+    LOG_INFO("get_ntrst_delay is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+void wrapper_set_nsrst_assert_width(unsigned int delay){
+    if(transport_is_jtag()){
+        return jtag_set_nsrst_assert_width(delay);
+    }
+    LOG_INFO("set_nsrst_assert_width is only supported for JTAG. It returns nothing on other transports.");
+}
+
+unsigned int wrapper_get_nsrst_assert_width(void){
+    if(transport_is_jtag()){
+        return jtag_get_nsrst_assert_width();
+    }
+    LOG_INFO("get_nsrst_assert_width is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+void wrapper_set_ntrst_assert_width(unsigned int delay){
+    if (transport_is_jtag()) {
+        return jtag_set_ntrst_assert_width(delay);
+    } 
+    LOG_INFO("set_nsrst_assert_width is only supported for JTAG. It returns nothing on other transports.");
+}
+
+unsigned int wrapper_get_ntrst_assert_width(void){
+    if (transport_is_jtag()) {
+        return jtag_get_ntrst_assert_width();
+    }
+    LOG_INFO("set_ntrst_assert_width is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+int wrapper_get_trst(void){
+    if (transport_is_jtag()) {
+        return jtag_get_trst();
+    }
+    LOG_INFO("get_trst is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+int wrapper_get_srst(void){
+    if (transport_is_jtag()) {
+        return jtag_get_srst();
+    }
+    LOG_INFO("get_srst is only supported for JTAG. It returns nothing on other transports.");
+    return ERROR_OK;
+}
+
+void wrapper_set_verify(bool enable){
+     if (transport_is_jtag()) {
+        jtag_set_verify(enable);
+    }
+    LOG_INFO("set_verify is only supported for JTAG. It returns nothing on other transports.");
+}
+
+bool wrapper_will_verify(void){
+    if (transport_is_jtag()) {
+        return jtag_will_verify();
+    }
+    LOG_INFO("will_verify is only supported for JTAG. It returns nothing on other transports.");
+    return false;
+}
+
+void wrapper_set_verify_capture_ir(bool enable){
+    if (transport_is_jtag()) {
+        return jtag_set_verify_capture_ir(enable);
+    } 
+    LOG_INFO("set_verify_capture is only supported for JTAG. It returns nothing on other transports.");
+}
+
+bool wrapper_will_verify_capture_ir(void){
+    if (transport_is_jtag()) {
+        return jtag_will_verify_capture_ir();
+    }
+    LOG_INFO("will_verify_capture is only supported for JTAG. It returns nothing on other transports.");
+    return false;
+}
+
+void wrapper_set_flush_queue_sleep(int ms){
+    if (transport_is_jtag()) {
+        return jtag_set_flush_queue_sleep(ms);
+    }
+    LOG_INFO("set_flush_queue_sleep is only supported for JTAG. It returns nothing on other transports.");
+}
+
+int wrapper_init(struct command_context *cmd_ctx){
+    if (transport_is_jtag()) {
+        return jtag_init(cmd_ctx);
+    } 
+    if (transport_is_socket()) {
+        // Call the socket initialization function
+        return socket_dmi_init(get_active_dtm_driver()); 
+    }
+    LOG_ERROR("Unsupported transport for init");
+    return ERROR_FAIL;
+}
+
+int wrapper_init_reset(struct command_context *cmd_ctx){
+    if (transport_is_jtag()) {
+        return jtag_init_reset(cmd_ctx);
+    } else if (transport_is_socket()) {
+        dtm_driver_t *active_driver = get_active_dtm_driver();
+        if (!active_driver || strcmp(active_driver->name, "socket") != 0) {
+            LOG_ERROR("Active DTM driver is not socket");
+            return ERROR_FAIL;
+        }
+        // clear_socket_buffer(active_driver->priv->sock_fd);
+        if (socket_dmi_init(active_driver) != 0) {
+            LOG_ERROR("Failed to connect to socket.");
+            return ERROR_FAIL;
+        }
+    }
+    LOG_ERROR("Unsupported transport for init_reset");
+    return ERROR_FAIL;
+}
+
+int wrapper_register_commands(struct command_context *cmd_ctx){
+    if (transport_is_jtag()) {
+        return jtag_register_commands(cmd_ctx);
+    } else if (transport_is_socket()) {
+        LOG_DEBUG("register_commands called for socket transport.");
+        return ERROR_OK;
+    } else {
+        LOG_ERROR("Unsupported transport for register_commands");
+        return ERROR_FAIL;
+    }
+}
+
+int wrapper_init_inner(struct command_context *cmd_ctx){
+    if (transport_is_jtag()) {
+        return jtag_init_inner(cmd_ctx);
+    } else if (transport_is_socket()) {
+        LOG_DEBUG("init_inner: Initializing socket...");
+        return socket_dmi_init(get_active_dtm_driver());
+    } else {
+        LOG_ERROR("Unsupported transport for init_inner");
+        return ERROR_FAIL;
+    }
+}
+
+
+void wrapper_add_ir_scan(struct jtag_tap *tap,
+    struct scan_field *fields, enum tap_state endstate){
+
+    if (transport_is_jtag()) {
+        return jtag_add_ir_scan(tap, fields, endstate);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG IR scan operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_ir_scan");
+}
+
+void wrapper_add_ir_scan_noverify(struct jtag_tap *tap,
+    const struct scan_field *fields, enum tap_state state){
+
+    if (transport_is_jtag()) {
+        return jtag_add_ir_scan_noverify(tap, fields, state);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG IR scan operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_ir_scan_noverify");
+}
+
+void wrapper_add_plain_ir_scan(int num_bits, const uint8_t *out_bits, uint8_t *in_bits,
+		enum tap_state endstate){
+
+    if (transport_is_jtag()) {
+        return jtag_add_plain_ir_scan(num_bits, out_bits, in_bits, endstate);
+    }
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG IR scan operations not supported on socket transport");
+        return;
+    } 
+    LOG_ERROR("Unsupported transport for add_plain_ir_scan");
+}
+
+void wrapper_add_dr_scan(struct jtag_tap *tap, int num_fields,
+		const struct scan_field *fields, enum tap_state endstate){
+
+    if (transport_is_jtag()) {
+        return jtag_add_dr_scan(tap, num_fields, fields, endstate);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG DR scan operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_dr_scan");
+}
+
+void wrapper_add_dr_scan_check(struct jtag_tap *tap, int num_fields,
+		struct scan_field *fields, enum tap_state endstate){
+
+    if (transport_is_jtag()) {
+        return jtag_add_dr_scan_check(tap, num_fields, fields, endstate);
+    }
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG DR scan operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_dr_scan_check");
+}
+
+void wrapper_add_plain_dr_scan(int num_bits,
+		const uint8_t *out_bits, uint8_t *in_bits, enum tap_state endstate){
+
+    if (transport_is_jtag()) {
+        return jtag_add_plain_dr_scan(num_bits, out_bits, in_bits, endstate);
+    }
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG DR scan operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_plain_dr_scan");
+}
+
+void wrapper_add_tlr(void){
+    if (transport_is_jtag()) {
+        return jtag_add_tlr();
+    }
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG Test Logic Reset not directly supported on socket transport");
+        // We could potentially implement a DMI equivalent of TLR here
+        // if our RISC-V target supports resetting the debug module
+        // through a specific DMI command.
+        // TO DO: Check and implement if needed
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_tlr");
+}
+
+void wrapper_add_pathmove(unsigned int num_states, const enum tap_state *path){
+    if (transport_is_jtag()) {
+        return jtag_add_pathmove(num_states, path);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG pathmove not supported on socket transport");
+        return; 
+    }
+    LOG_ERROR("Unsupported transport for add_pathmove");
+}
+
+int wrapper_add_statemove(enum tap_state goal_state){
+    if (transport_is_jtag()) {
+        return jtag_add_statemove(goal_state);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG statemove not supported on socket transport");
+        return ERROR_FAIL;
+    }
+    LOG_ERROR("Unsupported transport for add_statemove");
+    return ERROR_FAIL;
+}
+
+void wrapper_add_runtest(unsigned int num_cycles, enum tap_state endstate){
+    if (transport_is_jtag()) {
+        return jtag_add_runtest(num_cycles, endstate);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG runtest not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_runtest");
+}
+
+void wrapper_add_reset(int req_tlr_or_trst, int srst){
+    if (transport_is_jtag()) {
+        return jtag_add_reset(req_tlr_or_trst, srst);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG reset not directly supported on socket transport");
+        // We might implement a DMI-based reset here, if available. Currently not yet available!
+    }
+    LOG_ERROR("Unsupported transport for add_reset");
+}
+
+void wrapper_add_sleep(uint32_t us){
+    if (transport_is_jtag()) {
+        return jtag_add_sleep(us);
+    } 
+    if (transport_is_socket()) {
+        // We can use usleep directly or a socket-specific delay, if needed.
+        usleep(us);
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_sleep");
+}
+
+int wrapper_add_tms_seq(unsigned int nbits, const uint8_t *seq, enum tap_state t){
+    if (transport_is_jtag()) {
+        return jtag_add_tms_seq(nbits, seq, t);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG TMS sequences not supported on socket transport");
+        return ERROR_FAIL;
+    }
+    LOG_ERROR("Unsupported transport for add_tms_seq");
+    return ERROR_FAIL;
+}
+
+void wrapper_add_clocks(unsigned int num_cycles){
+    if (transport_is_jtag()) {
+        return jtag_add_clocks(num_cycles);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG clock operations not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for add_clocks");
+}
+
+int wrapper_execute_queue(void){
+    if (transport_is_jtag()) {
+        return jtag_execute_queue();
+    } 
+    if (transport_is_socket()) {
+        // Socket transport doesn't use a JTAG queue
+        LOG_ERROR("execute_queue not applicable to socket transport, error or do nothing.");
+        return ERROR_OK;
+    }
+    LOG_ERROR("Unsupported transport for execute_queue");
+    return ERROR_FAIL;
+}
+
+void wrapper_execute_queue_noclear(void){
+    if (transport_is_jtag()) {
+        return jtag_execute_queue_noclear();
+    } 
+    if (transport_is_socket()) {
+        // Socket transport doesn't use a JTAG queue
+        LOG_ERROR("execute_queue_noclear not applicable to socket transport, error or do nothing.");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for execute_queue_noclear");
+}
+
+unsigned int wrapper_get_flush_queue_count(void){
+    if (transport_is_jtag()) {
+        return jtag_get_flush_queue_count();
+    } 
+    if (transport_is_socket()) {
+        // Socket transport doesn't use a JTAG queue
+        LOG_DEBUG("get_flush_queue_count called for socket transport, returning default value (0).");
+        return 0;
+    }
+    LOG_ERROR("Unsupported transport for get_flush_queue_count");
+    return 0;
+}
+
+int wrapper_power_dropout(int *dropout){
+    if (transport_is_jtag()) {
+        return jtag_power_dropout(dropout);
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own power detection, otherwise return default
+        LOG_DEBUG("jtag_power_dropout called for socket transport, returning default value (0).");
+        *dropout = 0;
+        return ERROR_OK;
+    }
+    LOG_ERROR("Unsupported transport for jtag_power_dropout");
+    return ERROR_FAIL;
+}
+
+int wrapper_srst_asserted(int *srst_asserted){
+    if (transport_is_jtag()) {
+        return jtag_srst_asserted(srst_asserted);
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own SRST detection, otherwise return default
+        LOG_DEBUG("jtag_srst_asserted called for socket transport, returning default value (0).");
+        *srst_asserted = 0;
+        return ERROR_OK;
+    }
+    LOG_ERROR("Unsupported transport for jtag_srst_asserted");
+    return ERROR_FAIL;
+}
+
+void wrapper_check_value_mask(struct scan_field *field, uint8_t *value, uint8_t *mask){
+    if (transport_is_jtag()) {
+        return jtag_check_value_mask(field, value, mask);
+    } 
+    if (transport_is_socket()) {
+        LOG_ERROR("JTAG value/mask checking not supported on socket transport");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for check_value_mask");
+}
+
+void wrapper_sleep(uint32_t us){
+    if (transport_is_jtag()) {
+        return jtag_sleep(us);
+    } 
+    if (transport_is_socket()) {
+        // Use usleep directly or a socket-specific delay
+        usleep(us);
+        return;
+    }
+    LOG_ERROR("Unsupported transport for sleep");
+}
+
+void wrapper_set_error(int error){
+    if (transport_is_jtag()) {
+        return jtag_set_error(error);
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own error handling, otherwise do nothing
+        LOG_DEBUG("jtag_set_error called for socket transport, doing nothing.");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for jtag_set_error");
+}
+
+bool wrapper_is_jtag_poll_safe(void){
+    if (transport_is_jtag()) {
+        return is_jtag_poll_safe();
+    } 
+    if (transport_is_socket()) {
+        // Whether polling is safe depends on the socket implementation.
+        // We might need to add a mechanism to check if polling is safe
+        // based on the state of our socket connection.
+        // TODO: This is a future improvement.
+        LOG_DEBUG("is_jtag_poll_safe called for socket transport, returning default value (false).");
+        return false; 
+    }
+    LOG_ERROR("Unsupported transport for is_jtag_poll_safe");
+    return false;
+}
+
+bool wrapper_poll_get_enabled(void){
+    if (transport_is_jtag()) {
+        return jtag_poll_get_enabled();
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own polling mechanism, otherwise return default
+        LOG_DEBUG("jtag_poll_get_enabled called for socket transport, returning default value (false).");
+        return false;
+    }
+    LOG_ERROR("Unsupported transport for jtag_poll_get_enabled");
+    return false;
+}
+
+void wrapper_poll_set_enabled(bool value){
+    if (transport_is_jtag()) {
+        return jtag_poll_set_enabled(value);
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own polling mechanism, otherwise do nothing
+        LOG_DEBUG("jtag_poll_set_enabled called for socket transport, doing nothing.");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for jtag_poll_set_enabled");
+}
+
+bool wrapper_poll_mask(void){
+    if (transport_is_jtag()) {
+        return jtag_poll_mask();
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own polling mechanism, otherwise return default
+        LOG_DEBUG("jtag_poll_mask called for socket transport, returning default value (false).");
+        return false;
+    }
+    LOG_ERROR("Unsupported transport for jtag_poll_mask");
+    return false;
+}
+
+void wrapper_poll_unmask(bool saved){
+    if (transport_is_jtag()) {
+        return jtag_poll_unmask(saved);
+    } 
+    if (transport_is_socket()) {
+        // Socket transport might have its own polling mechanism, otherwise do nothing
+        LOG_DEBUG("jtag_poll_unmask called for socket transport, doing nothing.");
+        return;
+    }
+    LOG_ERROR("Unsupported transport for jtag_poll_unmask");
+}

--- a/src/jtag/core_communicator_wrapper.h
+++ b/src/jtag/core_communicator_wrapper.h
@@ -1,0 +1,126 @@
+
+#ifndef CORE_COMMUNICATOR_WRAPPER_H
+#define CORE_COMMUNICATOR_WRAPPER_H
+
+#include "jtag.h"
+#include "riscv_socket_dmi.h"
+/**
+ * @brief This file is used to wrap the JTAG, Socket, etc. core functionalities (core.c implementation) for communicating 
+ * with the device as well as batching and executing the instruction commands towards target, but in different ways, 
+ * not just JTAG, as it was status quo for many years. Now it can be extended by socket, pcie and any other communication
+ * interface, between OpenOCD and hardware/simulator/emulator. 
+ */
+
+
+/** Even though these (below functions) are related to jtag, there are some places where they are used. 
+ * So in this way we are consistent in having a wrapper for all possible JTAG and non-JTAG functions
+ * that might be used in the code. The functions are still called "wrapper_*" because non-jtag interfaces 
+ * will have empty implementations and would return default structs. The reason for this is because 
+ * JTAG is deeply embedded into OpenOCD and called in many places, that the cleanest way to use 
+ * something else is to replace directly those JTAG calls with wrappers, in the rest of the OpenOCD code. 
+*/
+void wrapper_tap_init(struct jtag_tap *tap);
+void wrapper_tap_free(struct jtag_tap *tap);
+
+struct jtag_tap *wrapper_all_taps(void);
+const char *wrapper_tap_name(const struct jtag_tap *tap);
+struct jtag_tap *wrapper_tap_by_string(const char *dotted_name);
+struct jtag_tap *wrapper_tap_by_position(unsigned int abs_position);
+struct jtag_tap *wrapper_tap_next_enabled(struct jtag_tap *p);
+unsigned int wrapper_tap_count_enabled(void);
+
+int wrapper_register_event_callback(jtag_event_handler_t f, void *x);
+int wrapper_unregister_event_callback(jtag_event_handler_t f, void *x);
+
+int wrapper_call_event_callbacks(enum jtag_event event);
+
+enum reset_types wrapper_get_reset_config(void);
+void wrapper_set_reset_config(enum reset_types type);
+
+void wrapper_set_nsrst_delay(unsigned int delay);
+unsigned int wrapper_get_nsrst_delay(void);
+
+void wrapper_set_ntrst_delay(unsigned int delay);
+unsigned int wrapper_get_ntrst_delay(void);
+
+void wrapper_set_nsrst_assert_width(unsigned int delay);
+unsigned int wrapper_get_nsrst_assert_width(void);
+
+void wrapper_set_ntrst_assert_width(unsigned int delay);
+unsigned int wrapper_get_ntrst_assert_width(void);
+
+int wrapper_get_trst(void);
+int wrapper_get_srst(void);
+
+void wrapper_set_verify(bool enable);
+bool wrapper_will_verify(void);
+
+void wrapper_set_verify_capture_ir(bool enable);
+bool wrapper_will_verify_capture_ir(void);
+
+void wrapper_set_flush_queue_sleep(int ms);
+
+int wrapper_init(struct command_context *cmd_ctx);
+
+int wrapper_init_reset(struct command_context *cmd_ctx);
+int wrapper_register_commands(struct command_context *cmd_ctx);
+int wrapper_init_inner(struct command_context *cmd_ctx);
+
+
+void wrapper_add_ir_scan(struct jtag_tap *tap,
+		struct scan_field *fields, enum tap_state endstate);
+void wrapper_add_ir_scan_noverify(struct jtag_tap *tap,
+		const struct scan_field *fields, enum tap_state state);
+void wrapper_add_plain_ir_scan(int num_bits, const uint8_t *out_bits, uint8_t *in_bits,
+		enum tap_state endstate);
+
+void wrapper_add_dr_scan(struct jtag_tap *tap, int num_fields,
+		const struct scan_field *fields, enum tap_state endstate);
+void wrapper_add_dr_scan_check(struct jtag_tap *tap, int num_fields,
+		struct scan_field *fields, enum tap_state endstate);
+void wrapper_add_plain_dr_scan(int num_bits,
+		const uint8_t *out_bits, uint8_t *in_bits, enum tap_state endstate);
+
+void wrapper_add_tlr(void);
+
+void wrapper_add_pathmove(unsigned int num_states, const enum tap_state *path);
+
+int wrapper_add_statemove(enum tap_state goal_state);
+
+void wrapper_add_runtest(unsigned int num_cycles, enum tap_state endstate);
+
+void wrapper_add_reset(int req_tlr_or_trst, int srst);
+
+void wrapper_add_sleep(uint32_t us);
+
+int wrapper_add_tms_seq(unsigned int nbits, const uint8_t *seq, enum tap_state t);
+
+void wrapper_add_clocks(unsigned int num_cycles);
+
+int wrapper_execute_queue(void);
+
+void wrapper_execute_queue_noclear(void);
+
+unsigned int wrapper_get_flush_queue_count(void);
+
+int wrapper_power_dropout(int *dropout);
+
+int wrapper_srst_asserted(int *srst_asserted);
+
+void wrapper_check_value_mask(struct scan_field *field, uint8_t *value, uint8_t *mask);
+
+void wrapper_sleep(uint32_t us);
+
+void wrapper_set_error(int error);
+
+bool wrapper_is_jtag_poll_safe(void);
+
+bool wrapper_poll_get_enabled(void);
+
+void wrapper_poll_set_enabled(bool value);
+
+bool wrapper_poll_mask(void);
+
+void wrapper_poll_unmask(bool saved);
+
+#endif // CORE_COMMUNICATOR_WRAPPER 

--- a/src/jtag/drivers/Makefile.am
+++ b/src/jtag/drivers/Makefile.am
@@ -211,6 +211,8 @@ if AM335XGPIO
 DRIVERFILES += %D%/am335xgpio.c
 endif
 
+DRIVERFILES += %D%/riscv_dtm/dtm.c
+
 DRIVERHEADERS = \
 	%D%/bitbang.h \
 	%D%/bitq.h \
@@ -223,6 +225,7 @@ DRIVERHEADERS = \
 	%D%/rlink_dtc_cmd.h \
 	%D%/rlink_ep1_cmd.h \
 	%D%/rlink_st7.h \
+	%D%/riscv_dtm/dtm.h \
 	%D%/versaloon/usbtoxxx/usbtoxxx.h \
 	%D%/versaloon/usbtoxxx/usbtoxxx_internal.h \
 	%D%/versaloon/versaloon.h \

--- a/src/jtag/drivers/riscv_dtm/dtm.c
+++ b/src/jtag/drivers/riscv_dtm/dtm.c
@@ -1,0 +1,117 @@
+#include "dtm.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <helper/command.h>
+#include <helper/log.h>
+#include "jtag/interface.h"
+#include "jtag/riscv_socket_dmi.h"
+
+#define MAX_DTM_DRIVERS 10
+
+static dtm_driver_t *registered_drivers[MAX_DTM_DRIVERS];
+static int driver_count = 0;
+
+static dtm_driver_t *active_driver = NULL;
+
+int register_dtm_driver(dtm_driver_t *driver) {
+    if (driver_count >= MAX_DTM_DRIVERS) {
+        fprintf(stderr, "Maximum number of DTM drivers reached.\n");
+        return ERROR_FAIL;
+    }
+    registered_drivers[driver_count++] = driver;
+    return ERROR_OK;
+}
+
+static int riscv_dtm_initialize(void) {
+    struct transport *current_transport = get_current_transport();
+    if (!current_transport) {
+        LOG_ERROR("No transport selected.");
+        return ERROR_FAIL;
+    }
+
+    const char *transport_name = current_transport->name;
+
+    if (select_dtm_driver(transport_name) != ERROR_OK) {
+        LOG_ERROR("Failedriverd to select DTM driver '%s'", transport_name);
+        return ERROR_FAIL;
+    }
+
+    dtm_driver_t *selected_dtm_driver = get_active_dtm_driver();
+    if (!selected_dtm_driver) {
+        LOG_ERROR("No DTM driver selected.");
+        return ERROR_FAIL;
+    }
+
+    if (selected_dtm_driver->set_transport && selected_dtm_driver->set_transport(current_transport) != ERROR_OK) {
+        LOG_ERROR("Failed to set transport for DTM driver '%s'", selected_dtm_driver->name);
+        return ERROR_FAIL;
+    }
+    LOG_INFO("DTM Adapter initialized with transport '%s'", transport_name);
+
+    return ERROR_OK;
+}
+
+
+static int riscv_dtm_init(void) {
+    // register all of the possible transports here that this adapter supports based on the current_transport name
+    if (register_riscv_socket_transport() != ERROR_OK) {
+        return ERROR_FAIL;
+    }
+    // if (current_transport && strcmp(current_transport->name, "pcie") == 0) {
+    //     return register_riscv_pcie_transport();
+    // }
+    return riscv_dtm_initialize();
+}
+
+// Retrieve a DTM driver by name
+dtm_driver_t *get_dtm_driver(const char *name) {
+    for (int i = 0; i < driver_count; i++) {
+        if (strcmp(registered_drivers[i]->name, name) == 0) {
+            return registered_drivers[i];
+        }
+    }
+    return NULL;
+}
+
+int select_dtm_driver(const char *name) {
+    dtm_driver_t *driver = get_dtm_driver(name);
+    if (!driver) {
+        fprintf(stderr, "DTM driver '%s' not found.\n", name);
+        return ERROR_FAIL;
+    }
+
+    if (driver->init(driver) != 0) {
+        fprintf(stderr, "Failed to initialize DTM driver '%s'.\n", name);
+        return ERROR_FAIL;
+    }
+
+    // If the previous active_driver is already in place and it has its own deinit function
+    // then we need to deinit it and to set the current one as active with the name from parameter 
+    if (active_driver && active_driver->deinit) {
+        active_driver->deinit(active_driver);
+    }
+
+    active_driver = driver;
+    return ERROR_OK;
+}
+
+dtm_driver_t *get_active_dtm_driver(void) {
+    return active_driver;
+}
+
+static int riscv_dtm_free(void) {
+    active_driver = get_active_dtm_driver();
+    active_driver->deinit(active_driver);
+    return ERROR_OK;
+}
+
+static const char * const riscv_dtm_transports[] = { "jtag", "socket", "pcie", NULL };
+
+struct adapter_driver riscv_dtm_adapter_driver = {
+	.name = "riscv_dtm",
+	.transports = riscv_dtm_transports,
+
+	.init = riscv_dtm_init,
+	.quit = riscv_dtm_free,
+};

--- a/src/jtag/drivers/riscv_dtm/dtm.h
+++ b/src/jtag/drivers/riscv_dtm/dtm.h
@@ -1,0 +1,29 @@
+// Defines the abstract interface for the Debug Transport Module (DTM)
+
+#ifndef RISCV_TRANSPORT_DTM_H
+#define RISCV_TRANSPORT_DTM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "../../../transport/transport.h"
+
+typedef struct dtm_driver {
+    const char *name; // e.g., "jtag", "pcie", "socket"
+    int (*init)(struct dtm_driver *driver);
+    int (*deinit)(struct dtm_driver *driver);
+    int (*read_dmi)(struct dtm_driver *driver, uint32_t *data, uint32_t address);
+    int (*write_dmi)(struct dtm_driver *driver, uint32_t address, uint32_t data);
+    int (*read_dtmcontrol)(struct dtm_driver *driver, uint32_t* value);
+    int (*set_transport)(struct transport *transport);
+    void *priv;  // Private data for the driver
+} dtm_driver_t;
+
+int register_dtm_driver(dtm_driver_t *driver);
+
+dtm_driver_t *get_dtm_driver(const char *name);
+
+int select_dtm_driver(const char *name);
+
+dtm_driver_t *get_active_dtm_driver(void);
+
+#endif /* RISCV_TRANSPORT_DTM_H */

--- a/src/jtag/interface.h
+++ b/src/jtag/interface.h
@@ -393,6 +393,7 @@ extern struct adapter_driver osbdm_adapter_driver;
 extern struct adapter_driver parport_adapter_driver;
 extern struct adapter_driver presto_adapter_driver;
 extern struct adapter_driver remote_bitbang_adapter_driver;
+extern struct adapter_driver riscv_dtm_adapter_driver;
 extern struct adapter_driver rlink_adapter_driver;
 extern struct adapter_driver rshim_dap_adapter_driver;
 extern struct adapter_driver stlink_dap_adapter_driver;

--- a/src/jtag/interfaces.c
+++ b/src/jtag/interfaces.c
@@ -17,6 +17,7 @@
  *   Copyright (C) 2020, Ampere Computing LLC                              *
  ***************************************************************************/
 
+#include "interface.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -156,5 +157,6 @@ struct adapter_driver *adapter_drivers[] = {
 #if BUILD_AM335XGPIO == 1
 		&am335xgpio_adapter_driver,
 #endif
+	&riscv_dtm_adapter_driver,
 		NULL,
 	};

--- a/src/jtag/riscv_socket_dmi.c
+++ b/src/jtag/riscv_socket_dmi.c
@@ -1,0 +1,519 @@
+#include "riscv_socket_dmi.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/tcp.h>
+#include "drivers/riscv_dtm/dtm.h"
+#include "transport/transport.h"
+#include "target/target.h"
+#include "target/riscv/riscv.h"
+#include "helper/log.h"
+
+#include <fcntl.h>
+#include <sys/select.h>
+#include <errno.h>
+
+typedef struct {
+    int sockfd;
+    char host[256];
+    int port;
+} socket_priv_t;
+
+// Commands for serialized socket message
+#define READ_COMMAND 0x00
+#define WRITE_COMMAND 0x01
+
+// Response codes
+#define RESPONSE_OK 0x00
+#define RESPONSE_ERROR 0x01
+
+#define DEFAULT_SOCKET_HOST "127.0.0.1"
+#define DEFAULT_SOCKET_PORT 5555
+
+static int transportIsRegistered = -1;
+
+int clear_socket_buffer(int sockfd) {
+    int flags = fcntl(sockfd, F_GETFL, 0);
+    if (flags == -1) {
+        perror("fcntl(F_GETFL)");
+        return -1;
+    }
+
+    // Make socket non-blocking
+    if (fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        perror("fcntl(F_SETFL, O_NONBLOCK)");
+        return -1;
+    }
+
+    fd_set readfds;
+    struct timeval timeout;
+    int ret;
+    char buf[1024]; // Buffer to discard data
+
+    do {
+        FD_ZERO(&readfds);
+        FD_SET(sockfd, &readfds);
+
+        // Set a short timeout (e.g., 100 milliseconds)
+        timeout.tv_sec = 0;
+        timeout.tv_usec = 100000;
+
+        ret = select(sockfd + 1, &readfds, NULL, NULL, &timeout);
+        if (ret == -1) {
+            perror("select");
+            return -1;
+        } else if (ret > 0) {
+            // Data is available to read
+            ssize_t bytes_read = recv(sockfd, buf, sizeof(buf), 0);
+            if (bytes_read == -1) {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    // No more data (expected in non-blocking mode)
+                    break;
+                } else {
+                    perror("recv");
+                    return -1;
+                }
+            }
+        }
+    } while (ret > 0);
+
+    // Restore original socket flags (if needed)
+    if (fcntl(sockfd, F_SETFL, flags) == -1) {
+        perror("fcntl(F_SETFL, flags)");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int recv_all(int sockfd, void *buf, size_t len) {
+    size_t to_read = len;
+    char *temp_buf = (char *)buf;
+    size_t total_bytes_read = 0;
+
+    while (to_read > 0) {
+        ssize_t bytes_read = recv(sockfd, temp_buf + total_bytes_read, to_read, 0);
+
+        if (bytes_read < 0) {
+            LOG_ERROR("recv error: %s", strerror(errno));
+            return ERROR_FAIL; 
+        } else if (bytes_read == 0) {
+            LOG_ERROR("Socket closed by remote host");
+            return ERROR_FAIL;
+        }
+
+        total_bytes_read += bytes_read;
+        to_read -= bytes_read;
+    }
+
+    return total_bytes_read;
+}
+
+static int socket_dmi_connect(dtm_driver_t* driver){
+    if (!driver->priv) {
+        return ERROR_FAIL;
+    }
+
+    socket_priv_t *priv = (socket_priv_t *)driver->priv;
+    if (priv->sockfd != -1) {
+        LOG_WARNING("Already connected, close it first.");
+        close(priv->sockfd);
+        priv->sockfd = -1;
+    }
+
+    priv->sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (priv->sockfd < 0) {
+        perror("Socket creation failed");
+        return ERROR_FAIL;
+    }
+
+    struct sockaddr_in server_addr;
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(priv->port);
+
+    if (inet_pton(AF_INET, priv->host, &server_addr.sin_addr) <= 0) {
+        perror("Invalid address/ Address not supported");
+        close(priv->sockfd);
+        priv->sockfd = -1;
+        return ERROR_FAIL;
+    }
+
+    if (connect(priv->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        perror("Connection Failed");
+        close(priv->sockfd);
+        priv->sockfd = -1;
+        return ERROR_FAIL;
+    }
+
+    return ERROR_OK;
+}
+
+int socket_dmi_init(dtm_driver_t *driver) {
+    // Use default values for now and later see if there is something in the openocd config file to connect with
+    // like socket specified host and port from the config file
+    socket_priv_t *priv = malloc(sizeof(socket_priv_t));
+    if (!priv) {
+        LOG_ERROR("Failed to allocate memory for socket_priv_t.");
+        return ERROR_FAIL;
+    }
+
+    strncpy(priv->host, DEFAULT_SOCKET_HOST, sizeof(priv->host) - 1);
+    priv->host[sizeof(priv->host) - 1] = '\0';
+    priv->port = DEFAULT_SOCKET_PORT;
+
+    priv->sockfd = -1; // Initialize to -1 to indicate not connected yet
+    driver->priv = priv;
+    return ERROR_OK;
+}
+
+
+int socket_dmi_deinit(dtm_driver_t *driver) {
+    if (!driver->priv) {
+        return ERROR_FAIL;
+    }
+
+    socket_priv_t *priv = (socket_priv_t *)driver->priv;
+    if (priv->sockfd != -1) {
+        close(priv->sockfd);
+    }
+    free(priv);
+    driver->priv = NULL;
+    return ERROR_OK;
+}
+
+int socket_dmi_read_dmi(dtm_driver_t *driver, uint32_t *data, uint32_t address) {
+    if (data == NULL) {
+        LOG_ERROR("data passed to socket_dmi_read_dmi function is nullptr! Make sure to examine which pointer is passed to socket_dmi_read_dmi");
+        return ERROR_FAIL;
+    }
+
+    if (driver == NULL) {
+        LOG_ERROR("driver passed to socket_dmi_read_dmi function is nullptr! Make sure to examine which pointer is passed to socket_dmi_read_dmi");
+        return ERROR_FAIL;
+    }
+
+    LOG_INFO("socket_dmi_read_dmi from address: address: %x", address);
+    if (!driver->priv) {
+        return ERROR_FAIL;
+    }
+
+    socket_priv_t *priv = (socket_priv_t *)driver->priv;
+
+    // Check if connected and connect if necessary
+    if (priv->sockfd == -1) {
+        if (socket_dmi_connect(driver) != 0) {
+            LOG_ERROR("Not connected and unable to establish connection.");
+            return -1;
+        }
+    }
+    const size_t data_length = 0;
+    const ssize_t request_size = 6; // Cmd(1) + Addr(4) + Len(1)
+    uint8_t buffer[request_size];
+    // Protocol: [READ_COMMAND][address (4 bytes)][data_length (1 byte, fixed as 4 for now)][Reserved (3 bytes)]
+    buffer[0] = READ_COMMAND; 
+    buffer[1] = (address >> 24) & 0xFF;
+    buffer[2] = (address >> 16) & 0xFF;
+    buffer[3] = (address >> 8) & 0xFF;
+    buffer[4] = address & 0xFF;
+    buffer[5] = data_length; // data length in bytes (fixed at 4)
+
+    // if (clear_socket_buffer(priv->sockfd) != 0) {
+    //     LOG_ERROR("Failed to clear socket buffer in socket_dmi_read_dmi");
+    //     return ERROR_FAIL;
+    // }
+
+    ssize_t sent = send(priv->sockfd, buffer, request_size, 0);
+    if (sent != request_size) { // Check against request_size
+        perror("Failed to send read DMI command");
+        return ERROR_FAIL;
+    }
+
+    const size_t response_length = 1;
+    uint8_t response_buffer[response_length];
+    size_t received_bytes = recv_all(priv->sockfd, response_buffer, response_length);
+    if (received_bytes != response_length) {
+        LOG_ERROR("Failed to receive response byte: received %zd bytes, expected 1", received_bytes);
+        return ERROR_FAIL;
+    }
+
+    if (response_buffer[0] != RESPONSE_OK) {
+        LOG_ERROR("DMI read failed (error code: 0x%X)", response_buffer[0]);
+        return -1;
+    }
+
+    const size_t response_data_length = 4; // Expect 4 bytes of data in response
+    uint8_t data_buffer[response_data_length];
+    received_bytes = recv_all(priv->sockfd, data_buffer, response_data_length);
+
+    if (received_bytes != response_data_length) {
+        LOG_ERROR("Failed to receive data: received %zd bytes, expected %zd", received_bytes, response_data_length);
+        return ERROR_FAIL;
+    }
+
+    *data = (data_buffer[0] << 24) |
+            (data_buffer[1] << 16) |
+            (data_buffer[2] << 8) |
+            data_buffer[3];
+
+    LOG_INFO("Received DMI read: addr=0x%08x, data=0x%08x", address, *data);
+
+    return ERROR_OK;
+}
+
+int socket_dmi_write_dmi(dtm_driver_t *driver, uint32_t address, uint32_t data) {
+    LOG_INFO("socket_dmi_write_dmi: address: %x, data: %x", address, data);
+    if (!driver->priv) {
+        return ERROR_FAIL;
+    }
+
+    socket_priv_t *priv = (socket_priv_t *)driver->priv;
+
+    // Check if connected and connect if necessary
+    if (priv->sockfd == -1) {
+        if (socket_dmi_connect(driver) != 0) {
+            LOG_ERROR("Not connected and unable to establish connection.");
+            return -1;
+        }
+    }
+    uint8_t buffer[10];
+    // Protocol: [WRITE_COMMAND][address (4 bytes)][data_length (1 byte, fixed as 4 for now)][data (4 bytes)]
+    buffer[0] = WRITE_COMMAND;
+    buffer[1] = (address >> 24) & 0xFF;
+    buffer[2] = (address >> 16) & 0xFF;
+    buffer[3] = (address >> 8) & 0xFF;
+    buffer[4] = address & 0xFF;
+    buffer[5] = 4; // data length in bytes (fixed at 4)
+    buffer[6] = (data >> 24) & 0xFF;
+    buffer[7] = (data >> 16) & 0xFF;
+    buffer[8] = (data >> 8) & 0xFF;
+    buffer[9] = data & 0xFF;
+
+    // if (clear_socket_buffer(priv->sockfd) != 0) {
+    //     LOG_ERROR("Failed to clear socket buffer in socket_dmi_write_dmi");
+    //     return ERROR_FAIL;
+    // }
+
+    ssize_t sent = send(priv->sockfd, buffer, sizeof(buffer), 0);
+    if (sent != sizeof(buffer)) {
+        perror("Failed to send write DMI command");
+        return ERROR_FAIL;
+    }
+
+    uint8_t recv_buffer[1];
+    ssize_t received_bytes = recv_all(priv->sockfd, recv_buffer, 1);
+    if (received_bytes != 1) {
+        return ERROR_FAIL;
+    }
+
+    if (recv_buffer[0] != RESPONSE_OK) {
+        LOG_ERROR("DMI write failed (error code: 0x%X)", buffer[0]);
+        return -1;
+    }
+
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(command_socket_host){
+	if (CMD_ARGC != 1)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+    dtm_driver_t *active_driver = get_active_dtm_driver();
+    if (!active_driver || strcmp(active_driver->name, "socket") != 0) {
+        LOG_ERROR("Active DTM driver is not socket");
+        return ERROR_FAIL;
+    }
+    socket_priv_t *priv = (socket_priv_t*)active_driver->priv;
+    strncpy(priv->host, CMD_ARGV[0], sizeof(priv->host) - 1);
+    priv->host[sizeof(priv->host) - 1] = '\0';
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(command_socket_port){
+	if (CMD_ARGC != 1)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+    dtm_driver_t *active_driver = get_active_dtm_driver();
+    if (!active_driver || strcmp(active_driver->name, "socket") != 0) {
+        LOG_ERROR("Active DTM driver is not socket'");
+        return ERROR_FAIL;
+    }
+
+    socket_priv_t *priv = (socket_priv_t*)active_driver->priv;
+    priv->port = atoi(CMD_ARGV[0]);
+    return ERROR_OK;
+}
+
+COMMAND_HANDLER(command_socket_connect){
+    dtm_driver_t *active_driver = get_active_dtm_driver();
+    if (!active_driver || strcmp(active_driver->name, "socket") != 0) {
+        LOG_ERROR("Active DTM driver is not socket");
+        return ERROR_FAIL;
+    }
+
+    if (socket_dmi_connect(active_driver) != 0) {
+        LOG_ERROR("Failed to connect to socket.");
+        return ERROR_FAIL;
+    }
+
+    return ERROR_OK;
+}
+
+static int socket_dtm_set_transport(struct transport *transport)
+{
+    // This function is called to set the transport
+    // In this case, we should verify the transport is "socket"
+    if (strcmp(transport->name, "socket") != 0) {
+        LOG_ERROR("transport->name != socket in socket_dtm_set_transport");
+        return ERROR_FAIL;
+    }
+
+    return ERROR_OK;
+}
+
+static dtm_driver_t socket_driver __attribute__((used)) = {
+    .name = "socket",
+    .init = socket_dmi_init,
+    .deinit = socket_dmi_deinit,
+    .read_dmi = socket_dmi_read_dmi,
+    .write_dmi = socket_dmi_write_dmi,
+    .read_dtmcontrol = socket_dtmcontrol_read_dmi,
+    .set_transport = socket_dtm_set_transport,
+    .priv = NULL
+};
+
+
+// Used for simulating DTMCONTROL, for socket simulation we do not need to simulate DTM directly. 
+int socket_dtmcontrol_read_dmi(struct dtm_driver *driver, uint32_t *value)
+{
+    LOG_INFO("Faking DTMCONTROL read in socket transport");
+    *value = (1 << 0) | (6 << 4);  // version=1, abits=6
+    return ERROR_OK;
+}
+
+int socket_dmi_read(struct target *target, uint32_t *data, uint32_t address) {
+    return socket_dmi_read_dmi(&socket_driver, data, address);
+}
+
+int socket_dmi_write(struct target *target, uint32_t address, uint32_t data) {
+    return socket_dmi_write_dmi(&socket_driver, address, data);
+}
+
+
+int socket_dtmcontrol_read(struct target *target, uint32_t *value)
+{
+    return socket_dtmcontrol_read_dmi(&socket_driver, value);
+}
+
+
+static const struct command_registration socket_transport_command_handlers[] = {
+    {
+        .name = "host",
+        .mode = COMMAND_ANY,
+        .help = "Set the hostname for the socket connection",
+        .usage = "<hostname>",
+        .handler = command_socket_host,
+    },
+    {
+        .name = "port",
+        .mode = COMMAND_ANY,
+        .help = "Set the port for the socket connection",
+        .usage = "<port>",
+        .handler = command_socket_port,
+    },
+    {
+        .name = "connect",
+        .mode = COMMAND_ANY,
+        .help = "Connect to the socket server",
+        .usage = "",
+        .handler = command_socket_connect,
+    },
+    COMMAND_REGISTRATION_DONE
+};
+
+static int socket_transport_select(struct command_context *ctx) {
+    struct target *target = get_current_target(ctx);
+    if (!target){
+        LOG_ERROR("Target not yet selected, socket transport will wait.");
+        return ERROR_FAIL;
+    }
+
+    // if (strcmp(target->type->name, "riscv") != 0) {
+    //     LOG_DEBUG("Target is not a riscv target, skipping socket transport.");
+    //     return ERROR_OK; // or ERROR_FAIL depending on your policy
+    // }
+
+    LOG_INFO("Selected socket transport for RISC-V target.");
+    RISCV_INFO(r);
+    r->dmi_read = socket_dmi_read;
+    r->dmi_write = socket_dmi_write;
+    return register_commands(ctx, NULL, socket_transport_command_handlers);
+}
+
+static int socket_transport_init(struct command_context *cmd_ctx)
+{
+    if (socket_dmi_init(&socket_driver) != 0) {
+        LOG_ERROR("Failed to register socket DMI driver.");
+        return ERROR_FAIL;
+    } else {
+        LOG_INFO("Socket DMI driver registered successfully.");
+    }
+
+    //return socket_dmi_init(&socket_driver);
+    return ERROR_OK;
+}
+
+static struct transport socket_transport __attribute__((used)) = {
+    .name = "socket",
+    .select = socket_transport_select,
+    .init = socket_transport_init,
+    .next = NULL,
+};
+
+int socket_transport_register(void) {
+    return transport_register(&socket_transport);
+}
+
+int register_socket_dtm_driver(void) {
+    return register_dtm_driver(&socket_driver);
+}
+
+int register_riscv_socket_transport(void) {
+    LOG_INFO("Initializing socket DTM driver.");
+    if (register_socket_dtm_driver() != 0) {
+        LOG_ERROR("Failed to register socket DTM driver.");
+        return ERROR_FAIL;
+    } else {
+        LOG_INFO("Socket DTM driver registered successfully.");
+    }
+
+    if (transportIsRegistered != -1){
+        LOG_INFO("Socket transport already registered successfully.");
+        return ERROR_OK;
+    }
+    LOG_INFO("Initializing socket transport.");
+    if (socket_transport_register() != ERROR_OK) {
+        LOG_ERROR("Failed to register socket transport.");
+        return ERROR_FAIL;
+    } else {
+        transportIsRegistered = 1;
+        LOG_INFO("Socket transport registered successfully.");
+    }
+
+    return ERROR_OK;
+
+}
+
+static void socket_constructor(void) __attribute__ ((constructor));
+static void socket_constructor(void)
+{
+    if(register_riscv_socket_transport() != 0){
+        LOG_ERROR("Failed to initialize socket transport!");
+    }
+    LOG_INFO("Socket transport successfully initialized.");
+}
+
+bool transport_is_socket(void)
+{
+	return get_current_transport() == &socket_transport;
+}

--- a/src/jtag/riscv_socket_dmi.h
+++ b/src/jtag/riscv_socket_dmi.h
@@ -1,0 +1,21 @@
+#ifndef SOCKET_DMI_H
+#define SOCKET_DMI_H
+
+#include "drivers/riscv_dtm/dtm.h"
+#include "helper/command.h"
+#include <stdint.h>
+
+int socket_dmi_init(dtm_driver_t *driver);
+int socket_dmi_deinit(dtm_driver_t *driver);
+int socket_dmi_read_dmi(dtm_driver_t *driver, uint32_t *data, uint32_t address);
+int socket_dmi_write_dmi(dtm_driver_t *driver, uint32_t address, uint32_t data);
+int socket_dtmcontrol_read_dmi(struct dtm_driver *driver, uint32_t *value);
+int register_socket_dtm_driver(void);
+
+
+int register_riscv_socket_transport(void);
+
+int socket_dmi_read(struct target *target, uint32_t *data, uint32_t address);
+int socket_dmi_write(struct target *target, uint32_t address, uint32_t data);
+bool transport_is_socket(void);
+#endif // SOCKET_DMI_H

--- a/src/target/riscv/Makefile.am
+++ b/src/target/riscv/Makefile.am
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 noinst_LTLIBRARIES += %D%/libriscv.la
+
 %C%_libriscv_la_SOURCES = \
        %D%/batch.h \
        %D%/debug_defines.h \

--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <stdint.h>
+#include <string.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -9,6 +11,8 @@
 #include "debug_reg_printer.h"
 #include "riscv.h"
 #include "field_helpers.h"
+#include "target/target_type.h"
+#include "jtag/core_communicator_wrapper.h"
 
 // TODO: DTM_DMI_MAX_ADDRESS_LENGTH should be reduced to 32 (per the debug spec)
 #define DTM_DMI_MAX_ADDRESS_LENGTH	((1<<DTM_DTMCS_ABITS_LENGTH)-1)
@@ -138,7 +142,9 @@ static void add_idle_before_batch(const struct riscv_batch *batch, size_t start_
 	const unsigned int idle_change = new_delay - batch->last_scan_delay;
 	LOG_TARGET_DEBUG(batch->target, "Adding %u idle cycles before the batch.",
 			idle_change);
-	jtag_add_runtest(idle_change, TAP_IDLE);
+	assert(idle_change <= INT_MAX);
+	// TODO: get rid of the JTAG dependency here
+	wrapper_add_runtest(idle_change, TAP_IDLE);
 }
 
 static unsigned int get_delay(const struct riscv_batch *batch, size_t scan_idx,
@@ -297,19 +303,21 @@ int riscv_batch_run_from(struct riscv_batch *batch, size_t start_idx,
 			riscv_add_bscan_tunneled_scan(batch->target->tap, batch->fields + i,
 							batch->bscan_ctxt + i);
 		else
-			jtag_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
+			wrapper_add_dr_scan(batch->target->tap, 1, batch->fields + i, TAP_IDLE);
 
 		delay = get_delay(batch, i, delays, resets_delays,
 				reset_delays_after);
 		if (delay > 0)
-			jtag_add_runtest(delay, TAP_IDLE);
+			wrapper_add_runtest(delay, TAP_IDLE);
 	}
 
 	keep_alive();
 
-	if (jtag_execute_queue() != ERROR_OK) {
-		LOG_TARGET_ERROR(batch->target, "Unable to execute JTAG queue");
-		return ERROR_FAIL;
+	if (strcmp(batch->target->type->name, "riscv") != 0) {	
+		if (wrapper_execute_queue() != ERROR_OK) {
+			LOG_TARGET_ERROR(batch->target, "Unable to execute JTAG queue");
+			return ERROR_FAIL;
+		}
 	}
 
 	keep_alive();
@@ -322,7 +330,9 @@ int riscv_batch_run_from(struct riscv_batch *batch, size_t start_idx,
 		}
 	}
 
-	log_batch(batch, start_idx, delays, resets_delays, reset_delays_after);
+	if (strcmp(batch->target->type->name, "riscv") != 0) {	
+		log_batch(batch, start_idx, delays, resets_delays, reset_delays_after);
+	}
 	batch->was_run = true;
 	batch->last_scan_delay = delay;
 	return ERROR_OK;

--- a/src/target/riscv/batch.h
+++ b/src/target/riscv/batch.h
@@ -122,7 +122,7 @@ static inline int riscv_scan_increase_delay(struct riscv_scan_delays *delays,
 
 /* A batch of multiple JTAG scans, which are grouped together to avoid the
  * overhead of some JTAG adapters when sending single commands.  This is
- * designed to support block copies, as that's what we actually need to go
+ * designed to support block copies, as that's what we actually need to do
  * fast. */
 struct riscv_batch {
 	struct target *target;

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <time.h>
+#include <string.h>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -335,7 +336,8 @@ static void increase_dbus_busy_delay(struct target *target)
 			info->dtmcontrol_idle, info->dbus_busy_delay,
 			info->interrupt_high_delay);
 
-	dtmcs_scan(target->tap, DTMCONTROL_DBUS_RESET, NULL /* discard value */);
+	bool is_jtag = strcmp(target->type->name, "riscv") == 0;
+	dtmcs_scan(target->tap, DTMCONTROL_DBUS_RESET, NULL /* discard value */, is_jtag);
 }
 
 static void increase_interrupt_high_delay(struct target *target)
@@ -1488,7 +1490,8 @@ static int examine(struct target *target)
 {
 	/* Don't need to select dbus, since the first thing we do is read dtmcontrol. */
 	uint32_t dtmcontrol;
-	if (dtmcs_scan(target->tap, 0, &dtmcontrol) != ERROR_OK || dtmcontrol == 0) {
+	bool is_jtag = (strcmp(target->type->name, "riscv") == 0);
+	if (dtmcs_scan(target->tap, 0, &dtmcontrol, is_jtag) != ERROR_OK || dtmcontrol == 0) {
 		LOG_ERROR("Could not scan dtmcontrol. Check JTAG connectivity/board power.");
 		return ERROR_FAIL;
 	}

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -5,6 +5,7 @@
  * latest draft.
  */
 
+#include "jtag/riscv_socket_dmi.h"
 #include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -20,6 +21,7 @@
 #include <helper/align.h>
 #include <helper/log.h>
 #include "jtag/jtag.h"
+#include "jtag/core_communicator_wrapper.h"
 #include "target/register.h"
 #include "target/breakpoints.h"
 #include "helper/time_support.h"
@@ -280,15 +282,27 @@ static dm013_info_t *get_dm(struct target *target)
 	if (info->dm)
 		return info->dm;
 
-	unsigned int abs_chain_position = target->tap->abs_chain_position;
-
 	dm013_info_t *entry;
 	dm013_info_t *dm = NULL;
-	list_for_each_entry(entry, &dm_list, list) {
-		if (entry->abs_chain_position == abs_chain_position
-				&& entry->base == target->dbgbase) {
-			dm = entry;
-			break;
+	unsigned int abs_chain_position = 0;
+
+	// For now we could let it be initialized to 0, as the comment suggests (default value), but if we 
+	// bypass it in the future or ignore its state, we might send commands that are not appropriate for the
+	// current state of the debug session, leading to errors or inconsistencies.
+	// The DM provides error codes and status information that help us understand whether a DMI command 
+	// was successful or if there was an issue (e.g., invalid address, unsupported command).
+    // Ignoring the DM means we lose access to this important feedback, making it harder to diagnose and fix problems.
+	// If we don't initialize the DM correctly, our DMI commands may not work as expected, 
+	// or they may cause the debug session to become unstable.
+
+	if (strcmp(target->type->name, "riscv") != 0){
+		abs_chain_position = target->tap->abs_chain_position;
+		list_for_each_entry(entry, &dm_list, list) {
+			if (entry->abs_chain_position == abs_chain_position
+					&& entry->base == target->dbgbase) {
+				dm = entry;
+				break;
+			}
 		}
 	}
 
@@ -298,7 +312,6 @@ static dm013_info_t *get_dm(struct target *target)
 		if (!dm)
 			return NULL;
 		dm->abs_chain_position = abs_chain_position;
-
 		/* Safety check for dbgbase */
 		assert(target->dbgbase_set || target->dbgbase == 0);
 
@@ -406,15 +419,18 @@ static uint32_t set_dmcontrol_hartsel(uint32_t initial, int hart_index)
 
 /*** Utility functions. ***/
 
-static void select_dmi(struct jtag_tap *tap)
+static void select_dmi(struct jtag_tap *tap, const char* name)
 {
 	if (bscan_tunnel_ir_width != 0) {
 		select_dmi_via_bscan(tap);
 		return;
 	}
-	if (!tap->enabled)
-		LOG_ERROR("BUG: Target's TAP '%s' is disabled!", jtag_tap_name(tap));
-
+	if (strcmp(name, "riscv") != 0) {
+		if (!tap->enabled){
+			return;
+		}
+	}
+		
 	bool need_ir_scan = false;
 	/* FIXME: make "tap" a const pointer. */
 	for (struct jtag_tap *other_tap = jtag_tap_next_enabled(NULL);
@@ -442,8 +458,10 @@ static int increase_dmi_busy_delay(struct target *target)
 {
 	RISCV013_INFO(info);
 
-	int res = dtmcs_scan(target->tap, DTM_DTMCS_DMIRESET,
-			NULL /* discard result */);
+	int res = -1;
+	bool is_jtag = 	IS_TARGET_JTAG(target->type->name);
+	res = dtmcs_scan(target->tap, DTM_DTMCS_DMIRESET,NULL /* discard result */, is_jtag);
+	
 	if (res != ERROR_OK)
 		return res;
 
@@ -490,13 +508,17 @@ static int batch_run_timeout(struct target *target, struct riscv_batch *batch);
 
 static int dmi_read(struct target *target, uint32_t *value, uint32_t address)
 {
-	struct riscv_batch *batch = riscv_batch_alloc(target, 1);
-	riscv_batch_add_dmi_read(batch, address, RISCV_DELAY_BASE);
-	int res = batch_run_timeout(target, batch);
-	if (res == ERROR_OK && value)
-		*value = riscv_batch_get_dmi_read_data(batch, 0);
-	riscv_batch_free(batch);
-	return res;
+	if (IS_TARGET_JTAG(target->type->name))
+	{
+			struct riscv_batch *batch = riscv_batch_alloc(target, 1);
+			riscv_batch_add_dmi_read(batch, address, RISCV_DELAY_BASE);
+			int res = batch_run_timeout(target, batch);
+			if (res == ERROR_OK && value)
+					*value = riscv_batch_get_dmi_read_data(batch, 0);
+			riscv_batch_free(batch);
+			return res;
+	}
+	return socket_dmi_read(target, value, address);
 }
 
 static int dm_read(struct target *target, uint32_t *value, uint32_t address)
@@ -521,12 +543,15 @@ static int dm_read_exec(struct target *target, uint32_t *value, uint32_t address
 
 static int dmi_write(struct target *target, uint32_t address, uint32_t value)
 {
-	struct riscv_batch *batch = riscv_batch_alloc(target, 1);
-	riscv_batch_add_dmi_write(batch, address, value, /*read_back*/ true,
-			RISCV_DELAY_BASE);
-	int res = batch_run_timeout(target, batch);
-	riscv_batch_free(batch);
-	return res;
+	if (IS_TARGET_JTAG(target->type->name)){
+		struct riscv_batch *batch = riscv_batch_alloc(target, 1);
+		riscv_batch_add_dmi_write(batch, address, value, /*read_back*/ true,
+				RISCV_DELAY_BASE);
+		int res = batch_run_timeout(target, batch);
+		riscv_batch_free(batch);
+		return res;
+	}
+	return socket_dmi_write(target, address, value);
 }
 
 static int dm_write(struct target *target, uint32_t address, uint32_t value)
@@ -656,14 +681,36 @@ static int dm013_select_target(struct target *target)
 
 #define ABSTRACT_COMMAND_BATCH_SIZE 2
 
+static uint8_t* get_buffer_values_from_uint32(uint32_t val){
+    uint8_t *out_buffer = (uint8_t *)malloc(4 * sizeof(uint8_t));
+    for (size_t i = 0; i < sizeof(uint32_t); i++){
+        out_buffer[i] = (val >> i*8) & 0xFF;
+    }
+    return out_buffer;
+}
+
 static size_t abstract_cmd_fill_batch(struct riscv_batch *batch,
 		uint32_t command)
 {
-	assert(riscv_batch_available_scans(batch)
-			>= ABSTRACT_COMMAND_BATCH_SIZE);
-	riscv_batch_add_dm_write(batch, DM_COMMAND, command, /* read_back */ true,
-			RISCV_DELAY_ABSTRACT_COMMAND);
-	return riscv_batch_add_dm_read(batch, DM_ABSTRACTCS, RISCV_DELAY_BASE);
+	if (IS_TARGET_JTAG(batch->target->type->name)){
+		assert(riscv_batch_available_scans(batch)
+				>= ABSTRACT_COMMAND_BATCH_SIZE);
+		riscv_batch_add_dm_write(batch, DM_COMMAND, command, /* read_back */ true,
+				RISCV_DELAY_ABSTRACT_COMMAND);
+		return riscv_batch_add_dm_read(batch, DM_ABSTRACTCS, RISCV_DELAY_BASE);
+	}
+	int res_write = dm_write(batch->target, DM_COMMAND, command);
+	if (res_write != ERROR_OK) {
+		return ERROR_FAIL;
+	}
+	int ret_status = riscv_batch_add_dm_read(batch, DM_ABSTRACTCS, RISCV_DELAY_BASE);
+	uint32_t value_read;
+	ret_status |= dm_read(batch->target, &value_read, DM_ABSTRACTCS);
+	if (ret_status != ERROR_OK){
+		return ret_status;
+	}
+	batch->data_out = get_buffer_values_from_uint32(value_read);
+	return ERROR_OK;
 }
 
 static int abstract_cmd_batch_check_and_clear_cmderr(struct target *target,
@@ -753,22 +800,21 @@ int riscv013_execute_abstract_command(struct target *target, uint32_t command,
 	struct riscv_batch *batch = riscv_batch_alloc(target,
 			ABSTRACT_COMMAND_BATCH_SIZE);
 	const size_t abstractcs_read_key = abstract_cmd_fill_batch(batch, command);
+	(void)abstractcs_read_key;
+	return abstractcs_read_key;
 
 	/* Abstract commands are executed while running the batch. */
-	dm->abstract_cmd_maybe_busy = true;
+	// dm->abstract_cmd_maybe_busy = true;
 
-	int res = batch_run_timeout(target, batch);
-	if (res != ERROR_OK)
-		goto cleanup;
+// 	int res = batch_run_timeout(target, batch);
+// 	if (res != ERROR_OK)
+// 		goto cleanup;
 
-	res = abstract_cmd_batch_check_and_clear_cmderr(target, batch,
-			abstractcs_read_key, cmderr);
-	if (res != ERROR_OK && *cmderr == CMDERR_NOT_SUPPORTED)
-		mark_command_as_unsupported(target, command);
-
-cleanup:
-	riscv_batch_free(batch);
-	return res;
+// 	res = abstract_cmd_batch_check_and_clear_cmderr(target, batch,
+// 			abstractcs_read_key, cmderr);
+// cleanup:
+// 	riscv_batch_free(batch);
+// 	return res;
 }
 
 /**
@@ -815,6 +861,28 @@ static int read_abstract_arg(struct target *target, riscv_reg_t *value,
 	assert(size_bits % 32 == 0);
 	const unsigned char size_in_words = size_bits / 32;
 	struct riscv_batch * const batch = riscv_batch_alloc(target, size_in_words);
+	if (strcmp(batch->target->type->name, "riscv") == 0){
+		dtm_driver_t* driver = get_active_dtm_driver();
+		uint64_t temp_value_64 = 0;
+		uint32_t dmi_data0_address = 0x04; // one more (0x05) for dmi_data1
+
+		for (size_t i = 0; i < sizeof(uint64_t) / sizeof(uint32_t); ++i){
+			uint32_t address = dmi_data0_address + i;
+			uint32_t value_32;
+			if (socket_dmi_read_dmi(driver, &value_32, address) != ERROR_OK){
+				LOG_TARGET_ERROR(batch->target, "Failed to read DMI data0");
+                return ERROR_FAIL;
+			} 
+			if (i == 0){
+				// First iteration: assign the first 32-bit value to the lower 32 bits
+				temp_value_64 = value_32;
+			} else {
+				temp_value_64 |= ((uint64_t)value_32) << 32;
+			}
+		}
+		*value = temp_value_64;
+		return ERROR_OK;
+	}
 	abstract_data_read_fill_batch(batch, index, size_bits);
 	int result = batch_run_timeout(target, batch);
 	if (result == ERROR_OK)
@@ -955,13 +1023,119 @@ static int register_read_abstract(struct target *target, riscv_reg_t *value,
 	return register_read_abstract_with_size(target, value, number, size);
 }
 
+static int register_write_abstract_direct(struct target *target, enum gdb_regno number,
+	riscv_reg_t value, dm013_info_t *dm)
+{
+	dtm_driver_t *driver = get_active_dtm_driver();
+	if (!driver) {
+		LOG_ERROR("Socket DMI driver not found for target %s", target_name(target));
+		return ERROR_FAIL;
+	}
+
+	const unsigned int size_bits = register_size(target, number);
+	const uint32_t command = riscv013_access_register_command(target, number, size_bits,
+			AC_ACCESS_REGISTER_TRANSFER |
+			AC_ACCESS_REGISTER_WRITE);
+	if (is_command_unsupported(target, command))
+		return ERROR_FAIL;
+
+	LOG_DEBUG_REG(target, AC_ACCESS_REGISTER, command);
+	assert(size_bits % 32 == 0);
+	const unsigned int size_in_words = size_bits / 32;
+
+	int res = ERROR_OK;
+
+	// Write data to abstract data registers (data0, data1, ...) directly
+	for (unsigned int i = 0; i < size_in_words; ++i) {
+		uint32_t word_val;
+		// Extract the correct 32-bit word from the 64-bit value
+		if (sizeof(riscv_reg_t) == 8) { // 64-bit host/register
+			word_val = (uint32_t)((value >> (i * 32)) & 0xFFFFFFFF);
+		} else { // 32-bit host/register
+			word_val = (uint32_t)value; // Only one word if size_bits is 32
+		}
+
+		uint32_t data_addr = DM_DATA0 + i;
+		LOG_DEBUG("Socket DMI Write: addr=0x%x, data=0x%08" PRIx32, data_addr, word_val);
+		res = socket_dmi_write_dmi(driver, data_addr, word_val);
+		if (res != ERROR_OK) {
+			LOG_ERROR("Failed to write abstract data%d via socket DMI", i);
+			return res;
+		}
+	}
+
+	// Write the command to the command register directly
+	LOG_DEBUG("Socket DMI Write: addr=0x%x, data=0x%08" PRIx32, DM_COMMAND, command);
+	res = socket_dmi_write_dmi(driver, DM_COMMAND, command);
+	if (res != ERROR_OK) {
+		LOG_ERROR("Failed to write abstract command via socket DMI");
+		return res;
+	}
+
+	// The target DM should process the command after the write to COMMAND completes.
+	// We now need to check the status.
+
+	// Read the abstractcs register directly to check status
+	uint32_t abstractcs_val;
+	LOG_DEBUG("Socket DMI Read: addr=0x%x", DM_ABSTRACTCS);
+	res = socket_dmi_read_dmi(driver, &abstractcs_val, DM_ABSTRACTCS);
+	if (res != ERROR_OK) {
+		LOG_ERROR("Failed to read abstractcs via socket DMI");
+		return res;
+	}
+	LOG_DEBUG("Read abstractcs value: 0x%08" PRIx32, abstractcs_val);
+
+
+	// Check cmderr field in abstractcs
+	// (Using standard RISC-V Debug Spec 0.13 definitions)
+	uint32_t cmderr = (abstractcs_val >> DM_ABSTRACTCS_CMDERR_OFFSET) & DM_ABSTRACTCS_CMDERR;
+
+	if (cmderr != CMDERR_NONE) {
+		LOG_ERROR("Abstract command failed, cmderr = %" PRIu32, cmderr);
+		res = ERROR_FAIL;
+
+		if (cmderr == CMDERR_BUSY) {
+			LOG_ERROR("  Command failed: Debug Module Busy");
+			// Here what might be added is a specific handling or retry logic
+		} else if (cmderr == CMDERR_NOT_SUPPORTED) {
+			LOG_ERROR("  Command failed: Not Supported");
+			mark_command_as_unsupported(target, command);
+		} else if (cmderr == CMDERR_EXCEPTION) {
+			LOG_ERROR("  Command failed: Exception during execution");
+		} else if (cmderr == CMDERR_HALT_RESUME) {
+			LOG_ERROR("  Command failed: Halt/resume issue");
+		} else if (cmderr == CMDERR_OTHER) {
+			LOG_ERROR("  Command failed: Other reason");
+		}
+
+		// Attempt to clear the error bit by writing cmderr back to abstractcs
+		// This is required by the spec to allow future commands.
+		uint32_t clear_cmd = cmderr << DM_ABSTRACTCS_CMDERR_OFFSET;
+		LOG_DEBUG("Attempting to clear cmderr by writing 0x%08" PRIx32 " to abstractcs", clear_cmd);
+		int clear_res = socket_dmi_write_dmi(driver, DM_ABSTRACTCS, clear_cmd);
+		if (clear_res != ERROR_OK) {
+			LOG_ERROR("Failed to clear cmderr in abstractcs via socket DMI");
+			// The original command still failed, so we keep res = ERROR_FAIL
+		}
+		return res;
+	}
+
+	return ERROR_OK;
+}
+
+
 static int register_write_abstract(struct target *target, enum gdb_regno number,
 		riscv_reg_t value)
 {
+	
 	dm013_info_t *dm = get_dm(target);
 	if (!dm)
 		return ERROR_FAIL;
 
+	if (!IS_TARGET_JTAG(target->type->name)){
+		// Covering the non-JTAG case
+		return register_write_abstract_direct(target, number, value, dm);
+	}
 	const unsigned int size_bits = register_size(target, number);
 	const uint32_t command = riscv013_access_register_command(target, number, size_bits,
 			AC_ACCESS_REGISTER_TRANSFER |
@@ -1839,7 +2013,10 @@ static int reset_dm(struct target *target)
 	 * prohibited.
 	 */
 	uint32_t dmcontrol;
-	int result = dm_read(target, &dmcontrol, DM_DMCONTROL);
+	
+	int result = 0;
+	result = dm_read(target, &dmcontrol, DM_DMCONTROL);
+
 	if (result != ERROR_OK)
 		return result;
 
@@ -1855,6 +2032,8 @@ static int reset_dm(struct target *target)
 		const time_t start = time(NULL);
 		LOG_TARGET_DEBUG(target, "Waiting for the DM to acknowledge reset.");
 		do {
+			uint32_t result_field = get_field(dmcontrol, DM_DMCONTROL_DMACTIVE);
+			LOG_TARGET_DEBUG(target, "******* result_field: %d", result_field);
 			result = dm_read(target, &dmcontrol, DM_DMCONTROL);
 			if (result != ERROR_OK)
 				return result;
@@ -1931,30 +2110,35 @@ static int examine_dm(struct target *target)
 
 	dm->hasel_supported = get_field(dmcontrol, DM_DMCONTROL_HASEL);
 
-	uint32_t hartsel =
-		(get_field(dmcontrol, DM_DMCONTROL_HARTSELHI) <<
-		 DM_DMCONTROL_HARTSELLO_LENGTH) |
-		get_field(dmcontrol, DM_DMCONTROL_HARTSELLO);
+	// uint32_t hartsel =
+	// 	(get_field(dmcontrol, DM_DMCONTROL_HARTSELHI) <<
+	// 	 DM_DMCONTROL_HARTSELLO_LENGTH) |
+	// 	get_field(dmcontrol, DM_DMCONTROL_HARTSELLO);
 
 	/* Before doing anything else we must first enumerate the harts. */
-	const int max_hart_count = MIN(RISCV_MAX_HARTS, hartsel + 1);
+	// const int max_hart_count = MIN(RISCV_MAX_HARTS, hartsel + 1);
+	const int max_hart_count = 1;
 	if (dm->hart_count < 0) {
 		for (int i = 0; i < max_hart_count; ++i) {
 			/* TODO: This is extremely similar to
 			 * riscv013_get_hart_state().
 			 * It would be best to reuse the code.
 			 */
+			LOG_TARGET_DEBUG(target, "####### About to enter dm013_select_hart, for the %d id of the loop", i); // TODO: delete this
 			result = dm013_select_hart(target, i);
-			if (result != ERROR_OK)
+			if (result != ERROR_OK) {
 				return result;
+			}
 
 			uint32_t s;
 			result = dmstatus_read(target, &s, /*authenticated*/ true);
-			if (result != ERROR_OK)
+			if (result != ERROR_OK){
 				return result;
+			}
 
-			if (get_field(s, DM_DMSTATUS_ANYNONEXISTENT))
+			if (get_field(s, DM_DMSTATUS_ANYNONEXISTENT)){
 				break;
+			}
 
 			dm->hart_count = i + 1;
 
@@ -1964,12 +2148,14 @@ static int examine_dm(struct target *target)
 				 * change `hartsel`.
 				 */
 				result = wait_for_idle_if_needed(target);
-				if (result != ERROR_OK)
+				if (result != ERROR_OK){
 					return result;
+				}
 				dmcontrol = set_dmcontrol_hartsel(dmcontrol, i);
 				result = dm_write(target, DM_DMCONTROL, dmcontrol);
-				if (result != ERROR_OK)
+				if (result != ERROR_OK){
 					return result;
+				}
 			}
 		}
 		LOG_TARGET_DEBUG(target, "Detected %d harts.", dm->hart_count);
@@ -1986,6 +2172,7 @@ static int examine_dm(struct target *target)
 
 static int examine(struct target *target)
 {
+	LOG_TARGET_ERROR(target, "*************** examine called!!! **********");
 	/* We reset target state in case if something goes wrong during examine:
 	 * DTM/DM scans could fail or hart may fail to halt. */
 	target->state = TARGET_UNKNOWN;
@@ -1995,10 +2182,27 @@ static int examine(struct target *target)
 	LOG_TARGET_DEBUG(target, "dbgbase=0x%x", target->dbgbase);
 
 	uint32_t dtmcontrol;
-	if (dtmcs_scan(target->tap, 0, &dtmcontrol) != ERROR_OK || dtmcontrol == 0) {
-		LOG_TARGET_ERROR(target, "Could not scan dtmcontrol. Check JTAG connectivity/board power.");
-		return ERROR_FAIL;
+	
+	bool is_jtag = 	IS_TARGET_JTAG(target->type->name);
+	if (is_jtag){
+		if (dtmcs_scan(target->tap, 0, &dtmcontrol, is_jtag) != ERROR_OK || dtmcontrol == 0) {
+			LOG_TARGET_ERROR(target, "Could not scan dtmcontrol. Check JTAG connectivity/board power.");
+			return ERROR_FAIL;
+		}
+	} else {
+		dtm_driver_t *driver = get_active_dtm_driver();
+		if (socket_dtmcontrol_read_dmi(driver, &dtmcontrol) != ERROR_OK) {
+			LOG_ERROR("Could not read dtmcontrol");
+			return ERROR_FAIL;
+		}
+		// dtm_driver_t *driver = get_active_dtm_driver();
+		// if (socket_dmi_read_dmi(driver, &dtmcontrol, 0x10) != ERROR_OK ||
+		// 	(dtmcontrol & DM_DMCONTROL_DMACTIVE) == 0) { 
+		// 	LOG_TARGET_ERROR(target, "Could not read dtmcontrol. Check socket connection/board power.");
+		// 	return ERROR_FAIL;
+		// }
 	}
+	
 
 	LOG_TARGET_DEBUG(target, "dtmcontrol=0x%x", dtmcontrol);
 	LOG_DEBUG_REG(target, DTM_DTMCS, dtmcontrol);
@@ -2508,7 +2712,7 @@ static int batch_run(struct target *target, struct riscv_batch *batch)
 {
 	RISCV_INFO(r);
 	RISCV013_INFO(info);
-	select_dmi(target->tap);
+	select_dmi(target->tap, target->type->name);
 	riscv_batch_add_nop(batch);
 	const int result = riscv_batch_run_from(batch, 0, &info->learned_delays,
 			/*resets_delays*/  r->reset_delays_wait >= 0,
@@ -2531,7 +2735,7 @@ static int batch_run(struct target *target, struct riscv_batch *batch)
 static int batch_run_timeout(struct target *target, struct riscv_batch *batch)
 {
 	RISCV013_INFO(info);
-	select_dmi(target->tap);
+	select_dmi(target->tap, target->type->name);
 	riscv_batch_add_nop(batch);
 
 	size_t finished_scans = 0;
@@ -2902,7 +3106,7 @@ static int assert_reset(struct target *target)
 	RISCV013_INFO(info);
 	int result;
 
-	select_dmi(target->tap);
+	select_dmi(target->tap, target->type->name);
 
 	if (target_has_event_action(target, TARGET_EVENT_RESET_ASSERT)) {
 		/* Run the user-supplied script if there is one. */
@@ -2956,7 +3160,7 @@ static int deassert_reset(struct target *target)
 		return ERROR_FAIL;
 	int result;
 
-	select_dmi(target->tap);
+	select_dmi(target->tap, target->type->name);
 	/* Clear the reset, but make sure haltreq is still set */
 	uint32_t control = 0;
 	control = set_field(control, DM_DMCONTROL_DMACTIVE, 1);
@@ -4450,7 +4654,7 @@ read_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
 {
 	assert(riscv_mem_access_is_read(args));
 
-	select_dmi(target->tap);
+	select_dmi(target->tap, target->type->name);
 	memset(args.read_buffer, 0, args.count * args.size);
 
 	if (execute_autofence(target) != ERROR_OK)

--- a/src/target/riscv/riscv-013_reg.c
+++ b/src/target/riscv/riscv-013_reg.c
@@ -88,7 +88,8 @@ static int init_cache_entry(struct target *target, uint32_t regno)
 	if (riscv_reg_impl_is_initialized(reg))
 		return ERROR_OK;
 	return riscv_reg_impl_init_cache_entry(target, regno,
-			riscv_reg_impl_gdb_regno_exist(target, regno),
+		// riscv_reg_impl_gdb_regno_exist(target, regno),
+			true,
 			riscv013_gdb_regno_reg_type(regno));
 }
 
@@ -316,6 +317,8 @@ int riscv013_reg_examine_all(struct target *target)
 	if (res != ERROR_OK)
 		return res;
 
+	// Analyzes the MISA (Machine ISA) CSR to detect supported RISC-V extensions. 
+	// This determines fundamental CPU capabilities like floating-point support, 32/64 bit arch. etc.
 	res = examine_misa(target);
 	if (res != ERROR_OK)
 		return res;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #ifdef HAVE_CONFIG_H
@@ -27,6 +28,8 @@
 #include "debug_defines.h"
 #include <helper/bits.h>
 #include "field_helpers.h"
+#include "jtag/drivers/riscv_dtm/dtm.h"
+#include "jtag/riscv_socket_dmi.h"
 
 /*** JTAG registers. ***/
 
@@ -413,8 +416,18 @@ static int dtmcs_scan_via_bscan(struct jtag_tap *tap, uint32_t out, uint32_t *in
 }
 
 /* TODO: rename "dtmcontrol"-> "dtmcs" */
-int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr)
+int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr, bool is_jtag)
 {
+	if (!is_jtag){
+		dtm_driver_t *driver = get_active_dtm_driver();
+		// uint32_t dtmcontrol_dmi_address = riscv_get_dmi_address(target, DTMCONTROL);
+		if (socket_dtmcontrol_read_dmi(driver, in_ptr) != ERROR_OK) {
+			LOG_ERROR("Could not read dtmcontrol");
+			return ERROR_FAIL;
+		}
+		return ERROR_OK;
+	}
+
 	uint8_t value[4];
 
 	if (bscan_tunnel_ir_width != 0)
@@ -452,6 +465,33 @@ int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr)
 	}
 	return ERROR_OK;
 }
+
+
+int dtmcontrol_write(struct target *target, uint32_t out, uint32_t *in_ptr)
+{
+	dtm_driver_t *driver = get_active_dtm_driver();
+    if (!driver) {
+        LOG_ERROR("No active DTM driver.");
+        return ERROR_FAIL;
+    }
+
+    uint32_t dtmcontrol_dmi_address = riscv_get_dmi_address(target, DTMCONTROL);
+
+    if (socket_dmi_write_dmi(driver, dtmcontrol_dmi_address, out) != ERROR_OK) {
+        LOG_ERROR("Failed to write to DTMCONTROL through socket.");
+        return ERROR_FAIL;
+    }
+
+    if (in_ptr) {
+		if (socket_dmi_read_dmi(driver, in_ptr, dtmcontrol_dmi_address) != ERROR_OK) {
+			LOG_ERROR("Failed to read back DTMCONTROL through socket.");
+			return ERROR_FAIL;
+		}
+    }
+
+    return ERROR_OK;
+}
+
 
 static struct target_type *get_target_type(struct target *target)
 {
@@ -668,29 +708,30 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 	info->cmd_ctx = cmd_ctx;
 	info->reset_delays_wait = -1;
 
-	select_dtmcontrol.num_bits = target->tap->ir_length;
-	select_dbus.num_bits = target->tap->ir_length;
-	select_idcode.num_bits = target->tap->ir_length;
+	if (IS_TARGET_JTAG(target->type->name)) {
+		select_dtmcontrol.num_bits = target->tap->ir_length;
+		select_dbus.num_bits = target->tap->ir_length;
+		select_idcode.num_bits = target->tap->ir_length;
 
-	if (bscan_tunnel_ir_width != 0) {
-		uint32_t ir_user4_raw = bscan_tunnel_ir_id;
-		/* Provide a default value which target some Xilinx FPGA USER4 IR */
-		if (ir_user4_raw == 0) {
-			assert(target->tap->ir_length >= 6);
-			ir_user4_raw = 0x23 << (target->tap->ir_length - 6);
+		if (bscan_tunnel_ir_width != 0) {
+			uint32_t ir_user4_raw = bscan_tunnel_ir_id;
+			/* Provide a default value which target some Xilinx FPGA USER4 IR */
+			if (ir_user4_raw == 0) {
+				assert(target->tap->ir_length >= 6);
+				ir_user4_raw = 0x23 << (target->tap->ir_length - 6);
+			}
+			h_u32_to_le(ir_user4, ir_user4_raw);
+			select_user4.num_bits = target->tap->ir_length;
+			if (bscan_tunnel_type == BSCAN_TUNNEL_DATA_REGISTER)
+				bscan_tunnel_data_register_select_dmi[1].num_bits = bscan_tunnel_ir_width;
+			else /* BSCAN_TUNNEL_NESTED_TAP */
+				bscan_tunnel_nested_tap_select_dmi[2].num_bits = bscan_tunnel_ir_width;
 		}
-		h_u32_to_le(ir_user4, ir_user4_raw);
-		select_user4.num_bits = target->tap->ir_length;
-		if (bscan_tunnel_type == BSCAN_TUNNEL_DATA_REGISTER)
-			bscan_tunnel_data_register_select_dmi[1].num_bits = bscan_tunnel_ir_width;
-		else /* BSCAN_TUNNEL_NESTED_TAP */
-			bscan_tunnel_nested_tap_select_dmi[2].num_bits = bscan_tunnel_ir_width;
 	}
 
 	riscv_semihosting_init(target);
 
 	target->debug_reason = DBG_REASON_DBGRQ;
-
 	return ERROR_OK;
 }
 
@@ -2481,7 +2522,8 @@ static int riscv_examine(struct target *target)
 
 	RISCV_INFO(info);
 	uint32_t dtmcontrol;
-	if (dtmcs_scan(target->tap, 0, &dtmcontrol) != ERROR_OK || dtmcontrol == 0) {
+	bool is_jtag = 	IS_TARGET_JTAG(target->type->name);
+	if (dtmcs_scan(target->tap, 0, &dtmcontrol, is_jtag) != ERROR_OK || dtmcontrol == 0) {
 		LOG_TARGET_ERROR(target, "Could not read dtmcontrol. Check JTAG connectivity/board power.");
 		return ERROR_FAIL;
 	}

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -32,6 +32,8 @@ struct riscv_program;
 #define RISCV_PGSIZE BIT(RISCV_PGSHIFT)
 #define RISCV_PGBASE(addr) ((addr) & ~(RISCV_PGSIZE - 1))
 #define RISCV_PGOFFSET(addr) ((addr) & (RISCV_PGSIZE - 1))
+#define IS_TARGET_JTAG(name) \
+	(strcmp(name, "riscv") != 0)
 
 #define PG_MAX_LEVEL 5
 
@@ -434,7 +436,7 @@ extern struct scan_field select_dtmcontrol;
 extern struct scan_field select_dbus;
 extern struct scan_field select_idcode;
 
-int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr);
+int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr, bool is_jtag);
 
 extern struct scan_field *bscan_tunneled_select_dmi;
 extern uint32_t bscan_tunneled_select_dmi_num_fields;
@@ -502,5 +504,7 @@ void riscv_add_bscan_tunneled_scan(struct jtag_tap *tap, const struct scan_field
 
 int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
 int riscv_write_by_any_size(struct target *target, target_addr_t address, uint32_t size, uint8_t *buffer);
+
+int dtmcontrol_write(struct target *target, uint32_t out, uint32_t *in_ptr);
 
 #endif /* OPENOCD_TARGET_RISCV_RISCV_H */

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -26,6 +26,7 @@
  *   andreas.fritiofson@gmail.com                                          *
  ***************************************************************************/
 
+#include <string.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -52,6 +53,7 @@
 /* default halt wait timeout (ms) */
 #define DEFAULT_HALT_TIMEOUT 5000
 
+
 static int target_read_buffer_default(struct target *target, target_addr_t address,
 		uint32_t count, uint8_t *buffer);
 static int target_write_buffer_default(struct target *target, target_addr_t address,
@@ -61,6 +63,9 @@ static int target_get_gdb_fileio_info_default(struct target *target,
 		struct gdb_fileio_info *fileio_info);
 static int target_gdb_fileio_end_default(struct target *target, int retcode,
 		int fileio_errno, bool ctrl_c);
+
+#define IS_TARGET_JTAG_WITH_CONDITION(name, additional_condition) ((strcmp(name, "riscv") != 0) && (additional_condition))
+
 
 static struct target_type *target_types[] = {
 	&arm7tdmi_target,
@@ -726,9 +731,9 @@ int target_examine(void)
 
 	for (target = all_targets; target; target = target->next) {
 		/* defer examination, but don't skip it */
-		if (!target->tap->enabled) {
+		if(IS_TARGET_JTAG_WITH_CONDITION(target->type->name, !target->tap->enabled)){
 			jtag_register_event_callback(jtag_enable_callback,
-					target);
+							target);
 			continue;
 		}
 
@@ -2979,8 +2984,9 @@ static int handle_target(void *priv)
 		 * schedule for now+polling_interval, the next poll won't
 		 * actually happen until a polling_interval later. */
 		bool poll_needed = timeval_ms() + polling_interval / 2 >= target->backoff.next_attempt;
-		if (!target->tap->enabled || power_dropout || srst_asserted || !poll_needed)
+		if (IS_TARGET_JTAG_WITH_CONDITION(target->type->name, !target->tap->enabled || power_dropout || srst_asserted || !poll_needed)){
 			continue;
+		}
 
 		/* polling may fail silently until the target has been examined */
 		retval = target_poll(target);
@@ -5694,7 +5700,7 @@ static int target_create(struct jim_getopt_info *goi)
 	cmd_ctx = current_command_context(goi->interp);
 	assert(cmd_ctx);
 
-	if (goi->argc < 3) {
+	if (goi->argc < 2) {
 		Jim_WrongNumArgs(goi->interp, 1, goi->argv, "?name? ?type? ..options...");
 		return JIM_ERR;
 	}
@@ -5818,13 +5824,13 @@ static int target_create(struct jim_getopt_info *goi)
 				e = JIM_ERR;
 			}
 		} else {
-			if (!target->tap_configured) {
+			if (IS_TARGET_JTAG_WITH_CONDITION(target->type->name, !target->tap_configured)){
 				Jim_SetResultString(goi->interp, "-chain-position ?name? required when creating target", -1);
 				e = JIM_ERR;
 			}
 		}
 		/* tap must be set after target was configured */
-		if (!target->tap)
+		if (IS_TARGET_JTAG_WITH_CONDITION(target->type->name, !target->tap))
 			e = JIM_ERR;
 	}
 
@@ -6040,7 +6046,7 @@ static int jim_target_create(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
 {
 	struct jim_getopt_info goi;
 	jim_getopt_setup(&goi, interp, argc - 1, argv + 1);
-	if (goi.argc < 3) {
+	if (goi.argc < 2) {
 		Jim_WrongNumArgs(goi.interp, goi.argc, goi.argv,
 			"<name> <target_type> [<target_options> ...]");
 		return JIM_ERR;


### PR DESCRIPTION
Separate makefile for transport, no autoconf changes with riscv flag

Initial autoconf changes

socket transport appears in the transport list command

Renamed socket to be more relatable to riscv architecture, for DMI, which is riscv specific thing

Improved socket, added host and port parsing and selection of transport for the adapter

Remove unnecessary include when it is done in header

Got rid of the hacky way of making the compiler link the new socket transport lib, doing it in adapter init instead, for every transport layer it supports.

Getting around JTAG (taps, chain-positions and cfg arguments meant for it)

Prevent a driver to get initialized twice

Bypassing the dtmcontrol_scan for jtag with socket

Localhost did not work, but the ip address for HOME does, socket can try to send something to server now

Wrong bits extracted, 1st byte was a read/write command, there was an offset here

Adding so far's python server simulator to make socket testing easier for socket transport layer

Made some fixes of some ptr bugs and how we advance in recv_all, but the issue still remains: data_buffer is all zeroes, examine that

Some other bugs fixed and out of bounds and fixed the shift

Improved server a bit by removing some unnecessary parts that sent the response twice and adding more logging/prints in the code

Adding no timeout and wait indefinitely (for send and recv) and improve the code a bit. Still getting all zeroes, though

Fix the server for the next command and adding more jtag guarded checks so that it could work via the socket.

Further adding the checks around JTAB and reset buffer in server code

Going around the JTAG buffered dmi_read for the socket

Now the server and riscv-openocd communicate constantly, although server is sending the same data to riscv-openocd

Returning the right value according to openocd's needs

A bit more improved server to align expectations what openocd expects

Bad indentation: infinite loop

Fixing the method to send a request to the target via socket and not to use the JTAG construct

Improved logging, dmi_write to have the socket version, too and some changed on the server to be more responsive

Listening on the port achieved, but with an ugly hack of temporary server reply

Adding an alternative of partially received buffer on the server side, adjust it to reach the same point as main1

Making sure now the server clears up the old data and with each received command starts anew

More precise assigning of data according to the riscv spec on https://riscv.org/wp-content/uploads/2024/12/riscv-debug-release.pdf pagde 21

Passing the stage of examining target, up to the stage where hart reset request is set

Commenting out troublesomecode to continue initialization

Some attempt of changes on OpenOCD's side and trying to remove some (maybe) not needed parts, also improving a server (python) for abstract commands

Some more crash fixes and restoring some commented out code that was actually needed for some future computations, otherwise there would have been a crash

Adding the read part in riscv batch dm read to be able to keep the counter to non-zero so that the future assertion passes

Adjusting the python server for reg number 0x300 needed from openocd's side

Potential memory corruption with this log line here

Putting back the log.

The error was not in log but rather in how log interprets the data and how prntf does it, that is more resilient.

The issue was in allocated and uninitialized, that caused some issues later on. This is why I used calloc for now.

With this approach it seems to work and to give positive results.

abstract_data_get_from_batch was needed to set the value of dcsr not to be uninitialized

Adding a counter so that the next time handle_dmi_read is called it returns another value, just like the spike simulator

Changing the server so that on the 2nd and future tries returns the same value.

Handling DM_STATUS_ALLHALTED later in the code execution to pass the halting stage on the server side

Adding risv guard around one more place that has it, that was skipped for socket, later in the execution logic

Uncommenting commented out parts for which I thought they cause issues

Server update with commented out support for gdb rsp packages and removed code that is not used plus some logging added

Unnecessary check when it was done in dm_read for platform

Changing the approach and moving the riscv_socket_dmi files to jtag, close to the core.h and core.c files so that a cleaner wrapper could be made

Wrapper for socket and jtag and other future transport layers added, but not yet used yet in the rest of the code. Replace jtag calls with wrapper calls.

Macro and not a static function expansion of reusable check due to the short circuiting and evaluation of parameters when passed to a function as opposed to the macro, where tap is a problematic access

Using wrapper for jtag in batch.c and fixing the issue with premature endinf og ifdef for file defined in riscv_socket_dmi.h

Changing macros in final places of riscv-013.c

Reset bit coming as 0, not as 1 anymore

Some pieces combined to be deeper decided if it is JTAG or socket (or other transport)

Revert "Some pieces combined to be deeper decided if it is JTAG or socket (or other transport)"

This reverts commit 46ddbebf59f9842b9d7d714758a96a5088670cd0.

Some pieces combined to be deeper decided if it is JTAG or socket (or other transport)

Dtm control scan reused and moved check deeper inside the function stack

dtmcontrol_scan also unified to do a check deeper in the functions it is calling

Final touches of moving the JTAG check deeper as in dmi_write as in dmi_read

Server should handle the case for replying bask to DM_ABSTRACTCS  with the value as Spike simulator does

Bringing back malloc where it was

MISA gets the value different than zero now for HW capabilities

Update misa access via socket by completely avoiding JTAG and buffers

Trying to use more riscv compliant server simulators to test socket dmi openocd connection to this target

more modern version of python server and openocd to accommodate communication with it