### PR TITLE
Update riscv_reg_impl.h to add warning before the assert.

### DIFF
--- a/src/target/riscv/riscv_reg_impl.h
+++ b/src/target/riscv/riscv_reg_impl.h
@@ -27,6 +27,11 @@ static inline bool riscv_reg_impl_is_initialized(const struct reg *reg)
 	assert(reg->arch_info);
 	assert(((riscv_reg_info_t *)reg->arch_info)->target);
 	assert((!reg->exist && !reg->value) || (reg->exist && reg->value));
+	if (!(reg->valid || !reg->dirty)) {
+        LOG_WARNING("riscv_reg_impl_is_initialized: reg cache invalid or dirty (%s)",
+                    reg->name ? reg->name : "unknown");
+        return false;
+    }
 	assert(reg->valid || !reg->dirty);
 	return true;
 }

--- a/src/target/riscv/riscv_reg_impl.h
+++ b/src/target/riscv/riscv_reg_impl.h
@@ -28,10 +28,10 @@ static inline bool riscv_reg_impl_is_initialized(const struct reg *reg)
 	assert(((riscv_reg_info_t *)reg->arch_info)->target);
 	assert((!reg->exist && !reg->value) || (reg->exist && reg->value));
 	if (!(reg->valid || !reg->dirty)) {
-        LOG_WARNING("riscv_reg_impl_is_initialized: reg cache invalid or dirty (%s)",
-                    reg->name ? reg->name : "unknown");
-        return false;
-    }
+		LOG_WARNING("%s: reg cache invalid or dirty (%s)",
+				 __func__, reg->name ? reg->name : "unknown");
+		return false;
+	}
 	assert(reg->valid || !reg->dirty);
 	return true;
 }


### PR DESCRIPTION
* Solves the issue : https://github.com/riscv-collab/riscv-openocd/issues/1309
* Added a warning message incase of force writing a dirty register.
* Helps to see which registers are inconsistent.
* Can later filter by this message if you suspect cache corruption.
* A soft indication if regs are forced before initializaton.