### PR TITLE
target/riscv: Adjust to upstream coding style

### DIFF
--- a/src/target/riscv/program.h
+++ b/src/target/riscv/program.h
@@ -7,13 +7,13 @@
 
 #define RISCV013_MAX_PROGBUF_SIZE 16
 
-typedef enum {
+enum riscv_progbuf_exec_result {
 	RISCV_PROGBUF_EXEC_RESULT_NOT_EXECUTED,
 	RISCV_PROGBUF_EXEC_RESULT_UNKNOWN,
 	RISCV_PROGBUF_EXEC_RESULT_EXCEPTION,
 	RISCV_PROGBUF_EXEC_RESULT_UNKNOWN_ERROR,
 	RISCV_PROGBUF_EXEC_RESULT_SUCCESS
-} riscv_progbuf_exec_result_t;
+};
 
 /* The various RISC-V debug specifications all revolve around setting up
  * program buffers and executing them on the target.  This structure contains a
@@ -28,7 +28,7 @@ struct riscv_program {
 
 	/* execution result of the program */
 	/* TODO: remove this field. We should make it a parameter to riscv_program_exec */
-	riscv_progbuf_exec_result_t execution_result;
+	enum riscv_progbuf_exec_result execution_result;
 };
 
 /* Initializes a program with the header. */

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -2013,7 +2013,7 @@ static int deassert_reset(struct target *target)
 		return wait_for_state(target, TARGET_RUNNING);
 }
 
-static int read_memory(struct target *target, const riscv_mem_access_args_t args)
+static int read_memory(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -2190,7 +2190,7 @@ static int setup_write_memory(struct target *target, uint32_t size)
 	return ERROR_OK;
 }
 
-static int write_memory(struct target *target, const riscv_mem_access_args_t args)
+static int write_memory(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 
@@ -2339,7 +2339,7 @@ error:
 	return ERROR_FAIL;
 }
 
-static int access_memory(struct target *target, const riscv_mem_access_args_t args)
+static int access_memory(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 	const bool is_write = riscv_mem_access_is_write(args);

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -64,16 +64,16 @@ static int register_read_direct(struct target *target, riscv_reg_t *value,
 		enum gdb_regno number);
 static int register_write_direct(struct target *target, enum gdb_regno number,
 		riscv_reg_t value);
-static int riscv013_access_memory(struct target *target, const riscv_mem_access_args_t args);
+static int riscv013_access_memory(struct target *target, const struct riscv_mem_access_args args);
 static bool riscv013_get_impebreak(const struct target *target);
 static unsigned int riscv013_get_progbufsize(const struct target *target);
 
-typedef enum {
+enum grouptype {
 	HALT_GROUP,
 	RESUME_GROUP
-} grouptype_t;
+};
 static int set_group(struct target *target, bool *supported, unsigned int group,
-		grouptype_t grouptype);
+		enum grouptype grouptype);
 
 /**
  * Since almost everything can be accomplish by scanning the dbus register, all
@@ -220,7 +220,7 @@ typedef struct {
 	/* We cache the read-only bits of sbcs here. */
 	uint32_t sbcs;
 
-	yes_no_maybe_t progbuf_writable;
+	enum yes_no_maybe progbuf_writable;
 	/* We only need the address so that we know the alignment of the buffer. */
 	riscv_addr_t progbuf_address;
 
@@ -1270,7 +1270,7 @@ static int scratch_read64(struct target *target, scratch_mem_t *scratch,
 		case SPACE_DMI_RAM:
 			{
 				uint8_t buffer[8] = {0};
-				const riscv_mem_access_args_t args = {
+				const struct riscv_mem_access_args args = {
 					.address = scratch->debug_address,
 					.read_buffer = buffer,
 					.size = 4,
@@ -1312,7 +1312,7 @@ static int scratch_write64(struct target *target, scratch_mem_t *scratch,
 					value >> 48,
 					value >> 56
 				};
-				const riscv_mem_access_args_t args = {
+				const struct riscv_mem_access_args args = {
 					.address = scratch->debug_address,
 					.write_buffer = buffer,
 					.size = 4,
@@ -1785,7 +1785,7 @@ static void deinit_target(struct target *target)
 }
 
 static int set_group(struct target *target, bool *supported, unsigned int group,
-		grouptype_t grouptype)
+		enum grouptype grouptype)
 {
 	uint32_t write_val = DM_DMCS2_HGWRITE;
 	assert(group <= 31);
@@ -2217,7 +2217,7 @@ static unsigned int riscv013_data_bits(struct target *target)
 	RISCV_INFO(r);
 
 	for (unsigned int i = 0; i < r->num_enabled_mem_access_methods; i++) {
-		riscv_mem_access_method_t method = r->mem_access_methods[i];
+		enum riscv_mem_access_method method = r->mem_access_methods[i];
 
 		if (method == RISCV_MEM_ACCESS_PROGBUF) {
 			if (has_sufficient_progbuf(target, 3))
@@ -3260,7 +3260,7 @@ static int restore_privilege_from_virt2phys_mode(struct target *target, riscv_re
 	return ERROR_OK;
 }
 
-static int read_memory_bus_v0(struct target *target, const riscv_mem_access_args_t args)
+static int read_memory_bus_v0(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -3350,7 +3350,7 @@ static int read_memory_bus_v0(struct target *target, const riscv_mem_access_args
 /**
  * Read the requested memory using the system bus interface.
  */
-static int read_memory_bus_v1(struct target *target, const riscv_mem_access_args_t args)
+static int read_memory_bus_v1(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -3496,7 +3496,8 @@ static int read_memory_bus_v1(struct target *target, const riscv_mem_access_args
 	return ERROR_OK;
 }
 
-static void log_mem_access_result(struct target *target, bool success, riscv_mem_access_method_t method, bool is_read)
+static void log_mem_access_result(struct target *target, bool success,
+		enum riscv_mem_access_method method, bool is_read)
 {
 	RISCV_INFO(r);
 	bool warn = false;
@@ -3667,7 +3668,7 @@ static struct mem_access_result mem_access_result(enum mem_access_result_enum va
 }
 
 static struct mem_access_result mem_should_skip_progbuf(struct target *target,
-	const riscv_mem_access_args_t args)
+	const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 	const char *const access_type =
@@ -3710,7 +3711,7 @@ static struct mem_access_result mem_should_skip_progbuf(struct target *target,
 }
 
 static struct mem_access_result
-mem_should_skip_sysbus(struct target *target, const riscv_mem_access_args_t args)
+mem_should_skip_sysbus(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -3743,7 +3744,7 @@ mem_should_skip_sysbus(struct target *target, const riscv_mem_access_args_t args
 }
 
 static struct mem_access_result
-mem_should_skip_abstract(struct target *target, const riscv_mem_access_args_t args)
+mem_should_skip_abstract(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -3778,7 +3779,7 @@ mem_should_skip_abstract(struct target *target, const riscv_mem_access_args_t ar
  * aamsize fields in the memory access abstract command.
  */
 static struct mem_access_result
-read_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
+read_memory_abstract(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -3855,7 +3856,7 @@ read_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
  * byte aamsize fields in the memory access abstract command.
  */
 static struct mem_access_result
-write_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
+write_memory_abstract(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 
@@ -4006,7 +4007,7 @@ clear_abstractauto_and_fail:
  */
 static int read_memory_progbuf_inner_on_ac_busy(struct target *target,
 		uint32_t start_index, uint32_t *elements_read,
-		const riscv_mem_access_args_t args)
+		const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4065,7 +4066,7 @@ static int read_memory_progbuf_inner_on_ac_busy(struct target *target,
  */
 static int read_memory_progbuf_inner_on_dmi_busy(struct target *target,
 		uint32_t start_index, uint32_t next_start_index,
-		const riscv_mem_access_args_t args)
+		const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4086,7 +4087,7 @@ static int read_memory_progbuf_inner_on_dmi_busy(struct target *target,
 static int read_memory_progbuf_inner_extract_batch_data(struct target *target,
 		const struct riscv_batch *batch,
 		uint32_t start_index, uint32_t elements_to_read, uint32_t *elements_read,
-		const riscv_mem_access_args_t args)
+		const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4143,7 +4144,7 @@ static int read_memory_progbuf_inner_extract_batch_data(struct target *target,
  * - DM_ABSTRACTAUTO_AUTOEXECDATA is set.
  */
 static int read_memory_progbuf_inner_run_and_process_batch(struct target *target,
-		struct riscv_batch *batch, const riscv_mem_access_args_t args,
+		struct riscv_batch *batch, const struct riscv_mem_access_args args,
 		uint32_t start_index, uint32_t elements_to_read, uint32_t *elements_read)
 {
 	assert(riscv_mem_access_is_read(args));
@@ -4214,7 +4215,7 @@ static uint32_t read_memory_progbuf_inner_fill_batch(struct riscv_batch *batch,
 }
 
 static int read_memory_progbuf_inner_try_to_read(struct target *target,
-		const riscv_mem_access_args_t args, uint32_t *elements_read,
+		const struct riscv_mem_access_args args, uint32_t *elements_read,
 		uint32_t index, uint32_t loop_count)
 {
 	assert(riscv_mem_access_is_read(args));
@@ -4237,7 +4238,7 @@ static int read_memory_progbuf_inner_try_to_read(struct target *target,
  * with the address argument equal to curr_target_address.
  */
 static int read_memory_progbuf_inner_ensure_forward_progress(struct target *target,
-		const riscv_mem_access_args_t args, uint32_t start_index)
+		const struct riscv_mem_access_args args, uint32_t start_index)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4248,7 +4249,7 @@ static int read_memory_progbuf_inner_ensure_forward_progress(struct target *targ
 		start_index * args.increment;
 	uint8_t * const curr_buffer_address = args.read_buffer +
 		start_index * args.size;
-	const riscv_mem_access_args_t curr_access = {
+	const struct riscv_mem_access_args curr_access = {
 		.read_buffer = curr_buffer_address,
 		.address = curr_target_address,
 		.size = args.size,
@@ -4270,7 +4271,7 @@ static int read_memory_progbuf_inner_ensure_forward_progress(struct target *targ
 	return ERROR_OK;
 }
 
-static void set_buffer_and_log_read(const riscv_mem_access_args_t args,
+static void set_buffer_and_log_read(const struct riscv_mem_access_args args,
 		uint32_t index, uint64_t value)
 {
 	assert(riscv_mem_access_is_read(args));
@@ -4287,7 +4288,7 @@ static void set_buffer_and_log_read(const riscv_mem_access_args_t args,
 }
 
 static int read_word_from_dm_data_regs(struct target *target,
-		const riscv_mem_access_args_t args, uint32_t index)
+		const struct riscv_mem_access_args args, uint32_t index)
 {
 	assert(args.size <= 8);
 	uint64_t value;
@@ -4299,7 +4300,7 @@ static int read_word_from_dm_data_regs(struct target *target,
 }
 
 static struct mem_access_result read_word_from_s1(struct target *target,
-		const riscv_mem_access_args_t args, uint32_t index)
+		const struct riscv_mem_access_args args, uint32_t index)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4352,7 +4353,7 @@ static int read_memory_progbuf_inner_fill_progbuf(struct target *target,
  * is encountered in the process.
  */
 static struct mem_access_result
-read_memory_progbuf_inner(struct target *target, const riscv_mem_access_args_t args)
+read_memory_progbuf_inner(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 	assert(args.count > 1 && "If count == 1, read_memory_progbuf_inner_one must be called");
@@ -4410,7 +4411,7 @@ read_memory_progbuf_inner(struct target *target, const riscv_mem_access_args_t a
  * program doesn't need to increment.
  */
 static struct mem_access_result
-read_memory_progbuf_inner_one(struct target *target, const riscv_mem_access_args_t args)
+read_memory_progbuf_inner_one(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4446,7 +4447,7 @@ read_memory_progbuf_inner_one(struct target *target, const riscv_mem_access_args
  * Read the requested memory, silently handling memory access errors.
  */
 static struct mem_access_result
-read_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
+read_memory_progbuf(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_read(args));
 
@@ -4462,10 +4463,10 @@ read_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
 }
 
 static struct mem_access_result
-write_memory_progbuf(struct target *target, const riscv_mem_access_args_t args);
+write_memory_progbuf(struct target *target, const struct riscv_mem_access_args args);
 
 static struct mem_access_result
-access_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
+access_memory_progbuf(struct target *target, const struct riscv_mem_access_args args)
 {
 	struct mem_access_result skip_reason = mem_should_skip_progbuf(target, args);
 	if (!is_mem_access_ok(skip_reason))
@@ -4500,12 +4501,12 @@ access_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
 }
 
 static int
-write_memory_bus_v0(struct target *target, const riscv_mem_access_args_t args);
+write_memory_bus_v0(struct target *target, const struct riscv_mem_access_args args);
 static int
-write_memory_bus_v1(struct target *target, const riscv_mem_access_args_t args);
+write_memory_bus_v1(struct target *target, const struct riscv_mem_access_args args);
 
 static struct mem_access_result
-access_memory_sysbus(struct target *target, const riscv_mem_access_args_t args)
+access_memory_sysbus(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -4533,7 +4534,7 @@ access_memory_sysbus(struct target *target, const riscv_mem_access_args_t args)
 }
 
 static struct mem_access_result
-access_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
+access_memory_abstract(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -4552,7 +4553,7 @@ access_memory_abstract(struct target *target, const riscv_mem_access_args_t args
 }
 
 static int
-riscv013_access_memory(struct target *target, const riscv_mem_access_args_t args)
+riscv013_access_memory(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -4577,7 +4578,7 @@ riscv013_access_memory(struct target *target, const riscv_mem_access_args_t args
 
 	RISCV_INFO(r);
 	for (unsigned int i = 0; i < r->num_enabled_mem_access_methods; ++i) {
-		riscv_mem_access_method_t method = r->mem_access_methods[i];
+		enum riscv_mem_access_method method = r->mem_access_methods[i];
 		switch (method) {
 			case RISCV_MEM_ACCESS_PROGBUF:
 				skip_reason[method] = access_memory_progbuf(target, args);
@@ -4612,7 +4613,7 @@ failure:
 	return ERROR_FAIL;
 }
 
-static int write_memory_bus_v0(struct target *target, const riscv_mem_access_args_t args)
+static int write_memory_bus_v0(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 
@@ -4666,7 +4667,7 @@ static int write_memory_bus_v0(struct target *target, const riscv_mem_access_arg
 	return ERROR_OK;
 }
 
-static int write_memory_bus_v1(struct target *target, const riscv_mem_access_args_t args)
+static int write_memory_bus_v1(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 
@@ -5011,7 +5012,7 @@ static int write_memory_progbuf_fill_progbuf(struct target *target, uint32_t siz
 
 static struct mem_access_result
 write_memory_progbuf_inner(struct target *target,
-		const riscv_mem_access_args_t args)
+		const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 
@@ -5046,7 +5047,7 @@ write_memory_progbuf_inner(struct target *target,
 }
 
 static struct mem_access_result
-write_memory_progbuf(struct target *target, const riscv_mem_access_args_t args)
+write_memory_progbuf(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_write(args));
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -155,7 +155,7 @@ bool riscv_virt2phys_mode_is_sw(const struct target *target)
 	return r->virt2phys_mode == RISCV_VIRT2PHYS_MODE_SW;
 }
 
-const char *riscv_virt2phys_mode_to_str(riscv_virt2phys_mode_t mode)
+const char *riscv_virt2phys_mode_to_str(enum riscv_virt2phys_mode mode)
 {
 	assert(mode == RISCV_VIRT2PHYS_MODE_OFF
 			|| mode == RISCV_VIRT2PHYS_MODE_SW
@@ -1768,16 +1768,16 @@ int riscv_remove_watchpoint(struct target *target,
 	return ERROR_OK;
 }
 
-typedef enum {
+enum mctrl6hitstatus {
 	M6_HIT_ERROR,
 	M6_HIT_NOT_SUPPORTED,
 	M6_NOT_HIT,
 	M6_HIT_BEFORE,
 	M6_HIT_AFTER,
 	M6_HIT_IMM_AFTER
-} mctrl6hitstatus;
+};
 
-static mctrl6hitstatus check_mcontrol6_hit_status(struct target *target,
+static enum mctrl6hitstatus check_mcontrol6_hit_status(struct target *target,
 		riscv_reg_t tdata1, uint64_t hit_mask)
 {
 	const uint32_t hit0 = get_field(tdata1, CSR_MCONTROL6_HIT0);
@@ -1870,7 +1870,7 @@ static int riscv_trigger_detect_hit_bits(struct target *target, int64_t *unique_
 					*need_single_step = true;
 				} else if (r->tinfo_version == RISCV_TINFO_VERSION_UNKNOWN
 					|| r->tinfo_version == CSR_TINFO_VERSION_1) {
-					mctrl6hitstatus hits_status = check_mcontrol6_hit_status(target,
+					enum mctrl6hitstatus hits_status = check_mcontrol6_hit_status(target,
 								tdata1, hit_mask);
 					if (hits_status == M6_HIT_ERROR)
 						return ERROR_FAIL;
@@ -2078,7 +2078,7 @@ static int get_loadstore_memoffset(struct target *target,
 		const riscv_insn_t instruction, int16_t *memoffset)
 {
 	uint32_t opcode = get_opcode(instruction);
-	int16_t offset;
+	int16_t offset = 0;
 
 	switch (opcode) {
 	case MATCH_LB:
@@ -2911,8 +2911,7 @@ static int resume_finish(struct target *target, bool debug_execution)
  * @par single_hart When true, only resume a single hart even if SMP is
  * configured.  This is used to run algorithms on just one hart.
  */
-static int riscv_resume(
-		struct target *target,
+static int riscv_resume(struct target *target,
 		bool current,
 		target_addr_t address,
 		bool handle_breakpoints,
@@ -3049,7 +3048,6 @@ static int riscv_mmu(struct target *target, int *enabled)
 				/* In hypervisor mode regular satp translation
 				 * doesn't happen. */
 				return ERROR_OK;
-
 		}
 
 		riscv_reg_t vsatp;
@@ -3145,7 +3143,7 @@ static int riscv_address_translate(struct target *target,
 
 		uint8_t buffer[8];
 		assert(info->pte_shift <= 3);
-		const riscv_mem_access_args_t args = {
+		const struct riscv_mem_access_args args = {
 			.address = pte_address,
 			.read_buffer = buffer,
 			.size = 4,
@@ -3388,7 +3386,7 @@ static int check_virt_memory_access(struct target *target, target_addr_t address
 static int riscv_read_phys_memory(struct target *target, target_addr_t phys_address,
 			uint32_t size, uint32_t count, uint8_t *buffer)
 {
-	const riscv_mem_access_args_t args = {
+	const struct riscv_mem_access_args args = {
 		.address = phys_address,
 		.read_buffer = buffer,
 		.size = size,
@@ -3402,7 +3400,7 @@ static int riscv_read_phys_memory(struct target *target, target_addr_t phys_addr
 static int riscv_write_phys_memory(struct target *target, target_addr_t phys_address,
 			uint32_t size, uint32_t count, const uint8_t *buffer)
 {
-	const riscv_mem_access_args_t args = {
+	const struct riscv_mem_access_args args = {
 		.address = phys_address,
 		.write_buffer = buffer,
 		.size = size,
@@ -3414,7 +3412,7 @@ static int riscv_write_phys_memory(struct target *target, target_addr_t phys_add
 	return r->access_memory(target, args);
 }
 
-static int riscv_rw_memory(struct target *target, const riscv_mem_access_args_t args)
+static int riscv_rw_memory(struct target *target, const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 
@@ -3456,7 +3454,7 @@ static int riscv_rw_memory(struct target *target, const riscv_mem_access_args_t 
 				(RISCV_PGSIZE - RISCV_PGOFFSET(current_address))
 				/ args.size);
 
-		riscv_mem_access_args_t current_access = args;
+		struct riscv_mem_access_args current_access = args;
 		current_access.address = physical_addr;
 		current_access.count = chunk_count;
 		if (is_write)
@@ -3477,7 +3475,7 @@ static int riscv_rw_memory(struct target *target, const riscv_mem_access_args_t 
 static int riscv_read_memory(struct target *target, target_addr_t address,
 		uint32_t size, uint32_t count, uint8_t *buffer)
 {
-	const riscv_mem_access_args_t args = {
+	const struct riscv_mem_access_args args = {
 		.address = address,
 		.read_buffer = buffer,
 		.size = size,
@@ -3491,7 +3489,7 @@ static int riscv_read_memory(struct target *target, target_addr_t address,
 static int riscv_write_memory(struct target *target, target_addr_t address,
 		uint32_t size, uint32_t count, const uint8_t *buffer)
 {
-	const riscv_mem_access_args_t args = {
+	const struct riscv_mem_access_args args = {
 		.address = address,
 		.write_buffer = buffer,
 		.size = size,
@@ -3548,8 +3546,7 @@ static int riscv_get_gdb_reg_list_internal(struct target *target,
 		if (is_read &&
 				target->reg_cache->reg_list[i].exist &&
 				!target->reg_cache->reg_list[i].valid) {
-			if (target->reg_cache->reg_list[i].type->get(
-						&target->reg_cache->reg_list[i]) != ERROR_OK)
+			if (target->reg_cache->reg_list[i].type->get(&target->reg_cache->reg_list[i]) != ERROR_OK)
 				return ERROR_FAIL;
 		}
 	}
@@ -4008,8 +4005,8 @@ static int sample_memory(struct target *target)
 					r->sample_buf.used + 1 + r->sample_config.bucket[i].size_bytes < r->sample_buf.size) {
 				assert(i < RISCV_SAMPLE_BUF_TIMESTAMP_BEFORE);
 				r->sample_buf.buf[r->sample_buf.used] = i;
-				result = riscv_read_phys_memory(
-					target, r->sample_config.bucket[i].address,
+				result = riscv_read_phys_memory(target,
+					r->sample_config.bucket[i].address,
 					r->sample_config.bucket[i].size_bytes, 1,
 					r->sample_buf.buf + r->sample_buf.used + 1);
 				if (result == ERROR_OK)
@@ -4497,7 +4494,7 @@ static int parse_reg_ranges_impl(struct list_head *ranges, char *args,
 		/* Check for overlap, name uniqueness. */
 		range_list_t *entry;
 		list_for_each_entry(entry, ranges, list) {
-			if ((entry->low <= high) && (low <= entry->high)) {
+			if (entry->low <= high && low <= entry->high) {
 				if (low == high)
 					LOG_WARNING("Duplicate %s register number - "
 							"Register %u has already been exposed previously", reg_type, low);
@@ -4624,10 +4621,10 @@ COMMAND_HANDLER(riscv_authdata_read)
 			return ERROR_FAIL;
 		command_print_sameline(CMD, "0x%08" PRIx32, value);
 		return ERROR_OK;
-	} else {
-		LOG_TARGET_ERROR(target, "authdata_read is not implemented for this target.");
-		return ERROR_FAIL;
 	}
+
+	LOG_TARGET_ERROR(target, "authdata_read is not implemented for this target.");
+	return ERROR_FAIL;
 }
 
 COMMAND_HANDLER(riscv_authdata_write)
@@ -5225,7 +5222,7 @@ COMMAND_HANDLER(handle_repeat_read)
 		LOG_ERROR("malloc failed");
 		return ERROR_FAIL;
 	}
-	const riscv_mem_access_args_t args = {
+	const struct riscv_mem_access_args args = {
 		.address = address,
 		.read_buffer = buffer,
 		.size = size,
@@ -5233,10 +5230,8 @@ COMMAND_HANDLER(handle_repeat_read)
 		.increment = 0,
 	};
 	int result = r->access_memory(target, args);
-	if (result == ERROR_OK) {
-		target_handle_md_output(cmd, target, address, size, count, buffer,
-			false);
-	}
+	if (result == ERROR_OK)
+		target_handle_md_output(cmd, target, address, size, count, buffer, false);
 	free(buffer);
 	return result;
 }
@@ -5562,7 +5557,7 @@ COMMAND_HANDLER(handle_riscv_virt2phys_mode)
 {
 	struct riscv_info *info = riscv_info(get_current_target(CMD_CTX));
 	if (CMD_ARGC == 0) {
-		riscv_virt2phys_mode_t mode = info->virt2phys_mode;
+		enum riscv_virt2phys_mode mode = info->virt2phys_mode;
 		command_print(CMD, "%s", riscv_virt2phys_mode_to_str(mode));
 		return ERROR_OK;
 	}

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -47,26 +47,26 @@ typedef uint64_t riscv_reg_t;
 typedef uint32_t riscv_insn_t;
 typedef uint64_t riscv_addr_t;
 
-typedef enum {
+enum yes_no_maybe {
 	YNM_MAYBE,
 	YNM_YES,
 	YNM_NO
-} yes_no_maybe_t;
+};
 
-typedef enum riscv_mem_access_method {
+enum riscv_mem_access_method {
 	RISCV_MEM_ACCESS_PROGBUF,
 	RISCV_MEM_ACCESS_SYSBUS,
 	RISCV_MEM_ACCESS_ABSTRACT,
 	RISCV_MEM_ACCESS_MAX_METHODS_NUM
-} riscv_mem_access_method_t;
+};
 
-typedef enum riscv_virt2phys_mode {
+enum riscv_virt2phys_mode {
 	RISCV_VIRT2PHYS_MODE_HW,
 	RISCV_VIRT2PHYS_MODE_SW,
 	RISCV_VIRT2PHYS_MODE_OFF
-} riscv_virt2phys_mode_t;
+};
 
-const char *riscv_virt2phys_mode_to_str(riscv_virt2phys_mode_t mode);
+const char *riscv_virt2phys_mode_to_str(enum riscv_virt2phys_mode mode);
 
 enum riscv_halt_reason {
 	RISCV_HALT_INTERRUPT,
@@ -133,7 +133,7 @@ struct reg_name_table {
 	char **reg_names;
 };
 
-typedef struct riscv_mem_access_args {
+struct riscv_mem_access_args {
 	target_addr_t address;
 
 	const uint8_t *write_buffer;
@@ -142,23 +142,23 @@ typedef struct riscv_mem_access_args {
 	uint32_t size;
 	uint32_t count;
 	uint32_t increment;
-} riscv_mem_access_args_t;
+};
 
 static inline bool
-riscv_mem_access_is_valid(const riscv_mem_access_args_t args)
+riscv_mem_access_is_valid(const struct riscv_mem_access_args args)
 {
 	return !args.read_buffer != !args.write_buffer;
 }
 
 static inline bool
-riscv_mem_access_is_read(const riscv_mem_access_args_t args)
+riscv_mem_access_is_read(const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 	return !args.write_buffer && args.read_buffer;
 }
 
 static inline bool
-riscv_mem_access_is_write(const riscv_mem_access_args_t args)
+riscv_mem_access_is_write(const struct riscv_mem_access_args args)
 {
 	assert(riscv_mem_access_is_valid(args));
 	return !args.read_buffer && args.write_buffer;
@@ -223,7 +223,7 @@ struct riscv_info {
 	int64_t trigger_hit;
 
 	/* The configured approach to translate virtual addresses to physical */
-	riscv_virt2phys_mode_t virt2phys_mode;
+	enum riscv_virt2phys_mode virt2phys_mode;
 
 	bool triggers_enumerated;
 
@@ -303,7 +303,7 @@ struct riscv_info {
 						 riscv_sample_config_t *config,
 						 int64_t until_ms);
 
-	int (*access_memory)(struct target *target, const riscv_mem_access_args_t args);
+	int (*access_memory)(struct target *target, const struct riscv_mem_access_args args);
 
 	unsigned int (*data_bits)(struct target *target);
 
@@ -330,7 +330,7 @@ struct riscv_info {
 	bool *reserved_triggers;
 
 	/* Memory access methods to use, ordered by priority, highest to lowest. */
-	riscv_mem_access_method_t mem_access_methods[RISCV_MEM_ACCESS_MAX_METHODS_NUM];
+	enum riscv_mem_access_method mem_access_methods[RISCV_MEM_ACCESS_MAX_METHODS_NUM];
 
 	unsigned int num_enabled_mem_access_methods;
 
@@ -356,7 +356,7 @@ struct riscv_info {
 	/* Track when we were last asked to do something substantial. */
 	int64_t last_activity;
 
-	yes_no_maybe_t vsew64_supported;
+	enum yes_no_maybe vsew64_supported;
 
 	bool range_trigger_fallback_encountered;
 


### PR DESCRIPTION
Adjust code to meet upstream OpenOCD's coding style requests (in particular "no new typedefs")