### PR TITLE
target/riscv: improve error messaging in case `sbasize` is zero

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2610,8 +2610,8 @@ static int sample_memory_bus_v1(struct target *target,
 {
 	RISCV013_INFO(info);
 	unsigned int sbasize = get_field(info->sbcs, DM_SBCS_SBASIZE);
-	if (sbasize > 64) {
-		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for sbasize <= 64.");
+	if (sbasize == 0 || sbasize > 64) {
+		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for non-zero sbasize <= 64.");
 		return ERROR_NOT_IMPLEMENTED;
 	}
 


### PR DESCRIPTION
From: Sriram Shanmuga <sriramharshalee@gmail.com>

RISC-V Debug Specification v1.0 [3.14.22. System Bus Access Control and Status (`sbcs`, at 0x38)] states in `sbasize` field description:
> Width of system bus addresses in bits. (0 indicates there is no bus
access support.)

Before the patch, the error message did not include the information about `sbcs.sbasize` being zero wich made it quite undescriptive:
```
[riscv.cpu] Turning off memory sampling because it failed.

```

Fixes #1270

Change-Id: I5402dd57dc9a81f65ee4c67d24e11c366006427c