### PR TITLE
drivers/jtag_dpi: fix wraparound bug in runtest

### DIFF
--- a/src/jtag/drivers/jtag_dpi.c
+++ b/src/jtag/drivers/jtag_dpi.c
@@ -189,7 +189,7 @@ static int jtag_dpi_runtest(unsigned int num_cycles)
 		return ERROR_FAIL;
 	}
 	snprintf(buf, sizeof(buf), "ib %d\n", num_bits);
-	while (num_cycles > 0) {
+	for (unsigned int cycle = 0; cycle < num_cycles; cycle += num_bits + 6) {
 		ret = write_sock(buf, strlen(buf));
 		if (ret != ERROR_OK) {
 			LOG_ERROR("write_sock() fail, file %s, line %d",
@@ -208,8 +208,6 @@ static int jtag_dpi_runtest(unsigned int num_cycles)
 				__FILE__, __LINE__);
 			goto out;
 		}
-
-		num_cycles -= num_bits + 6;
 	}
 
 out:


### PR DESCRIPTION
Commit [#0847a4d](https://github.com/riscv-collab/riscv-openocd/commit/0847a4d7fb9809a9bb36ba0965f43cb9d43ca2f3#diff-e1649ee658f67d11f42ab46e1600b72e84ece6d68270323c2e41a63c20c4e9d5) introduced bug when changing loop variable from `int` to `unsigned int`. Instead of getting negative and terminating the loop, the value would wrap around to `INT_MAX` and seemingly never finish.

Fixes #1279 