### PR TITLE
Update image in `build32`

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -5,7 +5,7 @@ name: Linux Build
 jobs:
   # 32-bit, clang
   build32:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CFLAGS: -m32
       CC: clang


### PR DESCRIPTION
Ubuntu 20.04 is no longer available.
See https://github.com/actions/runner-images/issues/11101

Change-Id: I0ec3e3342f9212a2a79d8dca6274e7db62ecedab