### PR TITLE
Align LOG_* messages with upstream style - remove trailing punctuation (#1212)

### DIFF
--- a/src/target/riscv/batch.c
+++ b/src/target/riscv/batch.c
@@ -55,34 +55,34 @@ struct riscv_batch *riscv_batch_alloc(struct target *target, size_t scans)
 	 * the real DR scan length on the given target) */
 	out->data_out = malloc(sizeof(*out->data_out) * scans * DMI_SCAN_BUF_SIZE);
 	if (!out->data_out) {
-		LOG_ERROR("Failed to allocate data_out in RISC-V batch.");
+		LOG_ERROR("Failed to allocate data_out in RISC-V batch");
 		goto alloc_error;
 	};
 	out->data_in = malloc(sizeof(*out->data_in) * scans * DMI_SCAN_BUF_SIZE);
 	if (!out->data_in) {
-		LOG_ERROR("Failed to allocate data_in in RISC-V batch.");
+		LOG_ERROR("Failed to allocate data_in in RISC-V batch");
 		goto alloc_error;
 	}
 	out->fields = malloc(sizeof(*out->fields) * scans);
 	if (!out->fields) {
-		LOG_ERROR("Failed to allocate fields in RISC-V batch.");
+		LOG_ERROR("Failed to allocate fields in RISC-V batch");
 		goto alloc_error;
 	}
 	out->delay_classes = malloc(sizeof(*out->delay_classes) * scans);
 	if (!out->delay_classes) {
-		LOG_ERROR("Failed to allocate delay_classes in RISC-V batch.");
+		LOG_ERROR("Failed to allocate delay_classes in RISC-V batch");
 		goto alloc_error;
 	}
 	if (bscan_tunnel_ir_width != 0) {
 		out->bscan_ctxt = malloc(sizeof(*out->bscan_ctxt) * scans);
 		if (!out->bscan_ctxt) {
-			LOG_ERROR("Failed to allocate bscan_ctxt in RISC-V batch.");
+			LOG_ERROR("Failed to allocate bscan_ctxt in RISC-V batch");
 			goto alloc_error;
 		}
 	}
 	out->read_keys = malloc(sizeof(*out->read_keys) * scans);
 	if (!out->read_keys) {
-		LOG_ERROR("Failed to allocate read_keys in RISC-V batch.");
+		LOG_ERROR("Failed to allocate read_keys in RISC-V batch");
 		goto alloc_error;
 	}
 

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -426,7 +426,7 @@ static dbus_status_t dbus_scan(struct target *target, uint16_t *address_in,
 		*address_in = 0;
 
 	if (info->addrbits == 0) {
-		LOG_TARGET_ERROR(target, "Can't access DMI because addrbits=0.");
+		LOG_TARGET_ERROR(target, "Can't access DMI because addrbits=0");
 		return DBUS_STATUS_FAILED;
 	}
 
@@ -696,7 +696,7 @@ static int read_bits(struct target *target, bits_t *result)
 			if (status == DBUS_STATUS_BUSY) {
 				if (address_in == (1<<info->addrbits) - 1 &&
 						value == (1ULL<<DBUS_DATA_SIZE) - 1) {
-					LOG_ERROR("TDO seems to be stuck high.");
+					LOG_ERROR("TDO seems to be stuck high");
 					return ERROR_FAIL;
 				}
 				increase_dbus_busy_delay(target);
@@ -897,7 +897,7 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 	int retval = scans_execute(scans);
 	if (retval != ERROR_OK) {
 		scans_delete(scans);
-		LOG_ERROR("JTAG execute failed.");
+		LOG_ERROR("JTAG execute failed");
 		return retval;
 	}
 
@@ -938,7 +938,7 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 			cache_clean(target);
 
 		if (wait_for_debugint_clear(target, true) != ERROR_OK) {
-			LOG_ERROR("Debug interrupt didn't clear.");
+			LOG_ERROR("Debug interrupt didn't clear");
 			dump_debug_ram(target);
 			scans_delete(scans);
 			return ERROR_FAIL;
@@ -959,7 +959,7 @@ static int cache_write(struct target *target, unsigned int address, bool run)
 				increase_interrupt_high_delay(target);
 				/* Slow path wait for it to clear. */
 				if (wait_for_debugint_clear(target, false) != ERROR_OK) {
-					LOG_ERROR("Debug interrupt didn't clear.");
+					LOG_ERROR("Debug interrupt didn't clear");
 					dump_debug_ram(target);
 					scans_delete(scans);
 					return ERROR_FAIL;
@@ -1167,7 +1167,7 @@ static int execute_resume(struct target *target, bool step)
 	cache_invalidate(target);
 
 	if (wait_for_debugint_clear(target, true) != ERROR_OK) {
-		LOG_ERROR("Debug interrupt didn't clear.");
+		LOG_ERROR("Debug interrupt didn't clear");
 		return ERROR_FAIL;
 	}
 
@@ -1980,7 +1980,7 @@ static int assert_reset(struct target *target)
 
 	/* The only assumption we can make is that the TAP was reset. */
 	if (wait_for_debugint_clear(target, true) != ERROR_OK) {
-		LOG_ERROR("Debug interrupt didn't clear.");
+		LOG_ERROR("Debug interrupt didn't clear");
 		return ERROR_FAIL;
 	}
 
@@ -2395,7 +2395,7 @@ static int wait_for_authbusy(struct target *target)
 static int riscv011_authdata_read(struct target *target, uint32_t *value, unsigned int index)
 {
 	if (index > 1) {
-		LOG_ERROR("Spec 0.11 only has a two authdata registers.");
+		LOG_ERROR("Spec 0.11 only has a two authdata registers");
 		return ERROR_FAIL;
 	}
 
@@ -2411,7 +2411,7 @@ static int riscv011_authdata_read(struct target *target, uint32_t *value, unsign
 static int riscv011_authdata_write(struct target *target, uint32_t value, unsigned int index)
 {
 	if (index > 1) {
-		LOG_ERROR("Spec 0.11 only has a two authdata registers.");
+		LOG_ERROR("Spec 0.11 only has a two authdata registers");
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -373,7 +373,7 @@ static void log_debug_reg(struct target *target, enum riscv_debug_reg_ordinal re
 	const riscv_debug_reg_ctx_t context = get_riscv_debug_reg_ctx(target);
 	char * const buf = malloc(riscv_debug_reg_to_s(NULL, reg, context, value, RISCV_DEBUG_REG_HIDE_UNNAMED_0) + 1);
 	if (!buf) {
-		LOG_ERROR("Unable to allocate memory.");
+		LOG_ERROR("Unable to allocate memory");
 		return;
 	}
 	riscv_debug_reg_to_s(buf, reg, context, value, RISCV_DEBUG_REG_HIDE_UNNAMED_0);
@@ -1053,7 +1053,7 @@ static int examine_progbuf(struct target *target)
 
 	if (info->progbufsize < 1) {
 		info->progbuf_writable = YNM_NO;
-		LOG_TARGET_INFO(target, "No program buffer present.");
+		LOG_TARGET_INFO(target, "No program buffer present");
 		return ERROR_OK;
 	}
 
@@ -1774,7 +1774,7 @@ static int halt_set_dcsr_ebreak(struct target *target)
 
 static void deinit_target(struct target *target)
 {
-	LOG_TARGET_DEBUG(target, "Deinitializing target.");
+	LOG_TARGET_DEBUG(target, "Deinitializing target");
 	struct riscv_info *info = target->arch_info;
 	if (!info)
 		return;
@@ -1853,13 +1853,13 @@ static int reset_dm(struct target *target)
 		/* `dmcontrol.hartsel` is not changed. */
 		dmcontrol = (dmcontrol & DM_DMCONTROL_HARTSELLO) |
 			(dmcontrol & DM_DMCONTROL_HARTSELHI);
-		LOG_TARGET_DEBUG(target, "Initiating DM reset.");
+		LOG_TARGET_DEBUG(target, "Initiating DM reset");
 		result = dm_write(target, DM_DMCONTROL, dmcontrol);
 		if (result != ERROR_OK)
 			return result;
 
 		const time_t start = time(NULL);
-		LOG_TARGET_DEBUG(target, "Waiting for the DM to acknowledge reset.");
+		LOG_TARGET_DEBUG(target, "Waiting for the DM to acknowledge reset");
 		do {
 			result = dm_read(target, &dmcontrol, DM_DMCONTROL);
 			if (result != ERROR_OK)
@@ -1872,16 +1872,16 @@ static int reset_dm(struct target *target)
 				return ERROR_TIMEOUT_REACHED;
 			}
 		} while (get_field32(dmcontrol, DM_DMCONTROL_DMACTIVE));
-		LOG_TARGET_DEBUG(target, "DM reset initiated.");
+		LOG_TARGET_DEBUG(target, "DM reset initiated");
 	}
 
-	LOG_TARGET_DEBUG(target, "Activating the DM.");
+	LOG_TARGET_DEBUG(target, "Activating the DM");
 	result = dm_write(target, DM_DMCONTROL, DM_DMCONTROL_DMACTIVE);
 	if (result != ERROR_OK)
 		return result;
 
 	const time_t start = time(NULL);
-	LOG_TARGET_DEBUG(target, "Waiting for the DM to come out of reset.");
+	LOG_TARGET_DEBUG(target, "Waiting for the DM to come out of reset");
 	do {
 		result = dm_read(target, &dmcontrol, DM_DMCONTROL);
 		if (result != ERROR_OK)
@@ -1895,7 +1895,7 @@ static int reset_dm(struct target *target)
 		}
 	} while (!get_field32(dmcontrol, DM_DMCONTROL_DMACTIVE));
 
-	LOG_TARGET_DEBUG(target, "DM successfully reset.");
+	LOG_TARGET_DEBUG(target, "DM successfully reset");
 	dm->was_reset = true;
 	return ERROR_OK;
 }
@@ -1982,7 +1982,7 @@ static int examine_dm(struct target *target)
 	}
 
 	if (dm->hart_count <= 0) {
-		LOG_TARGET_ERROR(target, "No harts found!");
+		LOG_TARGET_ERROR(target, "No harts found");
 		return ERROR_FAIL;
 	}
 
@@ -2172,7 +2172,7 @@ static int examine(struct target *target)
 static int riscv013_authdata_read(struct target *target, uint32_t *value, unsigned int index)
 {
 	if (index > 0) {
-		LOG_TARGET_ERROR(target, "Spec 0.13 only has a single authdata register.");
+		LOG_TARGET_ERROR(target, "Spec 0.13 only has a single authdata register");
 		return ERROR_FAIL;
 	}
 
@@ -2185,7 +2185,7 @@ static int riscv013_authdata_read(struct target *target, uint32_t *value, unsign
 static int riscv013_authdata_write(struct target *target, uint32_t value, unsigned int index)
 {
 	if (index > 0) {
-		LOG_TARGET_ERROR(target, "Spec 0.13 only has a single authdata register.");
+		LOG_TARGET_ERROR(target, "Spec 0.13 only has a single authdata register");
 		return ERROR_FAIL;
 	}
 
@@ -2610,12 +2610,12 @@ static int sample_memory_bus_v1(struct target *target,
 	RISCV013_INFO(info);
 	unsigned int sbasize = get_field(info->sbcs, DM_SBCS_SBASIZE);
 	if (sbasize == 0 || sbasize > 64) {
-		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for non-zero sbasize <= 64.");
+		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for non-zero sbasize <= 64");
 		return ERROR_NOT_IMPLEMENTED;
 	}
 
 	if (get_field(info->sbcs, DM_SBCS_SBVERSION) != 1) {
-		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for SBA version 1.");
+		LOG_TARGET_ERROR(target, "Memory sampling is only implemented for SBA version 1");
 		return ERROR_NOT_IMPLEMENTED;
 	}
 
@@ -2784,7 +2784,7 @@ static int riscv013_get_hart_state(struct target *target, enum riscv_hart_state 
 	if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 		return ERROR_FAIL;
 	if (get_field(dmstatus, DM_DMSTATUS_ANYHAVERESET)) {
-		LOG_TARGET_INFO(target, "Hart unexpectedly reset!");
+		LOG_TARGET_INFO(target, "Hart unexpectedly reset");
 		info->dcsr_ebreak_is_set = false;
 		/* TODO: Can we make this more obvious to eg. a gdb user? */
 		uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE |
@@ -2853,7 +2853,7 @@ static int tick(struct target *target)
 static int init_target(struct command_context *cmd_ctx,
 		struct target *target)
 {
-	LOG_TARGET_DEBUG(target, "Init.");
+	LOG_TARGET_DEBUG(target, "Init");
 	RISCV_INFO(generic_info);
 
 	generic_info->select_target = &dm013_select_target;
@@ -2985,7 +2985,7 @@ static int deassert_reset(struct target *target)
 	const unsigned int orig_base_delay = riscv_scan_get_delay(&info->learned_delays,
 			RISCV_DELAY_BASE);
 	time_t start = time(NULL);
-	LOG_TARGET_DEBUG(target, "Waiting for hart to come out of reset.");
+	LOG_TARGET_DEBUG(target, "Waiting for hart to come out of reset");
 	do {
 		result = dmstatus_read(target, &dmstatus, true);
 		if (result != ERROR_OK)
@@ -3816,7 +3816,7 @@ read_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
 			/* Set arg1 to the address: address + c * size */
 			result = write_abstract_arg(target, 1, args.address + c * args.size, riscv_xlen(target));
 			if (result != ERROR_OK) {
-				LOG_TARGET_ERROR(target, "Failed to write arg1.");
+				LOG_TARGET_ERROR(target, "Failed to write arg1");
 				return mem_access_result(MEM_ACCESS_FAILED_DM_ACCESS_FAILED);
 			}
 		}
@@ -3890,7 +3890,7 @@ write_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
 		riscv_reg_t value = buf_get_u64(p, 0, 8 * args.size);
 		result = write_abstract_arg(target, 0, value, riscv_xlen(target));
 		if (result != ERROR_OK) {
-			LOG_TARGET_ERROR(target, "Failed to write arg0.");
+			LOG_TARGET_ERROR(target, "Failed to write arg0");
 			return mem_access_result(MEM_ACCESS_FAILED_DM_ACCESS_FAILED);
 		}
 
@@ -3899,7 +3899,7 @@ write_memory_abstract(struct target *target, const riscv_mem_access_args_t args)
 			/* Set arg1 to the address: address + c * size */
 			result = write_abstract_arg(target, 1, args.address + c * args.size, riscv_xlen(target));
 			if (result != ERROR_OK) {
-				LOG_TARGET_ERROR(target, "Failed to write arg1.");
+				LOG_TARGET_ERROR(target, "Failed to write arg1");
 				return mem_access_result(MEM_ACCESS_FAILED_DM_ACCESS_FAILED);
 			}
 		}
@@ -4749,7 +4749,7 @@ static int write_memory_bus_v1(struct target *target, const riscv_mem_access_arg
 		bool dmi_busy_encountered = riscv_batch_was_batch_busy(batch);
 		riscv_batch_free(batch);
 		if (dmi_busy_encountered)
-			LOG_TARGET_DEBUG(target, "DMI busy encountered during system bus write.");
+			LOG_TARGET_DEBUG(target, "DMI busy encountered during system bus write");
 
 		result = read_sbcs_nonbusy(target, &sbcs);
 		if (result != ERROR_OK)
@@ -4757,7 +4757,7 @@ static int write_memory_bus_v1(struct target *target, const riscv_mem_access_arg
 
 		if (get_field(sbcs, DM_SBCS_SBBUSYERROR)) {
 			/* We wrote while the target was busy. */
-			LOG_TARGET_DEBUG(target, "Sbbusyerror encountered during system bus write.");
+			LOG_TARGET_DEBUG(target, "Sbbusyerror encountered during system bus write");
 			/* Clear the sticky error flag. */
 			dm_write(target, DM_SBCS, sbcs | DM_SBCS_SBBUSYERROR);
 			/* Slow down before trying again.
@@ -5202,7 +5202,7 @@ static int select_prepped_harts(struct target *target)
 	}
 
 	if (total_selected == 0) {
-		LOG_TARGET_ERROR(target, "No harts were prepped!");
+		LOG_TARGET_ERROR(target, "No harts were prepped");
 		free(hawindow);
 		return ERROR_FAIL;
 	} else if (total_selected == 1) {
@@ -5480,7 +5480,7 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 		bool step)
 {
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Hart is not halted!");
+		LOG_TARGET_ERROR(target, "Hart is not halted");
 		return ERROR_FAIL;
 	}
 

--- a/src/target/riscv/riscv-013_reg.c
+++ b/src/target/riscv/riscv-013_reg.c
@@ -140,7 +140,7 @@ static int examine_vlenb(struct target *target)
 	riscv_reg_t vlenb_val;
 	if (riscv_reg_get(target, &vlenb_val, GDB_REGNO_VLENB) != ERROR_OK) {
 		if (riscv_supports_extension(target, 'V'))
-			LOG_TARGET_WARNING(target, "Couldn't read vlenb; vector register access won't work.");
+			LOG_TARGET_WARNING(target, "Couldn't read vlenb; vector register access won't work");
 		r->vlenb = 0;
 		return riscv_reg_impl_set_exist(target, GDB_REGNO_VLENB, false);
 	}

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -456,7 +456,7 @@ int dtmcs_scan(struct jtag_tap *tap, uint32_t out, uint32_t *in_ptr)
 static struct target_type *get_target_type(struct target *target)
 {
 	if (!target->arch_info) {
-		LOG_TARGET_ERROR(target, "Target has not been initialized.");
+		LOG_TARGET_ERROR(target, "Target has not been initialized");
 		return NULL;
 	}
 
@@ -479,7 +479,7 @@ static struct riscv_private_config *alloc_default_riscv_private_config(void)
 {
 	struct riscv_private_config * const config = malloc(sizeof(*config));
 	if (!config) {
-		LOG_ERROR("Out of memory!");
+		LOG_ERROR("Out of memory");
 		return NULL;
 	}
 
@@ -501,7 +501,7 @@ static int riscv_create_target(struct target *target)
 	}
 	target->arch_info = calloc(1, sizeof(struct riscv_info));
 	if (!target->arch_info) {
-		LOG_TARGET_ERROR(target, "Failed to allocate RISC-V target structure.");
+		LOG_TARGET_ERROR(target, "Failed to allocate RISC-V target structure");
 		return ERROR_FAIL;
 	}
 	riscv_info_init(target, target->arch_info);
@@ -722,7 +722,7 @@ static void riscv_deinit_target(struct target *target)
 	struct riscv_info *info = target->arch_info;
 	struct target_type *tt = get_target_type(target);
 	if (!tt)
-		LOG_TARGET_ERROR(target, "Could not identify target type.");
+		LOG_TARGET_ERROR(target, "Could not identify target type");
 
 	if (riscv_reg_flush_all(target) != ERROR_OK)
 		LOG_TARGET_ERROR(target, "Failed to flush registers. Ignoring this error.");
@@ -1649,7 +1649,7 @@ static int riscv_add_breakpoint(struct target *target, struct breakpoint *breakp
 		int trigger_idx = find_first_trigger_by_id(target, breakpoint->unique_id);
 		breakpoint_hw_set(breakpoint, trigger_idx);
 	} else {
-		LOG_TARGET_INFO(target, "OpenOCD only supports hardware and software breakpoints.");
+		LOG_TARGET_INFO(target, "OpenOCD only supports hardware and software breakpoints");
 		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}
 	return ERROR_OK;
@@ -1709,7 +1709,7 @@ static int riscv_remove_breakpoint(struct target *target,
 			return result;
 
 	} else {
-		LOG_TARGET_INFO(target, "OpenOCD only supports hardware and software breakpoints.");
+		LOG_TARGET_INFO(target, "OpenOCD only supports hardware and software breakpoints");
 		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}
 
@@ -2473,7 +2473,7 @@ static int riscv_examine(struct target *target)
 {
 	LOG_TARGET_DEBUG(target, "Starting examination");
 	if (target_was_examined(target)) {
-		LOG_TARGET_DEBUG(target, "Target was already examined.");
+		LOG_TARGET_DEBUG(target, "Target was already examined");
 		return ERROR_OK;
 	}
 
@@ -2640,9 +2640,9 @@ static int halt_prep(struct target *target)
 	LOG_TARGET_DEBUG(target, "prep hart, debug_reason=%d", target->debug_reason);
 	r->prepped = false;
 	if (target->state == TARGET_HALTED) {
-		LOG_TARGET_DEBUG(target, "Hart is already halted.");
+		LOG_TARGET_DEBUG(target, "Hart is already halted");
 	} else if (target->state == TARGET_UNAVAILABLE) {
-		LOG_TARGET_DEBUG(target, "Hart is unavailable.");
+		LOG_TARGET_DEBUG(target, "Hart is unavailable");
 	} else {
 		if (r->halt_prep(target) != ERROR_OK)
 			return ERROR_FAIL;
@@ -2660,7 +2660,7 @@ static int riscv_halt_go_all_harts(struct target *target)
 	if (riscv_get_hart_state(target, &state) != ERROR_OK)
 		return ERROR_FAIL;
 	if (state == RISCV_STATE_HALTED) {
-		LOG_TARGET_DEBUG(target, "Hart is already halted.");
+		LOG_TARGET_DEBUG(target, "Hart is already halted");
 		if (target->state != TARGET_HALTED) {
 			target->state = TARGET_HALTED;
 			enum riscv_halt_reason halt_reason = riscv_halt_reason(target);
@@ -2762,7 +2762,7 @@ static int riscv_assert_reset(struct target *target)
 		return ERROR_FAIL;
 
 	if (riscv_reg_cache_any_dirty(target, LOG_LVL_INFO))
-		LOG_TARGET_INFO(target, "Discarding values of dirty registers.");
+		LOG_TARGET_INFO(target, "Discarding values of dirty registers");
 
 	riscv_reg_cache_invalidate_all(target);
 	return tt->assert_reset(target);
@@ -2781,7 +2781,7 @@ static int riscv_deassert_reset(struct target *target)
 static int disable_watchpoints(struct target *target, bool *wp_is_set)
 {
 	RISCV_INFO(r);
-	LOG_TARGET_DEBUG(target, "Disabling triggers.");
+	LOG_TARGET_DEBUG(target, "Disabling triggers");
 
 	/* TODO: The algorithm is flawed and may result in a situation described in
 	 * https://github.com/riscv-collab/riscv-openocd/issues/1108
@@ -2859,7 +2859,7 @@ static int resume_prep(struct target *target, bool current,
 			return ERROR_FAIL;
 	}
 
-	LOG_TARGET_DEBUG(target, "Mark as prepped.");
+	LOG_TARGET_DEBUG(target, "Mark as prepped");
 	r->prepped = true;
 
 	return ERROR_OK;
@@ -2981,7 +2981,7 @@ static int riscv_target_resume(struct target *target, bool current,
 		target_addr_t address, bool handle_breakpoints, bool debug_execution)
 {
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Not halted.");
+		LOG_TARGET_ERROR(target, "Not halted");
 		return ERROR_TARGET_NOT_HALTED;
 	}
 	return riscv_resume(target, current, address, handle_breakpoints,
@@ -2992,14 +2992,14 @@ static int riscv_effective_privilege_mode(struct target *target, int *v_mode, in
 {
 	riscv_reg_t priv;
 	if (riscv_reg_get(target, &priv, GDB_REGNO_PRIV) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read priv register.");
+		LOG_TARGET_ERROR(target, "Failed to read priv register");
 		return ERROR_FAIL;
 	}
 	*v_mode = get_field(priv, VIRT_PRIV_V);
 
 	riscv_reg_t mstatus;
 	if (riscv_reg_get(target, &mstatus, GDB_REGNO_MSTATUS) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read mstatus register.");
+		LOG_TARGET_ERROR(target, "Failed to read mstatus register");
 		return ERROR_FAIL;
 	}
 
@@ -3023,7 +3023,7 @@ static int riscv_mmu(struct target *target, int *enabled)
 	/* Don't use MMU in explicit or effective M (machine) mode */
 	riscv_reg_t priv;
 	if (riscv_reg_get(target, &priv, GDB_REGNO_PRIV) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read priv register.");
+		LOG_TARGET_ERROR(target, "Failed to read priv register");
 		return ERROR_FAIL;
 	}
 
@@ -3045,7 +3045,7 @@ static int riscv_mmu(struct target *target, int *enabled)
 		}
 		/* vsatp is identical to satp, so we can use the satp macros. */
 		if (get_field(vsatp, RISCV_SATP_MODE(xlen)) != SATP_MODE_OFF) {
-			LOG_TARGET_DEBUG(target, "VS-stage translation is enabled.");
+			LOG_TARGET_DEBUG(target, "VS-stage translation is enabled");
 			*enabled = 1;
 			return ERROR_OK;
 		}
@@ -3057,10 +3057,10 @@ static int riscv_mmu(struct target *target, int *enabled)
 			return ERROR_FAIL;
 		}
 		if (get_field(hgatp, RISCV_HGATP_MODE(xlen)) != HGATP_MODE_OFF) {
-			LOG_TARGET_DEBUG(target, "G-stage address translation is enabled.");
+			LOG_TARGET_DEBUG(target, "G-stage address translation is enabled");
 			*enabled = 1;
 		} else {
-			LOG_TARGET_DEBUG(target, "No V-mode address translation enabled.");
+			LOG_TARGET_DEBUG(target, "No V-mode address translation enabled");
 		}
 
 		return ERROR_OK;
@@ -3068,21 +3068,21 @@ static int riscv_mmu(struct target *target, int *enabled)
 
 	/* Don't use MMU in explicit or effective M (machine) mode */
 	if (effective_mode == PRV_M) {
-		LOG_TARGET_DEBUG(target, "SATP/MMU ignored in Machine mode.");
+		LOG_TARGET_DEBUG(target, "SATP/MMU ignored in Machine mode");
 		return ERROR_OK;
 	}
 
 	riscv_reg_t satp;
 	if (riscv_reg_get(target, &satp, GDB_REGNO_SATP) != ERROR_OK) {
-		LOG_TARGET_DEBUG(target, "Couldn't read SATP.");
+		LOG_TARGET_DEBUG(target, "Couldn't read SATP");
 		/* If we can't read SATP, then there must not be an MMU. */
 		return ERROR_OK;
 	}
 
 	if (get_field(satp, RISCV_SATP_MODE(xlen)) == SATP_MODE_OFF) {
-		LOG_TARGET_DEBUG(target, "MMU is disabled.");
+		LOG_TARGET_DEBUG(target, "MMU is disabled");
 	} else {
-		LOG_TARGET_DEBUG(target, "MMU is enabled.");
+		LOG_TARGET_DEBUG(target, "MMU is enabled");
 		*enabled = 1;
 	}
 
@@ -3166,7 +3166,7 @@ static int riscv_address_translate(struct target *target,
 	}
 
 	if (i < 0) {
-		LOG_TARGET_ERROR(target, "Couldn't find the PTE.");
+		LOG_TARGET_ERROR(target, "Couldn't find the PTE");
 		return ERROR_FAIL;
 	}
 
@@ -3191,7 +3191,7 @@ static int riscv_virt2phys_v(struct target *target, target_addr_t virtual, targe
 {
 	riscv_reg_t vsatp;
 	if (riscv_reg_get(target, &vsatp, GDB_REGNO_VSATP) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read vsatp register.");
+		LOG_TARGET_ERROR(target, "Failed to read vsatp register");
 		return ERROR_FAIL;
 	}
 	/* vsatp is identical to satp, so we can use the satp macros. */
@@ -3200,7 +3200,7 @@ static int riscv_virt2phys_v(struct target *target, target_addr_t virtual, targe
 	LOG_TARGET_DEBUG(target, "VS-stage translation mode: %d", vsatp_mode);
 	riscv_reg_t hgatp;
 	if (riscv_reg_get(target, &hgatp, GDB_REGNO_HGATP) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read hgatp register.");
+		LOG_TARGET_ERROR(target, "Failed to read hgatp register");
 		return ERROR_FAIL;
 	}
 	int hgatp_mode = get_field(hgatp, RISCV_HGATP_MODE(xlen));
@@ -3310,7 +3310,7 @@ static int riscv_virt2phys(struct target *target, target_addr_t virtual, target_
 
 	riscv_reg_t priv;
 	if (riscv_reg_get(target, &priv, GDB_REGNO_PRIV) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read priv register.");
+		LOG_TARGET_ERROR(target, "Failed to read priv register");
 		return ERROR_FAIL;
 	}
 
@@ -3319,7 +3319,7 @@ static int riscv_virt2phys(struct target *target, target_addr_t virtual, target_
 
 	riscv_reg_t satp_value;
 	if (riscv_reg_get(target, &satp_value, GDB_REGNO_SATP) != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read SATP register.");
+		LOG_TARGET_ERROR(target, "Failed to read SATP register");
 		return ERROR_FAIL;
 	}
 
@@ -3430,7 +3430,7 @@ static int riscv_rw_memory(struct target *target, const riscv_mem_access_args_t 
 		target_addr_t physical_addr;
 		result = target->type->virt2phys(target, current_address, &physical_addr);
 		if (result != ERROR_OK) {
-			LOG_TARGET_ERROR(target, "Address translation failed.");
+			LOG_TARGET_ERROR(target, "Address translation failed");
 			return result;
 		}
 
@@ -3623,7 +3623,7 @@ static int riscv_run_algorithm(struct target *target, int num_mem_params,
 		}
 
 		if (r->number > GDB_REGNO_XPR31) {
-			LOG_TARGET_ERROR(target, "Only GPRs can be use as argument registers.");
+			LOG_TARGET_ERROR(target, "Only GPRs can be use as argument registers");
 			return ERROR_FAIL;
 		}
 
@@ -3817,7 +3817,7 @@ static int riscv_checksum_memory(struct target *target,
 	if (retval == ERROR_OK)
 		*checksum = buf_get_u32(reg_params[0].value, 0, 32);
 	else
-		LOG_TARGET_ERROR(target, "Error executing RISC-V CRC algorithm.");
+		LOG_TARGET_ERROR(target, "Error executing RISC-V CRC algorithm");
 
 	destroy_reg_param(&reg_params[0]);
 	destroy_reg_param(&reg_params[1]);
@@ -3875,7 +3875,7 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 		return ERROR_FAIL;
 
 	if (state == RISCV_STATE_NON_EXISTENT) {
-		LOG_TARGET_ERROR(target, "Hart is non-existent!");
+		LOG_TARGET_ERROR(target, "Hart is non-existent");
 		return ERROR_FAIL;
 	}
 
@@ -3950,7 +3950,7 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 
 			case RISCV_STATE_UNAVAILABLE:
 				LOG_TARGET_DEBUG(target, "  became unavailable");
-				LOG_TARGET_INFO(target, "became unavailable.");
+				LOG_TARGET_INFO(target, "became unavailable");
 				target->state = TARGET_UNAVAILABLE;
 				if (r->handle_became_unavailable &&
 						r->handle_became_unavailable(target, previous_riscv_state) != ERROR_OK)
@@ -3958,7 +3958,7 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 				break;
 
 			case RISCV_STATE_NON_EXISTENT:
-				LOG_TARGET_ERROR(target, "Hart is non-existent!");
+				LOG_TARGET_ERROR(target, "Hart is non-existent");
 				target->state = TARGET_UNAVAILABLE;
 				break;
 		}
@@ -4008,7 +4008,7 @@ static int sample_memory(struct target *target)
 exit:
 	riscv_sample_buf_maybe_add_timestamp(target, false);
 	if (result != ERROR_OK) {
-		LOG_TARGET_INFO(target, "Turning off memory sampling because it failed.");
+		LOG_TARGET_INFO(target, "Turning off memory sampling because it failed");
 		r->sample_config.enabled = false;
 	}
 	return result;
@@ -4017,7 +4017,7 @@ exit:
 /*** OpenOCD Interface ***/
 int riscv_openocd_poll(struct target *target)
 {
-	LOG_TARGET_DEBUG(target, "Polling all harts.");
+	LOG_TARGET_DEBUG(target, "Polling all harts");
 
 	struct riscv_info *i = riscv_info(target);
 
@@ -4129,12 +4129,12 @@ int riscv_openocd_poll(struct target *target)
 		 *
 		 * Poll again so that the true halt reason can be discovered (e.g. CSR_DCSR_CAUSE_EBREAK) */
 		if (halted == cause_groups) {
-			LOG_TARGET_DEBUG(target, "The harts appear to just be in the process of halting due to a halt group.");
+			LOG_TARGET_DEBUG(target, "The harts appear to just be in the process of halting due to a halt group");
 			if (i->halt_group_repoll_count < RISCV_HALT_GROUP_REPOLL_LIMIT) {
 				/* Wait a little, then re-poll. */
 				i->halt_group_repoll_count++;
 				alive_sleep(10);
-				LOG_TARGET_DEBUG(target, "Re-polling the state of the SMP group.");
+				LOG_TARGET_DEBUG(target, "Re-polling the state of the SMP group");
 				return riscv_openocd_poll(target);
 			}
 			/* We have already re-polled multiple times but the halt group is still inconsistent. */
@@ -4226,14 +4226,14 @@ static int riscv_openocd_step_impl(struct target *target, bool current,
 		/* Disable Interrupts before stepping. */
 		if (riscv_interrupts_disable(target, &current_mstatus) != ERROR_OK) {
 			success = false;
-			LOG_TARGET_ERROR(target, "Unable to disable interrupts.");
+			LOG_TARGET_ERROR(target, "Unable to disable interrupts");
 			goto _exit;
 		}
 	}
 
 	if (riscv_step_rtos_hart(target) != ERROR_OK) {
 		success = false;
-		LOG_TARGET_ERROR(target, "Unable to step rtos hart.");
+		LOG_TARGET_ERROR(target, "Unable to step rtos hart");
 	}
 
 	if (riscv_reg_cache_any_dirty(target, LOG_LVL_ERROR)) {
@@ -4249,7 +4249,7 @@ static int riscv_openocd_step_impl(struct target *target, bool current,
 	if (info->isrmask_mode == RISCV_ISRMASK_STEPONLY)
 		if (riscv_interrupts_restore(target, current_mstatus) != ERROR_OK) {
 			success = false;
-			LOG_TARGET_ERROR(target, "Unable to restore interrupts.");
+			LOG_TARGET_ERROR(target, "Unable to restore interrupts");
 		}
 
 _exit:
@@ -4261,7 +4261,7 @@ _exit:
 
 	if (breakpoint && (riscv_add_breakpoint(target, breakpoint) != ERROR_OK)) {
 		success = false;
-		LOG_TARGET_ERROR(target, "Unable to restore the disabled breakpoint.");
+		LOG_TARGET_ERROR(target, "Unable to restore the disabled breakpoint");
 	}
 
 	if (success) {
@@ -4347,7 +4347,7 @@ COMMAND_HANDLER(riscv_set_mem_access)
 		}
 	}
 	if (progbuf_cnt > 1 || sysbus_cnt > 1 || abstract_cnt > 1) {
-		LOG_ERROR("Syntax error - duplicate arguments to `riscv set_mem_access`.");
+		LOG_ERROR("Syntax error - duplicate arguments to `riscv set_mem_access`");
 		return ERROR_COMMAND_SYNTAX_ERROR;
 	}
 
@@ -4593,13 +4593,13 @@ COMMAND_HANDLER(riscv_authdata_read)
 
 	struct target *target = get_current_target(CMD_CTX);
 	if (!target) {
-		LOG_ERROR("target is NULL!");
+		LOG_ERROR("target is NULL");
 		return ERROR_FAIL;
 	}
 
 	RISCV_INFO(r);
 	if (!r) {
-		LOG_TARGET_ERROR(target, "riscv_info is NULL!");
+		LOG_TARGET_ERROR(target, "riscv_info is NULL");
 		return ERROR_FAIL;
 	}
 
@@ -4610,7 +4610,7 @@ COMMAND_HANDLER(riscv_authdata_read)
 		command_print_sameline(CMD, "0x%08" PRIx32, value);
 		return ERROR_OK;
 	} else {
-		LOG_TARGET_ERROR(target, "authdata_read is not implemented for this target.");
+		LOG_TARGET_ERROR(target, "authdata_read is not implemented for this target");
 		return ERROR_FAIL;
 	}
 }
@@ -4634,7 +4634,7 @@ COMMAND_HANDLER(riscv_authdata_write)
 	RISCV_INFO(r);
 
 	if (!r->authdata_write) {
-		LOG_TARGET_ERROR(target, "authdata_write is not implemented for this target.");
+		LOG_TARGET_ERROR(target, "authdata_write is not implemented for this target");
 		return ERROR_FAIL;
 	}
 
@@ -4653,16 +4653,16 @@ uint32_t riscv_get_dmi_address(const struct target *target, uint32_t dm_address)
 static int riscv_dmi_read(struct target *target, uint32_t *value, uint32_t address)
 {
 	if (!target) {
-		LOG_ERROR("target is NULL!");
+		LOG_ERROR("target is NULL");
 		return ERROR_FAIL;
 	}
 	RISCV_INFO(r);
 	if (!r) {
-		LOG_TARGET_ERROR(target, "riscv_info is NULL!");
+		LOG_TARGET_ERROR(target, "riscv_info is NULL");
 		return ERROR_FAIL;
 	}
 	if (!r->dmi_read) {
-		LOG_TARGET_ERROR(target, "dmi_read is not implemented.");
+		LOG_TARGET_ERROR(target, "dmi_read is not implemented");
 		return ERROR_FAIL;
 	}
 	return r->dmi_read(target, value, address);
@@ -4671,16 +4671,16 @@ static int riscv_dmi_read(struct target *target, uint32_t *value, uint32_t addre
 static int riscv_dmi_write(struct target *target, uint32_t dmi_address, uint32_t value)
 {
 	if (!target) {
-		LOG_ERROR("target is NULL!");
+		LOG_ERROR("target is NULL");
 		return ERROR_FAIL;
 	}
 	RISCV_INFO(r);
 	if (!r) {
-		LOG_TARGET_ERROR(target, "riscv_info is NULL!");
+		LOG_TARGET_ERROR(target, "riscv_info is NULL");
 		return ERROR_FAIL;
 	}
 	if (!r->dmi_write) {
-		LOG_TARGET_ERROR(target, "dmi_write is not implemented.");
+		LOG_TARGET_ERROR(target, "dmi_write is not implemented");
 		return ERROR_FAIL;
 	}
 	const int result = r->dmi_write(target, dmi_address, value);
@@ -5046,14 +5046,14 @@ COMMAND_HANDLER(riscv_itrigger)
 		}
 		int result = maybe_add_trigger_t4(target, vs, vu, nmi, m, s, u, interrupts, ITRIGGER_UNIQUE_ID);
 		if (result != ERROR_OK)
-			LOG_TARGET_ERROR(target, "Failed to set requested itrigger.");
+			LOG_TARGET_ERROR(target, "Failed to set requested itrigger");
 		return result;
 
 	} else if (!strcmp(CMD_ARGV[0], "clear")) {
 		return riscv_clear_trigger(CMD, ITRIGGER_UNIQUE_ID, "itrigger");
 
 	} else {
-		LOG_ERROR("First argument must be either 'set' or 'clear'.");
+		LOG_ERROR("First argument must be either 'set' or 'clear'");
 		return ERROR_COMMAND_SYNTAX_ERROR;
 	}
 	return ERROR_OK;
@@ -5111,14 +5111,14 @@ COMMAND_HANDLER(riscv_icount)
 		}
 		int result = maybe_add_trigger_t3(target, vs, vu, m, s, u, pending, count, ICOUNT_UNIQUE_ID);
 		if (result != ERROR_OK)
-			LOG_TARGET_ERROR(target, "Failed to set requested icount trigger.");
+			LOG_TARGET_ERROR(target, "Failed to set requested icount trigger");
 		return result;
 
 	} else if (!strcmp(CMD_ARGV[0], "clear")) {
 		return riscv_clear_trigger(CMD, ICOUNT_UNIQUE_ID, "icount trigger");
 
 	} else {
-		LOG_ERROR("First argument must be either 'set' or 'clear'.");
+		LOG_ERROR("First argument must be either 'set' or 'clear'");
 		return ERROR_COMMAND_SYNTAX_ERROR;
 	}
 	return ERROR_OK;
@@ -5173,14 +5173,14 @@ COMMAND_HANDLER(riscv_etrigger)
 		}
 		int result = maybe_add_trigger_t5(target, vs, vu, m, s, u, exception_codes, ETRIGGER_UNIQUE_ID);
 		if (result != ERROR_OK)
-			LOG_TARGET_ERROR(target, "Failed to set requested etrigger.");
+			LOG_TARGET_ERROR(target, "Failed to set requested etrigger");
 		return result;
 
 	} else if (!strcmp(CMD_ARGV[0], "clear")) {
 		return riscv_clear_trigger(CMD, ETRIGGER_UNIQUE_ID, "etrigger");
 
 	} else {
-		LOG_ERROR("First argument must be either 'set' or 'clear'.");
+		LOG_ERROR("First argument must be either 'set' or 'clear'");
 		return ERROR_COMMAND_SYNTAX_ERROR;
 	}
 	return ERROR_OK;
@@ -5264,7 +5264,7 @@ COMMAND_HANDLER(handle_memory_sample_command)
 			COMMAND_PARSE_NUMBER(u32, CMD_ARGV[2], r->sample_config.bucket[bucket].size_bytes);
 			if (r->sample_config.bucket[bucket].size_bytes != 4 &&
 					r->sample_config.bucket[bucket].size_bytes != 8) {
-				LOG_TARGET_ERROR(target, "Only 4-byte and 8-byte sizes are supported.");
+				LOG_TARGET_ERROR(target, "Only 4-byte and 8-byte sizes are supported");
 				return ERROR_COMMAND_ARGUMENT_INVALID;
 			}
 		} else {
@@ -5310,7 +5310,7 @@ COMMAND_HANDLER(handle_dump_sample_buf_command)
 		unsigned char *encoded = base64_encode(r->sample_buf.buf,
 									  r->sample_buf.used, NULL);
 		if (!encoded) {
-			LOG_TARGET_ERROR(target, "Failed base64 encode!");
+			LOG_TARGET_ERROR(target, "Failed base64 encode");
 			result = ERROR_FAIL;
 			goto error;
 		}
@@ -5440,11 +5440,11 @@ COMMAND_HANDLER(riscv_exec_progbuf)
 	riscv_reg_cache_invalidate_all(target);
 
 	if (error != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "exec_progbuf: Program buffer execution failed.");
+		LOG_TARGET_ERROR(target, "exec_progbuf: Program buffer execution failed");
 		return ERROR_FAIL;
 	}
 
-	LOG_TARGET_DEBUG(target, "exec_progbuf: Program buffer execution successful.");
+	LOG_TARGET_DEBUG(target, "exec_progbuf: Program buffer execution successful");
 
 	return ERROR_OK;
 }
@@ -5986,18 +5986,18 @@ static int riscv_resume_go_all_harts(struct target *target)
 		if (r->resume_go(target) != ERROR_OK)
 			return ERROR_FAIL;
 	} else {
-		LOG_TARGET_DEBUG(target, "Hart requested resume, but was already resumed.");
+		LOG_TARGET_DEBUG(target, "Hart requested resume, but was already resumed");
 	}
 	return ERROR_OK;
 }
 
 static int riscv_interrupts_disable(struct target *target, riscv_reg_t *old_mstatus)
 {
-	LOG_TARGET_DEBUG(target, "Disabling interrupts.");
+	LOG_TARGET_DEBUG(target, "Disabling interrupts");
 	riscv_reg_t current_mstatus;
 	int ret = riscv_reg_get(target, &current_mstatus, GDB_REGNO_MSTATUS);
 	if (ret != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read mstatus!");
+		LOG_TARGET_ERROR(target, "Failed to read mstatus");
 		return ret;
 	}
 	if (old_mstatus)
@@ -6007,17 +6007,17 @@ static int riscv_interrupts_disable(struct target *target, riscv_reg_t *old_msta
 
 static int riscv_interrupts_restore(struct target *target, riscv_reg_t old_mstatus)
 {
-	LOG_TARGET_DEBUG(target, "Restoring interrupts.");
+	LOG_TARGET_DEBUG(target, "Restoring interrupts");
 	riscv_reg_t current_mstatus;
 	int ret = riscv_reg_get(target, &current_mstatus, GDB_REGNO_MSTATUS);
 	if (ret != ERROR_OK) {
-		LOG_TARGET_ERROR(target, "Failed to read mstatus!");
+		LOG_TARGET_ERROR(target, "Failed to read mstatus");
 		return ret;
 	}
 	if ((current_mstatus & mstatus_ie_mask) != 0) {
-		LOG_TARGET_WARNING(target, "Interrupt enable bits in mstatus changed during single-step.");
-		LOG_TARGET_WARNING(target, "OpenOCD might have affected the program when it restored the interrupt bits after single-step.");
-		LOG_TARGET_WARNING(target, "Hint: Use 'riscv set_maskisr off' to prevent OpenOCD from touching mstatus during single-step.");
+		LOG_TARGET_WARNING(target, "Interrupt enable bits in mstatus changed during single-step");
+		LOG_TARGET_WARNING(target, "OpenOCD might have affected the program when it restored the interrupt bits after single-step");
+		LOG_TARGET_WARNING(target, "Hint: Use 'riscv set_maskisr off' to prevent OpenOCD from touching mstatus during single-step");
 	}
 	return riscv_reg_set(target, GDB_REGNO_MSTATUS, current_mstatus | (old_mstatus & mstatus_ie_mask));
 }
@@ -6025,17 +6025,17 @@ static int riscv_interrupts_restore(struct target *target, riscv_reg_t old_mstat
 static int riscv_step_rtos_hart(struct target *target)
 {
 	RISCV_INFO(r);
-	LOG_TARGET_DEBUG(target, "Stepping.");
+	LOG_TARGET_DEBUG(target, "Stepping");
 
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Hart isn't halted before single step!");
+		LOG_TARGET_ERROR(target, "Hart isn't halted before single step");
 		return ERROR_FAIL;
 	}
 	r->on_step(target);
 	if (r->step_current_hart(target) != ERROR_OK)
 		return ERROR_FAIL;
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Hart was not halted after single step!");
+		LOG_TARGET_ERROR(target, "Hart was not halted after single step");
 		return ERROR_FAIL;
 	}
 	return ERROR_OK;
@@ -6077,7 +6077,7 @@ static enum riscv_halt_reason riscv_halt_reason(struct target *target)
 {
 	RISCV_INFO(r);
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Hart is not halted!");
+		LOG_TARGET_ERROR(target, "Hart is not halted");
 		return RISCV_HALT_UNKNOWN;
 	}
 	return r->halt_reason(target);
@@ -6218,7 +6218,7 @@ int riscv_enumerate_triggers(struct target *target)
 		return ERROR_OK;
 
 	if (target->state != TARGET_HALTED) {
-		LOG_TARGET_ERROR(target, "Unable to enumerate triggers: target not halted.");
+		LOG_TARGET_ERROR(target, "Unable to enumerate triggers: target not halted");
 		return ERROR_FAIL;
 	}
 
@@ -6246,7 +6246,7 @@ int riscv_enumerate_triggers(struct target *target)
 		LOG_TARGET_DEBUG(target, "Trigger tinfo.version = %d.", r->tinfo_version);
 	} else {
 		r->tinfo_version = RISCV_TINFO_VERSION_UNKNOWN;
-		LOG_TARGET_DEBUG(target, "Trigger tinfo.version is unknown.");
+		LOG_TARGET_DEBUG(target, "Trigger tinfo.version is unknown");
 	}
 
 	unsigned int t = 0;

--- a/src/target/riscv/riscv_reg.c
+++ b/src/target/riscv/riscv_reg.c
@@ -129,7 +129,7 @@ static char *init_reg_name(const char *name)
 
 	char * const buf = calloc(size_buf, sizeof(char));
 	if (!buf) {
-		LOG_ERROR("Failed to allocate memory for a register name.");
+		LOG_ERROR("Failed to allocate memory for a register name");
 		return NULL;
 	}
 	strcpy(buf, name);
@@ -160,7 +160,7 @@ static char *init_reg_name_with_prefix(const char *name_prefix,
 
 	char * const buf = calloc(size_buf, sizeof(char));
 	if (!buf) {
-		LOG_ERROR("Failed to allocate memory for a register name.");
+		LOG_ERROR("Failed to allocate memory for a register name");
 		return NULL;
 	}
 	int result = snprintf(buf, size_buf, "%s%d", name_prefix, num);
@@ -588,7 +588,7 @@ static int resize_reg(const struct target *target, uint32_t regno, bool exist,
 	if (reg->exist) {
 		reg->value = malloc(DIV_ROUND_UP(reg->size, 8));
 		if (!reg->value) {
-			LOG_ERROR("Failed to allocate memory.");
+			LOG_ERROR("Failed to allocate memory");
 			return ERROR_FAIL;
 		}
 	} else {
@@ -627,7 +627,7 @@ int riscv_reg_impl_init_cache_entry(struct target *target, uint32_t regno,
 	} else {
 		reg->arch_info = calloc(1, sizeof(riscv_reg_info_t));
 		if (!reg->arch_info) {
-			LOG_ERROR("Out of memory.");
+			LOG_ERROR("Out of memory");
 			return ERROR_FAIL;
 		}
 		riscv_reg_info_t * const reg_arch_info = reg->arch_info;
@@ -901,7 +901,7 @@ void riscv_reg_cache_invalidate_all(struct target *target)
 	if (!target->reg_cache)
 		return;
 
-	LOG_TARGET_DEBUG(target, "Invalidating register cache.");
+	LOG_TARGET_DEBUG(target, "Invalidating register cache");
 	register_cache_invalidate(target->reg_cache);
 }
 


### PR DESCRIPTION
Fixes #1212. Removes trailing period/exclamation from log messages in src/target/riscv/* per OpenOCD C style guide. Multi-sentence messages were left unchanged.