### PR TITLE
Fix: Memory leak in riscv_openocd_step_impl() 

### DIFF
--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -105,7 +105,15 @@ jobs:
           git clone "$RISCV_TESTS_REPO"
           cd riscv-tests
           git checkout "$RISCV_TESTS_REV"
-          git submodule update --init --recursive
+          git submodule update --init --recursive      
+          
+      - name: Run basic debug test under Valgrind (memory leak check)
+        run: |
+          sudo apt-get install -y valgrind
+          echo "Running RISC-V debug test under Valgrind for memory leak detection..."
+          # Run a minimal configuration to detect leaks in riscv_openocd_step_impl()
+          valgrind --leak-check=full --error-exitcode=1 \
+            ./src/openocd -f tcl/interface/jtag_dummy.cfg -f tcl/target/riscv.cfg -c "init; shutdown"
 
       - name: Run Spike32 Tests
         id: spike32-tests

--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -113,7 +113,8 @@ jobs:
           echo "Running RISC-V debug test under Valgrind for memory leak detection..."
           # Run a minimal configuration to detect leaks in riscv_openocd_step_impl()
           valgrind --leak-check=full --error-exitcode=1 \
-            ./src/openocd -f tcl/interface/jtag_dummy.cfg -f tcl/target/riscv.cfg -c "init; shutdown"
+            ./src/openocd -f tcl/target/riscv.cfg -f tcl/target/riscv.cfg -c "init; shutdown"
+
 
       - name: Run Spike32 Tests
         id: spike32-tests

--- a/.github/workflows/spike-openocd-tests.yml
+++ b/.github/workflows/spike-openocd-tests.yml
@@ -113,7 +113,7 @@ jobs:
           echo "Running RISC-V debug test under Valgrind for memory leak detection..."
           # Run a minimal configuration to detect leaks in riscv_openocd_step_impl()
           valgrind --leak-check=full --error-exitcode=1 \
-            ./src/openocd -f tcl/target/riscv.cfg -f tcl/target/riscv.cfg -c "init; shutdown"
+            ./src/openocd -c "interface none; transport select jtag; jtag newtap fake tap -irlen 5; target create fake.core riscv -chain-position fake.tap; init; shutdown"
 
 
       - name: Run Spike32 Tests

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1385,6 +1385,11 @@ static int fpr_read_progbuf(struct target *target, uint64_t *value,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_DEBUG("Skipping FPR read: insufficient progbuf (size=%d)",
+		          get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 
 	const unsigned int freg = number - GDB_REGNO_FPR0;
 
@@ -1417,6 +1422,11 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_DEBUG("Skipping CSR read: insufficient progbuf (size=%d)",
+		          get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1484,6 +1494,11 @@ static int fpr_write_progbuf(struct target *target, enum gdb_regno number,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_DEBUG("Skipping FPR Write: insufficient progbuf (size=%d)",
+		          get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 	const unsigned int freg = number - GDB_REGNO_FPR0;
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
@@ -1559,6 +1574,11 @@ static int csr_write_progbuf(struct target *target, enum gdb_regno number,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_DEBUG("Skipping CSR write: insufficient progbuf (size=%d)",
+		          get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1386,8 +1386,7 @@ static int fpr_read_progbuf(struct target *target, uint64_t *value,
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
 	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_DEBUG("Skipping FPR read: insufficient progbuf (size=%d)",
-		          get_info(target)->progbufsize);
+		LOG_TARGET_DEBUG("Skipping FPR read: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
 		return ERROR_FAIL;
 	}
 
@@ -1423,8 +1422,7 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
 	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_DEBUG("Skipping CSR read: insufficient progbuf (size=%d)",
-		          get_info(target)->progbufsize);
+		LOG_TARGET_DEBUG("Skipping CSR read: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
 		return ERROR_FAIL;
 	}
 
@@ -1440,6 +1438,7 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 
 	return register_read_abstract(target, value, GDB_REGNO_S0) != ERROR_OK;
 }
+
 
 /**
  * This function reads a register by writing a program to program buffer and
@@ -1495,8 +1494,7 @@ static int fpr_write_progbuf(struct target *target, enum gdb_regno number,
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
 	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_DEBUG("Skipping FPR Write: insufficient progbuf (size=%d)",
-		          get_info(target)->progbufsize);
+		LOG_TARGET_DEBUG("Skipping FPR Write: insufficient progbuf (size=%u)",get_info(target)->progbufsize);
 		return ERROR_FAIL;
 	}
 	const unsigned int freg = number - GDB_REGNO_FPR0;
@@ -1530,6 +1528,11 @@ static int fpr_write_progbuf(struct target *target, enum gdb_regno number,
 static int vtype_write_progbuf(struct target *target, riscv_reg_t value)
 {
 	assert(target->state == TARGET_HALTED);
+	/* Ensure program buffer is large enough for 2 instructions */
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_TARGET_DEBUG("Skipping vtype write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1551,6 +1554,11 @@ static int vtype_write_progbuf(struct target *target, riscv_reg_t value)
 static int vl_write_progbuf(struct target *target, riscv_reg_t value)
 {
 	assert(target->state == TARGET_HALTED);
+	/* Ensure program buffer is large enough for 2 instructions */
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_TARGET_DEBUG("Skipping vl write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
+		return ERROR_FAIL;
+	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1575,8 +1583,7 @@ static int csr_write_progbuf(struct target *target, enum gdb_regno number,
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
 	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_DEBUG("Skipping CSR write: insufficient progbuf (size=%d)",
-		          get_info(target)->progbufsize);
+		LOG_TARGET_DEBUG("Skipping CSR write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -1385,10 +1385,6 @@ static int fpr_read_progbuf(struct target *target, uint64_t *value,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping FPR read: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 
 	const unsigned int freg = number - GDB_REGNO_FPR0;
 
@@ -1421,10 +1417,6 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping CSR read: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1438,7 +1430,6 @@ static int csr_read_progbuf(struct target *target, uint64_t *value,
 
 	return register_read_abstract(target, value, GDB_REGNO_S0) != ERROR_OK;
 }
-
 
 /**
  * This function reads a register by writing a program to program buffer and
@@ -1493,10 +1484,6 @@ static int fpr_write_progbuf(struct target *target, enum gdb_regno number,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_FPR0 && number <= GDB_REGNO_FPR31);
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping FPR Write: insufficient progbuf (size=%u)",get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 	const unsigned int freg = number - GDB_REGNO_FPR0;
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
@@ -1528,11 +1515,6 @@ static int fpr_write_progbuf(struct target *target, enum gdb_regno number,
 static int vtype_write_progbuf(struct target *target, riscv_reg_t value)
 {
 	assert(target->state == TARGET_HALTED);
-	/* Ensure program buffer is large enough for 2 instructions */
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping vtype write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1554,11 +1536,6 @@ static int vtype_write_progbuf(struct target *target, riscv_reg_t value)
 static int vl_write_progbuf(struct target *target, riscv_reg_t value)
 {
 	assert(target->state == TARGET_HALTED);
-	/* Ensure program buffer is large enough for 2 instructions */
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping vl write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;
@@ -1582,10 +1559,6 @@ static int csr_write_progbuf(struct target *target, enum gdb_regno number,
 {
 	assert(target->state == TARGET_HALTED);
 	assert(number >= GDB_REGNO_CSR0 && number <= GDB_REGNO_CSR4095);
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_DEBUG("Skipping CSR write: insufficient progbuf (size=%u)", get_info(target)->progbufsize);
-		return ERROR_FAIL;
-	}
 
 	if (riscv013_reg_save(target, GDB_REGNO_S0) != ERROR_OK)
 		return ERROR_FAIL;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -4258,6 +4258,8 @@ _exit:
 		LOG_TARGET_ERROR(target, "Failed to re-enable watchpoints "
 				"after single-step.");
 	}
+	free(wps_to_enable);
+	//no longer needed to be kept
 
 	if (breakpoint && (riscv_add_breakpoint(target, breakpoint) != ERROR_OK)) {
 		success = false;


### PR DESCRIPTION
cleared wps_to_enable in _exit after there is no further reference to it .
The memory allocated at :
<img width="1314" height="736" alt="image" src="https://github.com/user-attachments/assets/467ecca4-5dcd-4d12-87ab-b1fd06691e83" />

```
_exit:
	if (enable_watchpoints(target, wps_to_enable) != ERROR_OK) {
		success = false;
		LOG_TARGET_ERROR(target, "Failed to re-enable watchpoints "
				"after single-step.");
	}
	free(wps_to_enable);
	//no longer needed to be kept
```

Fixes the issue: https://github.com/riscv-collab/riscv-openocd/issues/1284

* Working on the Valgrind part ,will add soon .