### PR TITLE
target/riscv: hard reset DTM if dmistat is busy

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2016,6 +2016,12 @@ static int examine(struct target *target)
 		return ERROR_FAIL;
 	}
 
+	if (get_field(dtmcontrol, DTM_DTMCS_DMISTAT) != DTM_DMI_OP_SUCCESS) {
+		if (dtmcs_scan(target->tap, DTM_DTMCS_DTMHARDRESET,
+				NULL /* discard result */) != ERROR_OK)
+			return ERROR_FAIL;
+	}
+
 	riscv013_info_t *info = get_info(target);
 
 	info->index = target->coreid;


### PR DESCRIPTION
Due to certain reasons, the DMI scan is busy, leading to a timeout and exit. When restarting OpenCD, a hard reset of the DTM is required.