### PR TITLE
target/riscv: fix potential UB reported by ubsan in ac cache lookup

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -201,6 +201,8 @@ static void ac_cache_insert(struct ac_cache *cache, uint32_t command)
 
 static bool ac_cache_contains(const struct ac_cache *cache, uint32_t command)
 {
+	if (cache->size == 0)
+		return false;
 	return bsearch(&command, cache->commands, cache->size,
 			sizeof(*cache->commands), ac_cache_elem_comparator);
 }


### PR DESCRIPTION
when running OpenOCD built with ubsan enabled I've encountered the following error message:

```
riscv-013.c:204:9: runtime error: null pointer passed as argument 2, which is declared to never be null
```

This is caused by a NULL pointer passed to bsearch function when abstract command cache is still empty. This behavor was introduced in ab97974d1b0d65bde3263596a27cfdbecda6c280