### PR TITLE
target/riscv: handle unavailable harts during reset halt

### DIFF
--- a/doc/openocd.texi
+++ b/doc/openocd.texi
@@ -9548,8 +9548,15 @@ or the @var{address} provided by user.
 @deffnx {Command} {reset halt}
 @deffnx {Command} {reset init}
 Perform as hard a reset as possible, using SRST if possible.
-@emph{All defined targets will be reset, and target
-events will fire during the reset sequence.}
+@emph{The currently selected target's configured reset group will be reset,
+and target events will fire during the reset sequence.}
+
+If the current target is part of an SMP group, all targets in that group are
+reset together. Otherwise only the current target is reset.
+
+Note: if SRST is used, the physical reset signal affects all hardware on the
+board regardless of the SMP group boundary.  Reset event handling and halt
+management, however, are scoped to the selected reset group.
 
 The optional parameter specifies what should
 happen after the reset.

--- a/src/target/riscv/opcodes.h
+++ b/src/target/riscv/opcodes.h
@@ -99,8 +99,17 @@ static uint32_t jal(unsigned int rd, int32_t imm)
 	return imm_j((uint32_t)imm) | inst_rd(rd) | MATCH_JAL;
 }
 
-static uint32_t csrsi(unsigned int csr, uint8_t imm) __attribute__ ((unused));
-static uint32_t csrsi(unsigned int csr, uint8_t imm)
+static uint32_t csrci(unsigned int csr, uint16_t imm) __attribute__ ((unused));
+static uint32_t csrci(unsigned int csr, uint16_t imm)
+{
+	assert(csr <= MAX_CSR_NUM);
+	assert(imm <= MAX_UINT5);
+
+	return imm_i(csr) | inst_rs1(imm) | MATCH_CSRRCI;
+}
+
+static uint32_t csrsi(unsigned int csr, uint16_t imm) __attribute__ ((unused));
+static uint32_t csrsi(unsigned int csr, uint16_t imm)
 {
 	assert(csr <= MAX_CSR_NUM);
 	assert(imm <= MAX_UINT5);
@@ -214,6 +223,16 @@ static uint32_t csrr(unsigned int rd, unsigned int csr)
 	assert(csr <= MAX_CSR_NUM);
 
 	return imm_i(csr) | inst_rd(rd) | MATCH_CSRRS;
+}
+
+static uint32_t csrrc(unsigned int rd, unsigned int rs, unsigned int csr) __attribute__ ((unused));
+static uint32_t csrrc(unsigned int rd, unsigned int rs, unsigned int csr)
+{
+	assert(rd <= MAX_GPR_NUM);
+	assert(rs <= MAX_GPR_NUM);
+	assert(csr <= MAX_CSR_NUM);
+
+	return imm_i(csr) | inst_rs1(rs) | inst_rd(rd) | MATCH_CSRRC;
 }
 
 static uint32_t csrrs(unsigned int rd, unsigned int rs, unsigned int csr) __attribute__ ((unused));

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2150,19 +2150,19 @@ static int examine(struct target *target)
 	/* Don't call any riscv_* functions until after we've counted the number of
 	 * cores and initialized registers. */
 
-	enum riscv_hart_state state_at_examine_start;
-	if (riscv_get_hart_state(target, &state_at_examine_start) != ERROR_OK)
+	enum riscv_hart_state riscv_state_at_examine_start;
+	if (riscv_get_hart_state(target, &riscv_state_at_examine_start) != ERROR_OK)
 		return ERROR_FAIL;
 
 	/* Skip full examination and reporting of hart if it is currently unavailable */
-	const bool hart_unavailable_at_examine_start = state_at_examine_start == RISCV_STATE_UNAVAILABLE;
+	const bool hart_unavailable_at_examine_start = riscv_state_at_examine_start == RISCV_STATE_UNAVAILABLE;
 	if (hart_unavailable_at_examine_start) {
 		LOG_TARGET_DEBUG(target, "Did not fully examine hart %d as it was currently unavailable, deferring examine.", info->index);
 		target->state = TARGET_UNAVAILABLE;
 		target->defer_examine = true;
 		return ERROR_OK;
 	}
-	const bool hart_halted_at_examine_start = state_at_examine_start == RISCV_STATE_HALTED;
+	const bool hart_halted_at_examine_start = riscv_state_at_examine_start == RISCV_STATE_HALTED;
 	if (!hart_halted_at_examine_start) {
 		if (riscv013_halt_target(target) != ERROR_OK) {
 			LOG_TARGET_ERROR(target, "Fatal: Hart %d failed to halt during %s",
@@ -2192,11 +2192,11 @@ static int examine(struct target *target)
 	if (set_dcsr_ebreak(target, false) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (state_at_examine_start == RISCV_STATE_RUNNING) {
+	if (riscv_state_at_examine_start == RISCV_STATE_RUNNING) {
 		riscv013_step_or_resume_current_hart(target, false);
 		target->state = TARGET_RUNNING;
 		target->debug_reason = DBG_REASON_NOTHALTED;
-	} else if (state_at_examine_start == RISCV_STATE_HALTED) {
+	} else if (riscv_state_at_examine_start == RISCV_STATE_HALTED) {
 		target->state = TARGET_HALTED;
 		target->debug_reason = DBG_REASON_UNDEFINED;
 	}
@@ -2826,7 +2826,7 @@ static int sample_memory(struct target *target,
 	return sample_memory_bus_v1(target, buf, config, until_ms);
 }
 
-static int riscv013_get_hart_state(struct target *target, enum riscv_hart_state *state)
+static int riscv013_get_hart_state(struct target *target, enum riscv_hart_state *riscv_state)
 {
 	RISCV013_INFO(info);
 	if (dm013_select_target(target) != ERROR_OK)
@@ -2858,19 +2858,19 @@ static int riscv013_get_hart_state(struct target *target, enum riscv_hart_state 
 		dm_write(target, DM_DMCONTROL, dmcontrol);
 	}
 	if (get_field(dmstatus, DM_DMSTATUS_ALLNONEXISTENT)) {
-		*state = RISCV_STATE_NON_EXISTENT;
+		*riscv_state = RISCV_STATE_NON_EXISTENT;
 		return ERROR_OK;
 	}
 	if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
-		*state = RISCV_STATE_UNAVAILABLE;
+		*riscv_state = RISCV_STATE_UNAVAILABLE;
 		return ERROR_OK;
 	}
 	if (get_field(dmstatus, DM_DMSTATUS_ALLHALTED)) {
-		*state = RISCV_STATE_HALTED;
+		*riscv_state = RISCV_STATE_HALTED;
 		return ERROR_OK;
 	}
 	if (get_field(dmstatus, DM_DMSTATUS_ALLRUNNING)) {
-		*state = RISCV_STATE_RUNNING;
+		*riscv_state = RISCV_STATE_RUNNING;
 		return ERROR_OK;
 	}
 	LOG_TARGET_ERROR(target, "Couldn't determine state. dmstatus=0x%x", dmstatus);
@@ -2955,6 +2955,13 @@ static int init_target(struct command_context *cmd_ctx,
 	return ERROR_OK;
 }
 
+static uint32_t riscv013_dmcontrol_for_hart(struct target *target)
+{
+	RISCV013_INFO(info);
+
+	return set_dmcontrol_hartsel(DM_DMCONTROL_DMACTIVE, info->index);
+}
+
 static int assert_reset(struct target *target)
 {
 	RISCV013_INFO(info);
@@ -2970,8 +2977,7 @@ static int assert_reset(struct target *target)
 		if (!dm)
 			return ERROR_FAIL;
 
-		uint32_t control = set_field(0, DM_DMCONTROL_DMACTIVE, 1);
-		control = set_dmcontrol_hartsel(control, info->index);
+		uint32_t control = riscv013_dmcontrol_for_hart(target);
 		control = set_field(control, DM_DMCONTROL_HALTREQ,
 				target->reset_halt ? 1 : 0);
 		control = set_field(control, DM_DMCONTROL_NDMRESET, 1);
@@ -3006,6 +3012,101 @@ static bool dcsr_ebreak_config_equals_reset_value(const struct target *target)
 	return true;
 }
 
+enum riscv013_reset_wait_condition {
+	RISCV013_RESET_WAIT_LEAVE_RESET,
+	RISCV013_RESET_WAIT_HALT,
+};
+
+static const char *riscv013_reset_wait_action(
+		enum riscv013_reset_wait_condition condition)
+{
+	switch (condition) {
+	case RISCV013_RESET_WAIT_LEAVE_RESET:
+		return "come out of reset";
+	case RISCV013_RESET_WAIT_HALT:
+		return "halt";
+	}
+	assert(false);
+	return "complete reset operation";
+}
+
+static bool riscv013_reset_wait_done(enum riscv013_reset_wait_condition condition,
+		uint32_t dmstatus)
+{
+	switch (condition) {
+	case RISCV013_RESET_WAIT_LEAVE_RESET:
+		/* Certain debug modules, like the one in GD32VF103 MCUs,
+		 * violate the specification's requirement that each hart is in
+		 * "exactly one of four states" and, during reset, report harts
+		 * as both unavailable and halted/running. To work around this,
+		 * check for the absence of the unavailable state rather than
+		 * the presence of any other state. */
+		return !get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL) ||
+			get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET);
+	case RISCV013_RESET_WAIT_HALT:
+		return get_field(dmstatus, DM_DMSTATUS_ALLHALTED);
+	}
+	assert(false);
+	return true;
+}
+
+static void riscv013_log_reset_wait_timeout(struct target *target,
+		enum riscv013_reset_wait_condition condition, uint32_t dmstatus)
+{
+	switch (condition) {
+	case RISCV013_RESET_WAIT_LEAVE_RESET:
+		LOG_TARGET_ERROR(target, "Hart didn't leave reset in %ds; "
+				"dmstatus=0x%x (allunavail=%s, allhavereset=%s); "
+				"Increase the timeout with riscv set_command_timeout_sec.",
+				riscv_get_command_timeout_sec(), dmstatus,
+				get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL) ? "true" : "false",
+				get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET) ? "true" : "false");
+		break;
+	case RISCV013_RESET_WAIT_HALT:
+		LOG_TARGET_ERROR(target, "Hart didn't halt in %ds; "
+				"dmstatus=0x%x (allhalted=%s); "
+				"Increase the timeout with riscv set_command_timeout_sec.",
+				riscv_get_command_timeout_sec(), dmstatus,
+				get_field(dmstatus, DM_DMSTATUS_ALLHALTED) ? "true" : "false");
+		break;
+	}
+}
+
+static int riscv013_wait_for_reset_condition(struct target *target,
+		enum riscv013_reset_wait_condition condition, uint32_t *dmstatus)
+{
+	RISCV013_INFO(info);
+	const unsigned int orig_base_delay = riscv_scan_get_delay(&info->learned_delays,
+			RISCV_DELAY_BASE);
+	time_t start = time(NULL);
+	int result = ERROR_OK;
+	bool wait_done = false;
+
+	LOG_TARGET_DEBUG(target, "Waiting for hart to %s.",
+			riscv013_reset_wait_action(condition));
+
+	do {
+		result = dmstatus_read(target, dmstatus, true);
+		if (result != ERROR_OK)
+			break;
+
+		if (time(NULL) - start > riscv_get_command_timeout_sec()) {
+			riscv013_log_reset_wait_timeout(target, condition, *dmstatus);
+			result = ERROR_TIMEOUT_REACHED;
+			break;
+		}
+
+		wait_done = riscv013_reset_wait_done(condition, *dmstatus);
+		if (!wait_done)
+			usleep(10);
+	} while (!wait_done);
+
+	riscv_scan_set_delay(&info->learned_delays, RISCV_DELAY_BASE,
+			orig_base_delay);
+
+	return result;
+}
+
 static int deassert_reset(struct target *target)
 {
 	RISCV013_INFO(info);
@@ -3016,10 +3117,8 @@ static int deassert_reset(struct target *target)
 
 	select_dmi(target->tap);
 	/* Clear the reset, but make sure haltreq is still set */
-	uint32_t control = 0;
-	control = set_field(control, DM_DMCONTROL_DMACTIVE, 1);
+	uint32_t control = riscv013_dmcontrol_for_hart(target);
 	control = set_field(control, DM_DMCONTROL_HALTREQ, target->reset_halt ? 1 : 0);
-	control = set_dmcontrol_hartsel(control, info->index);
 	/* If `abstractcs.busy` is set, debugger should not
 	 * change `hartsel`.
 	 */
@@ -3034,42 +3133,23 @@ static int deassert_reset(struct target *target)
 		return result;
 
 	uint32_t dmstatus;
-	const unsigned int orig_base_delay = riscv_scan_get_delay(&info->learned_delays,
-			RISCV_DELAY_BASE);
-	time_t start = time(NULL);
-	LOG_TARGET_DEBUG(target, "Waiting for hart to come out of reset.");
-	do {
-		result = dmstatus_read(target, &dmstatus, true);
+	result = riscv013_wait_for_reset_condition(target,
+			RISCV013_RESET_WAIT_LEAVE_RESET, &dmstatus);
+	if (result != ERROR_OK)
+		return result;
+
+	/* If reset-halt was requested and hart is not unavailable,
+	 * wait for the hart to actually halt. */
+	if (target->reset_halt && !get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
+		result = riscv013_wait_for_reset_condition(target,
+				RISCV013_RESET_WAIT_HALT, &dmstatus);
 		if (result != ERROR_OK)
 			return result;
-
-		if (time(NULL) - start > riscv_get_command_timeout_sec()) {
-			LOG_TARGET_ERROR(target, "Hart didn't leave reset in %ds; "
-					"dmstatus=0x%x (allunavail=%s, allhavereset=%s); "
-					"Increase the timeout with riscv set_command_timeout_sec.",
-					riscv_get_command_timeout_sec(), dmstatus,
-					get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL) ? "true" : "false",
-					get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET) ? "true" : "false");
-			return ERROR_TIMEOUT_REACHED;
-		}
-		/* Certain debug modules, like the one in GD32VF103
-		 * MCUs, violate the specification's requirement that
-		 * each hart is in "exactly one of four states" and,
-		 * during reset, report harts as both unavailable and
-		 * halted/running. To work around this, we check for
-		 * the absence of the unavailable state rather than
-		 * the presence of any other state. */
-	} while (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL) &&
-			!get_field(dmstatus, DM_DMSTATUS_ALLHAVERESET));
-
-	riscv_scan_set_delay(&info->learned_delays, RISCV_DELAY_BASE,
-			orig_base_delay);
+	}
 
 	/* Ack reset and clear DM_DMCONTROL_HALTREQ if previously set */
-	control = 0;
-	control = set_field(control, DM_DMCONTROL_DMACTIVE, 1);
+	control = riscv013_dmcontrol_for_hart(target);
 	control = set_field(control, DM_DMCONTROL_ACKHAVERESET, 1);
-	control = set_dmcontrol_hartsel(control, info->index);
 	result = dm_write(target, DM_DMCONTROL, control);
 	if (result != ERROR_OK)
 		return result;
@@ -5321,6 +5401,9 @@ static int riscv013_halt_target(struct target *target)
 
 static int riscv013_resume_go(struct target *target)
 {
+	RISCV_INFO(r);
+
+	r->prepped = false;
 	return riscv013_step_or_resume_current_hart(target, false);
 }
 

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -18,6 +18,7 @@
 #include "target/algorithm.h"
 #include "target/target_type.h"
 #include <helper/align.h>
+#include <target/smp.h>
 #include <helper/log.h>
 #include "jtag/jtag.h"
 #include "target/register.h"
@@ -35,7 +36,7 @@
 #include "debug_reg_printer.h"
 #include "field_helpers.h"
 
-static int riscv013_on_step_or_resume(struct target *target, bool step);
+static int riscv013_on_step_or_resume(struct target *target, bool skip, bool step);
 static int riscv013_step_or_resume_current_hart(struct target *target,
 		bool step);
 static int riscv013_clear_abstract_error(struct target *target);
@@ -44,6 +45,7 @@ static int riscv013_clear_abstract_error(struct target *target);
 static int dm013_select_hart(struct target *target, int hart_index);
 static int riscv013_halt_prep(struct target *target);
 static int riscv013_halt_go(struct target *target);
+static int riscv013_halt_target(struct target *target);
 static int riscv013_resume_go(struct target *target);
 static int riscv013_step_current_hart(struct target *target);
 static int riscv013_on_step(struct target *target);
@@ -241,6 +243,7 @@ typedef struct {
 	uint8_t datasize;
 	uint8_t dataaccess;
 	int16_t dataaddr;
+	uint8_t nscratch;
 
 	/* The width of the hartsel field. */
 	unsigned int hartsellen;
@@ -1688,29 +1691,68 @@ static int set_dcsr_ebreak(struct target *target, bool step)
 		return ERROR_FAIL;
 
 	RISCV013_INFO(info);
-	riscv_reg_t original_dcsr, dcsr;
-	/* We want to twiddle some bits in the debug CSR so debugging works. */
-	if (riscv_reg_get(target, &dcsr, GDB_REGNO_DCSR) != ERROR_OK)
-		return ERROR_FAIL;
-	original_dcsr = dcsr;
-	dcsr = set_field(dcsr, CSR_DCSR_STEP, step);
 	const struct riscv_private_config * const config = riscv_private_config(target);
-	dcsr = set_field(dcsr, CSR_DCSR_EBREAKM, config->dcsr_ebreak_fields[RISCV_MODE_M]);
-	dcsr = set_field(dcsr, CSR_DCSR_EBREAKS, config->dcsr_ebreak_fields[RISCV_MODE_S]);
-	dcsr = set_field(dcsr, CSR_DCSR_EBREAKU, config->dcsr_ebreak_fields[RISCV_MODE_U]);
-	dcsr = set_field(dcsr, CSR_DCSR_EBREAKVS, config->dcsr_ebreak_fields[RISCV_MODE_VS]);
-	dcsr = set_field(dcsr, CSR_DCSR_EBREAKVU, config->dcsr_ebreak_fields[RISCV_MODE_VU]);
-	if (dcsr != original_dcsr &&
-			riscv_reg_set(target, GDB_REGNO_DCSR, dcsr) != ERROR_OK)
-		return ERROR_FAIL;
+	if (info->nscratch >= 1 && has_sufficient_progbuf(target, 8)) {
+		uint32_t set_ebreak_bits = 0;
+		uint32_t clear_ebreak_bits = 0;
+
+		if (config->dcsr_ebreak_fields[RISCV_MODE_M])
+			set_ebreak_bits |= CSR_DCSR_EBREAKM;
+		else
+			clear_ebreak_bits |= CSR_DCSR_EBREAKM;
+		if (config->dcsr_ebreak_fields[RISCV_MODE_S])
+			set_ebreak_bits |= CSR_DCSR_EBREAKS;
+		else
+			clear_ebreak_bits |= CSR_DCSR_EBREAKS;
+		if (config->dcsr_ebreak_fields[RISCV_MODE_U])
+			set_ebreak_bits |= CSR_DCSR_EBREAKU;
+		else
+			clear_ebreak_bits |= CSR_DCSR_EBREAKU;
+		if (config->dcsr_ebreak_fields[RISCV_MODE_VS])
+			set_ebreak_bits |= CSR_DCSR_EBREAKVS;
+		else
+			clear_ebreak_bits |= CSR_DCSR_EBREAKVS;
+		if (config->dcsr_ebreak_fields[RISCV_MODE_VU])
+			set_ebreak_bits |= CSR_DCSR_EBREAKVU;
+		else
+			clear_ebreak_bits |= CSR_DCSR_EBREAKVU;
+
+		struct riscv_program program;
+		riscv_program_init(&program, target);
+		riscv_program_insert(&program, csrw(S0, CSR_DSCRATCH0));
+		riscv_program_insert(&program, lui(S0, set_ebreak_bits));
+		riscv_program_insert(&program, csrrs(ZERO, S0, CSR_DCSR));
+		riscv_program_insert(&program, lui(S0, clear_ebreak_bits));
+		riscv_program_insert(&program, csrrc(ZERO, S0, CSR_DCSR));
+		if (step)
+			riscv_program_insert(&program, csrsi(CSR_DCSR, 0x4));
+		else
+			riscv_program_insert(&program, csrci(CSR_DCSR, 0x4));
+		riscv_program_insert(&program, csrr(S0, CSR_DSCRATCH0));
+		if (riscv_program_exec(&program, target) != ERROR_OK)
+			return ERROR_FAIL;
+	} else {
+		riscv_reg_t original_dcsr, dcsr;
+		/* We want to twiddle some bits in the debug CSR so debugging works. */
+		if (riscv_reg_get(target, &dcsr, GDB_REGNO_DCSR) != ERROR_OK)
+			return ERROR_FAIL;
+		original_dcsr = dcsr;
+		dcsr = set_field(dcsr, CSR_DCSR_STEP, step);
+		dcsr = set_field(dcsr, CSR_DCSR_EBREAKM, config->dcsr_ebreak_fields[RISCV_MODE_M]);
+		dcsr = set_field(dcsr, CSR_DCSR_EBREAKS, config->dcsr_ebreak_fields[RISCV_MODE_S]);
+		dcsr = set_field(dcsr, CSR_DCSR_EBREAKU, config->dcsr_ebreak_fields[RISCV_MODE_U]);
+		dcsr = set_field(dcsr, CSR_DCSR_EBREAKVS, config->dcsr_ebreak_fields[RISCV_MODE_VS]);
+		dcsr = set_field(dcsr, CSR_DCSR_EBREAKVU, config->dcsr_ebreak_fields[RISCV_MODE_VU]);
+		if (dcsr != original_dcsr &&
+				riscv_reg_set(target, GDB_REGNO_DCSR, dcsr) != ERROR_OK)
+			return ERROR_FAIL;
+	}
 	info->dcsr_ebreak_is_set = true;
 	return ERROR_OK;
 }
 
 static int halt_set_dcsr_ebreak(struct target *target)
 {
-	RISCV_INFO(r);
-	RISCV013_INFO(info);
 	LOG_TARGET_DEBUG(target, "Halt to set DCSR.ebreak*");
 
 	/* Remove this hart from the halt group.  This won't work on all targets
@@ -1736,36 +1778,37 @@ static int halt_set_dcsr_ebreak(struct target *target)
 	 */
 
 
-	if (info->haltgroup_supported) {
-		bool supported;
-		if (set_group(target, &supported, 0, HALT_GROUP) != ERROR_OK)
-			return ERROR_FAIL;
-		if (!supported)
-			LOG_TARGET_ERROR(target, "Couldn't place hart in halt group 0. "
-						 "Some harts may be unexpectedly halted.");
+	struct target_list *entry;
+	struct list_head *targets;
+
+	if (target->smp) {
+		targets = target->smp_targets;
+		foreach_smp_target(entry, targets) {
+			struct target *t = entry->target;
+			if (riscv013_halt_prep(t) != ERROR_OK)
+				return ERROR_FAIL;
+		}
 	}
 
 	int result = ERROR_OK;
+	int halt_result = ERROR_OK;
+	int resume_result = ERROR_OK;
 
-	r->prepped = true;
-	if (riscv013_halt_go(target) != ERROR_OK ||
-			set_dcsr_ebreak(target, false) != ERROR_OK ||
-			riscv013_step_or_resume_current_hart(target, false) != ERROR_OK) {
+	halt_result = riscv013_halt_go(target);
+	if (halt_result == ERROR_OK)
+		if (riscv013_on_step_or_resume(target, true, false) == ERROR_OK) {
+			resume_result = riscv013_step_or_resume_current_hart(target, false);
+			if (resume_result == ERROR_OK) {
+				target->state = TARGET_RUNNING;
+				target->debug_reason = DBG_REASON_NOTHALTED;
+			} else if (resume_result == ERROR_TARGET_RESOURCE_NOT_AVAILABLE)
+				target->state = TARGET_UNAVAILABLE;
+			else
+				result = ERROR_FAIL;
+		} else
+			result = ERROR_FAIL;
+	else if (halt_result != ERROR_TARGET_RESOURCE_NOT_AVAILABLE)
 		result = ERROR_FAIL;
-	} else {
-		target->state = TARGET_RUNNING;
-		target->debug_reason = DBG_REASON_NOTHALTED;
-	}
-
-	/* Add it back to the halt group. */
-	if (info->haltgroup_supported) {
-		bool supported;
-		if (set_group(target, &supported, target->smp, HALT_GROUP) != ERROR_OK)
-			return ERROR_FAIL;
-		if (!supported)
-			LOG_TARGET_ERROR(target, "Couldn't place hart back in halt group %d. "
-						 "Some harts may be unexpectedly halted.", target->smp);
-	}
 
 	return result;
 }
@@ -2083,6 +2126,7 @@ static int examine(struct target *target)
 	info->datasize = get_field(hartinfo, DM_HARTINFO_DATASIZE);
 	info->dataaccess = get_field(hartinfo, DM_HARTINFO_DATAACCESS);
 	info->dataaddr = get_field(hartinfo, DM_HARTINFO_DATAADDR);
+	info->nscratch = get_field(hartinfo, DM_HARTINFO_NSCRATCH);
 
 	if (!get_field(dmstatus, DM_DMSTATUS_AUTHENTICATED)) {
 		LOG_TARGET_ERROR(target, "Debugger is not authenticated to target Debug Module. "
@@ -2101,17 +2145,7 @@ static int examine(struct target *target)
 	info->datacount = get_field(abstractcs, DM_ABSTRACTCS_DATACOUNT);
 	info->progbufsize = get_field(abstractcs, DM_ABSTRACTCS_PROGBUFSIZE);
 
-	LOG_TARGET_INFO(target, "datacount=%d progbufsize=%d",
-			info->datacount, info->progbufsize);
-
 	info->impebreak = get_field(dmstatus, DM_DMSTATUS_IMPEBREAK);
-
-	if (!has_sufficient_progbuf(target, 2)) {
-		LOG_TARGET_WARNING(target, "We won't be able to execute fence instructions on this "
-				"target. Memory may not always appear consistent. "
-				"(progbufsize=%d, impebreak=%d)", info->progbufsize,
-				info->impebreak);
-	}
 
 	/* Don't call any riscv_* functions until after we've counted the number of
 	 * cores and initialized registers. */
@@ -2120,16 +2154,33 @@ static int examine(struct target *target)
 	if (riscv_get_hart_state(target, &state_at_examine_start) != ERROR_OK)
 		return ERROR_FAIL;
 
-	RISCV_INFO(r);
+	/* Skip full examination and reporting of hart if it is currently unavailable */
+	const bool hart_unavailable_at_examine_start = state_at_examine_start == RISCV_STATE_UNAVAILABLE;
+	if (hart_unavailable_at_examine_start) {
+		LOG_TARGET_DEBUG(target, "Did not fully examine hart %d as it was currently unavailable, deferring examine.", info->index);
+		target->state = TARGET_UNAVAILABLE;
+		target->defer_examine = true;
+		return ERROR_OK;
+	}
 	const bool hart_halted_at_examine_start = state_at_examine_start == RISCV_STATE_HALTED;
 	if (!hart_halted_at_examine_start) {
-		r->prepped = true;
-		if (riscv013_halt_go(target) != ERROR_OK) {
+		if (riscv013_halt_target(target) != ERROR_OK) {
 			LOG_TARGET_ERROR(target, "Fatal: Hart %d failed to halt during %s",
 					info->index, __func__);
 			return ERROR_FAIL;
 		}
 	}
+
+	LOG_TARGET_INFO(target, "datacount=%d progbufsize=%d",
+			info->datacount, info->progbufsize);
+
+	if (!has_sufficient_progbuf(target, 2)) {
+		LOG_TARGET_WARNING(target, "We won't be able to execute fence instructions on this "
+				"target. Memory may not always appear consistent. "
+				"(progbufsize=%d, impebreak=%d)", info->progbufsize,
+				info->impebreak);
+	}
+
 
 	target->state = TARGET_HALTED;
 	target->debug_reason = hart_halted_at_examine_start ? DBG_REASON_UNDEFINED : DBG_REASON_DBGRQ;
@@ -2164,6 +2215,7 @@ static int examine(struct target *target)
 	/* Some regression suites rely on seeing 'Examined RISC-V core' to know
 	 * when they can connect with gdb/telnet.
 	 * We will need to update those suites if we want to change that text. */
+	RISCV_INFO(r);
 	LOG_TARGET_INFO(target, "Examined RISC-V core");
 	LOG_TARGET_INFO(target, " XLEN=%d, misa=0x%" PRIx64, r->xlen, r->misa);
 	return ERROR_OK;
@@ -2784,7 +2836,7 @@ static int riscv013_get_hart_state(struct target *target, enum riscv_hart_state 
 	if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 		return ERROR_FAIL;
 	if (get_field(dmstatus, DM_DMSTATUS_ANYHAVERESET)) {
-		LOG_TARGET_INFO(target, "Hart unexpectedly reset!");
+		LOG_TARGET_DEBUG(target, "Hart unexpectedly reset!");
 		info->dcsr_ebreak_is_set = false;
 		/* TODO: Can we make this more obvious to eg. a gdb user? */
 		uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE |
@@ -3022,7 +3074,9 @@ static int deassert_reset(struct target *target)
 	if (result != ERROR_OK)
 		return result;
 
-	if (target->reset_halt) {
+	if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
+		target->state = TARGET_UNAVAILABLE;
+	} else if (target->reset_halt) {
 		target->state = TARGET_HALTED;
 		target->debug_reason = DBG_REASON_DBGRQ;
 	} else {
@@ -5164,94 +5218,67 @@ static int dm013_select_hart(struct target *target, int hart_index)
 	return ERROR_OK;
 }
 
-/* Select all harts that were prepped and that are selectable, clearing the
- * prepped flag on the harts that actually were selected. */
-static int select_prepped_harts(struct target *target)
-{
-	RISCV_INFO(r);
-	dm013_info_t *dm = get_dm(target);
-	if (!dm)
-		return ERROR_FAIL;
-	if (!dm->hasel_supported) {
-		r->prepped = false;
-		return dm013_select_target(target);
-	}
-
-	assert(dm->hart_count);
-	unsigned int hawindow_count = (dm->hart_count + 31) / 32;
-	uint32_t *hawindow = calloc(hawindow_count, sizeof(uint32_t));
-	if (!hawindow)
-		return ERROR_FAIL;
-
-	target_list_t *entry;
-	unsigned int total_selected = 0;
-	unsigned int selected_index = 0;
-	list_for_each_entry(entry, &dm->target_list, list) {
-		struct target *t = entry->target;
-		struct riscv_info *info = riscv_info(t);
-		riscv013_info_t *info_013 = get_info(t);
-		unsigned int index = info_013->index;
-		LOG_TARGET_DEBUG(target, "index=%d, prepped=%d", index, info->prepped);
-		if (info->prepped) {
-			info_013->selected = true;
-			hawindow[index / 32] |= 1 << (index % 32);
-			info->prepped = false;
-			total_selected++;
-			selected_index = index;
-		}
-	}
-
-	if (total_selected == 0) {
-		LOG_TARGET_ERROR(target, "No harts were prepped!");
-		free(hawindow);
-		return ERROR_FAIL;
-	} else if (total_selected == 1) {
-		/* Don't use hasel if we only need to talk to one hart. */
-		free(hawindow);
-		return dm013_select_hart(target, selected_index);
-	}
-
-	if (dm013_select_hart(target, HART_INDEX_MULTIPLE) != ERROR_OK) {
-		free(hawindow);
-		return ERROR_FAIL;
-	}
-
-	for (unsigned int i = 0; i < hawindow_count; i++) {
-		if (dm_write(target, DM_HAWINDOWSEL, i) != ERROR_OK) {
-			free(hawindow);
-			return ERROR_FAIL;
-		}
-		if (dm_write(target, DM_HAWINDOW, hawindow[i]) != ERROR_OK) {
-			free(hawindow);
-			return ERROR_FAIL;
-		}
-	}
-
-	free(hawindow);
-	return ERROR_OK;
-}
-
 static int riscv013_halt_prep(struct target *target)
 {
+	LOG_TARGET_DEBUG(target, "grouping hart");
+
+	if (target->smp) {
+		/* Let's make sure that all non-halted harts are in the same halt group */
+		riscv013_info_t *info = get_info(target);
+		if (info->haltgroup_supported) {
+			if (dm013_select_target(target) != ERROR_OK)
+				return ERROR_FAIL;
+			bool supported;
+			if (set_group(target, &supported, target->smp, HALT_GROUP) != ERROR_OK)
+				return ERROR_FAIL;
+			if (!supported)
+				LOG_TARGET_ERROR(target, "Couldn't place hart %d in halt group %d. "
+							 "Some harts may be unexpectedly halted.", target->coreid, target->smp);
+		}
+	}
+
 	return ERROR_OK;
 }
 
 static int riscv013_halt_go(struct target *target)
 {
-	dm013_info_t *dm = get_dm(target);
-	if (!dm)
-		return ERROR_FAIL;
-
-	if (select_prepped_harts(target) != ERROR_OK)
-		return ERROR_FAIL;
-
 	LOG_TARGET_DEBUG(target, "halting hart");
+
+	if (dm013_select_target(target) != ERROR_OK) {
+		return ERROR_FAIL;
+	}
+	if (target->smp) {
+		/* Let's make sure that harts we want to halt are placed in another group */
+		riscv013_info_t *info = get_info(target);
+		if (info->haltgroup_supported) {
+			bool supported;
+			if (set_group(target, &supported, 0, HALT_GROUP) != ERROR_OK)
+				return ERROR_FAIL;
+			if (!supported)
+				LOG_TARGET_ERROR(target, "Couldn't place hart in halt group 0. "
+							 "Some harts may be unexpectedly halted.");
+		}
+	}
+
+	int result = riscv013_halt_target(target);
+	if (result == ERROR_TARGET_RESOURCE_NOT_AVAILABLE)
+		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+	else if (result != ERROR_OK)
+		return ERROR_FAIL;
+
+	return ERROR_OK;
+}
+
+static int riscv013_halt_target(struct target *target)
+{
+	LOG_TARGET_DEBUG(target, "halting one hart");
 
 	/* `haltreq` should not be issued if `abstractcs.busy` is set. */
 	int result = wait_for_idle_if_needed(target);
 	if (result != ERROR_OK)
 		return result;
 
+	dm013_info_t *dm = get_dm(target);
 	/* Issue the halt command, and then wait for the current hart to halt. */
 	uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE | DM_DMCONTROL_HALTREQ;
 	dmcontrol = set_dmcontrol_hartsel(dmcontrol, dm->current_hartid);
@@ -5260,13 +5287,12 @@ static int riscv013_halt_go(struct target *target)
 	for (size_t i = 0; i < 256; ++i) {
 		if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 			return ERROR_FAIL;
-		/* When no harts are running, there's no point in continuing this loop. */
+		/* When hart is not running, there's no point in continuing this loop. */
 		if (!get_field(dmstatus, DM_DMSTATUS_ANYRUNNING))
 			break;
 	}
 
-	/* We declare success if no harts are running. One or more of them may be
-	 * unavailable, though. */
+	/* We declare success if hart is not running. It may be unavailable, though. */
 
 	if ((get_field(dmstatus, DM_DMSTATUS_ANYRUNNING))) {
 		if (dm_read(target, &dmcontrol, DM_DMCONTROL) != ERROR_OK)
@@ -5280,44 +5306,14 @@ static int riscv013_halt_go(struct target *target)
 	dmcontrol = set_field(dmcontrol, DM_DMCONTROL_HALTREQ, 0);
 	dm_write(target, DM_DMCONTROL, dmcontrol);
 
-	if (dm->current_hartid == HART_INDEX_MULTIPLE) {
-		target_list_t *entry;
-		list_for_each_entry(entry, &dm->target_list, list) {
-			struct target *t = entry->target;
-			uint32_t t_dmstatus;
-			if (get_field(dmstatus, DM_DMSTATUS_ALLHALTED) ||
-					get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
-				/* All harts are either halted or unavailable. No
-				 * need to read dmstatus for each hart. */
-				t_dmstatus = dmstatus;
-			} else {
-				/* Only some harts were halted/unavailable. Read
-				 * dmstatus for this one to see what its status
-				 * is. */
-				if (dm013_select_target(target) != ERROR_OK)
-					return ERROR_FAIL;
-				if (dm_read(target, &t_dmstatus, DM_DMSTATUS) != ERROR_OK)
-					return ERROR_FAIL;
-			}
-			/* Set state for the current target based on its dmstatus. */
-			if (get_field(t_dmstatus, DM_DMSTATUS_ALLHALTED)) {
-				t->state = TARGET_HALTED;
-				if (t->debug_reason == DBG_REASON_NOTHALTED)
-					t->debug_reason = DBG_REASON_DBGRQ;
-			} else if (get_field(t_dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
-				t->state = TARGET_UNAVAILABLE;
-			}
-		}
-
-	} else {
-		/* Set state for the current target based on its dmstatus. */
-		if (get_field(dmstatus, DM_DMSTATUS_ALLHALTED)) {
-			target->state = TARGET_HALTED;
-			if (target->debug_reason == DBG_REASON_NOTHALTED)
-				target->debug_reason = DBG_REASON_DBGRQ;
-		} else if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
-			target->state = TARGET_UNAVAILABLE;
-		}
+	/* Set state for the current target based on its dmstatus. */
+	if (get_field(dmstatus, DM_DMSTATUS_ALLHALTED)) {
+		target->state = TARGET_HALTED;
+		if (target->debug_reason == DBG_REASON_NOTHALTED)
+			target->debug_reason = DBG_REASON_DBGRQ;
+	} else if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
+		target->state = TARGET_UNAVAILABLE;
+		return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
 	}
 
 	return ERROR_OK;
@@ -5325,9 +5321,6 @@ static int riscv013_halt_go(struct target *target)
 
 static int riscv013_resume_go(struct target *target)
 {
-	if (select_prepped_harts(target) != ERROR_OK)
-		return ERROR_FAIL;
-
 	return riscv013_step_or_resume_current_hart(target, false);
 }
 
@@ -5339,12 +5332,12 @@ static int riscv013_step_current_hart(struct target *target)
 static int riscv013_resume_prep(struct target *target)
 {
 	assert(target->state == TARGET_HALTED);
-	return riscv013_on_step_or_resume(target, false);
+	return riscv013_on_step_or_resume(target, false, false);
 }
 
 static int riscv013_on_step(struct target *target)
 {
-	return riscv013_on_step_or_resume(target, true);
+	return riscv013_on_step_or_resume(target, false, true);
 }
 
 static enum riscv_halt_reason riscv013_halt_reason(struct target *target)
@@ -5462,9 +5455,9 @@ static unsigned int riscv013_get_dmi_address_bits(const struct target *target)
 }
 
 /* Helper Functions. */
-static int riscv013_on_step_or_resume(struct target *target, bool step)
+static int riscv013_on_step_or_resume(struct target *target, bool skip, bool step)
 {
-	if (has_sufficient_progbuf(target, 2))
+	if (!skip && has_sufficient_progbuf(target, 2))
 		if (execute_autofence(target) != ERROR_OK)
 			return ERROR_FAIL;
 
@@ -5492,6 +5485,10 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 
 	riscv_reg_cache_invalidate_all(target);
 
+	if (dm013_select_target(target) != ERROR_OK)
+		return ERROR_FAIL;
+
+
 	dm013_info_t *dm = get_dm(target);
 	/* Issue the resume command, and then wait for the current hart to resume. */
 	uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE | DM_DMCONTROL_RESUMEREQ;
@@ -5509,14 +5506,32 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 		usleep(10);
 		if (dmstatus_read(target, &dmstatus, true) != ERROR_OK)
 			return ERROR_FAIL;
-		if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL))
-			return ERROR_FAIL;
+		if (get_field(dmstatus, DM_DMSTATUS_ALLUNAVAIL)) {
+			target->state = TARGET_UNAVAILABLE;
+			return ERROR_TARGET_RESOURCE_NOT_AVAILABLE;
+		}
+		if (get_field(dmstatus, DM_DMSTATUS_ANYHAVERESET))
+			dmcontrol = dmcontrol | DM_DMCONTROL_ACKHAVERESET;
 		if (get_field(dmstatus, DM_DMSTATUS_ALLRESUMEACK) == 0)
 			continue;
 		if (step && get_field(dmstatus, DM_DMSTATUS_ALLHALTED) == 0)
 			continue;
 
 		dm_write(target, DM_DMCONTROL, dmcontrol);
+
+		if (target->smp) {
+			/* Let's make sure that this hart is placed back with all non-halted harts */
+			riscv013_info_t *info = get_info(target);
+			if (info->haltgroup_supported) {
+				bool supported;
+				if (set_group(target, &supported, target->smp, HALT_GROUP) != ERROR_OK)
+					return ERROR_FAIL;
+				if (!supported)
+					LOG_TARGET_ERROR(target, "Couldn't place hart back in halt group %d. "
+								 "Some harts may be unexpectedly halted.", target->smp);
+			}
+		}
+
 		return ERROR_OK;
 	}
 

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -2658,10 +2658,10 @@ static int riscv_halt_go_all_harts(struct target *target)
 {
 	RISCV_INFO(r);
 
-	enum riscv_hart_state state;
-	if (riscv_get_hart_state(target, &state) != ERROR_OK)
+	enum riscv_hart_state riscv_state;
+	if (riscv_get_hart_state(target, &riscv_state) != ERROR_OK)
 		return ERROR_FAIL;
-	if (state == RISCV_STATE_HALTED) {
+	if (riscv_state == RISCV_STATE_HALTED) {
 		LOG_TARGET_DEBUG(target, "Hart is already halted.");
 		if (target->state != TARGET_HALTED) {
 			target->state = TARGET_HALTED;
@@ -2953,7 +2953,9 @@ static int riscv_resume(
 	struct target_list *tlist;
 	foreach_smp_target_direction(resume_order == RO_NORMAL, tlist, targets) {
 		struct target *t = tlist->target;
+		struct riscv_info *i = riscv_info(t);
 		LOG_TARGET_DEBUG(t, "target->state=%s", target_state_name(t));
+		i->prepped = false;
 		if (t->state != TARGET_HALTED)
 			LOG_TARGET_DEBUG(t, "skipping this target: target not halted");
 		else if (resume_prep(t, current, address, handle_breakpoints,
@@ -3875,24 +3877,24 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 
 	/* If OpenOCD thinks we're running but this hart is halted then it's time
 	 * to raise an event. */
-	enum riscv_hart_state state;
-	if (riscv_get_hart_state(target, &state) != ERROR_OK)
+	enum riscv_hart_state riscv_state;
+	if (riscv_get_hart_state(target, &riscv_state) != ERROR_OK)
 		return ERROR_FAIL;
 
-	if (state == RISCV_STATE_NON_EXISTENT) {
+	if (riscv_state == RISCV_STATE_NON_EXISTENT) {
 		LOG_TARGET_ERROR(target, "Hart is non-existent!");
 		return ERROR_FAIL;
 	}
 
-	if (state == RISCV_STATE_HALTED && timeval_ms() - r->last_activity > 100) {
+	if (riscv_state == RISCV_STATE_HALTED && timeval_ms() - r->last_activity > 100) {
 		/* If we've been idle for a while, flush the register cache. Just in case
 		 * OpenOCD is going to be disconnected without shutting down cleanly. */
 		if (riscv_reg_flush_all(target) != ERROR_OK)
 			return ERROR_FAIL;
 	}
 
-	if (target->state == TARGET_UNKNOWN || state != previous_riscv_state) {
-		switch (state) {
+	if (target->state == TARGET_UNKNOWN || riscv_state != previous_riscv_state) {
+		switch (riscv_state) {
 			case RISCV_STATE_HALTED:
 				if (previous_riscv_state == RISCV_STATE_UNAVAILABLE)
 					LOG_TARGET_INFO(target, "became available (halted)");
@@ -6079,11 +6081,11 @@ unsigned int riscv_vlenb(const struct target *target)
 	return r->vlenb;
 }
 
-int riscv_get_hart_state(struct target *target, enum riscv_hart_state *state)
+int riscv_get_hart_state(struct target *target, enum riscv_hart_state *riscv_state)
 {
 	RISCV_INFO(r);
 	assert(r->get_hart_state);
-	return r->get_hart_state(target, state);
+	return r->get_hart_state(target, riscv_state);
 }
 
 static enum riscv_halt_reason riscv_halt_reason(struct target *target)

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -724,7 +724,9 @@ static void riscv_deinit_target(struct target *target)
 	if (!tt)
 		LOG_TARGET_ERROR(target, "Could not identify target type.");
 
-	if (riscv_reg_flush_all(target) != ERROR_OK)
+	/* Unexamined targets may still own per-target allocations, but they won't
+	 * have dirty register state to flush. */
+	if (target_was_examined(target) && riscv_reg_flush_all(target) != ERROR_OK)
 		LOG_TARGET_ERROR(target, "Failed to flush registers. Ignoring this error.");
 
 	if (tt && info && info->version_specific)
@@ -2718,28 +2720,31 @@ int riscv_halt(struct target *target)
 
 	LOG_TARGET_DEBUG(target, "halting all harts");
 
+	/* Only halt a hart if it has been examined (was available) */
 	int result = ERROR_OK;
 	if (target->smp) {
 		struct target_list *tlist;
 		foreach_smp_target(tlist, target->smp_targets) {
 			struct target *t = tlist->target;
-			if (halt_prep(t) != ERROR_OK)
-				result = ERROR_FAIL;
+			if (target_was_examined(t))
+				if (halt_prep(t) != ERROR_OK)
+					result = ERROR_FAIL;
 		}
 
 		foreach_smp_target(tlist, target->smp_targets) {
 			struct target *t = tlist->target;
 			struct riscv_info *i = riscv_info(t);
-			if (i->prepped) {
-				if (halt_go(t) != ERROR_OK)
-					result = ERROR_FAIL;
-			}
+			if (target_was_examined(t))
+				if (i->prepped)
+					if (halt_go(t) != ERROR_OK)
+						result = ERROR_FAIL;
 		}
 
 		foreach_smp_target(tlist, target->smp_targets) {
 			struct target *t = tlist->target;
-			if (halt_finish(t) != ERROR_OK)
-				return ERROR_FAIL;
+			if (target_was_examined(t))
+				if (halt_finish(t) != ERROR_OK)
+					return ERROR_FAIL;
 		}
 
 	} else {
@@ -3949,8 +3954,16 @@ static int riscv_poll_hart(struct target *target, enum riscv_next_action *next_a
 				break;
 
 			case RISCV_STATE_UNAVAILABLE:
-				LOG_TARGET_DEBUG(target, "  became unavailable");
-				LOG_TARGET_INFO(target, "became unavailable.");
+				if (previous_riscv_state == RISCV_STATE_HALTED) {
+					LOG_TARGET_DEBUG(target, "  became unavailable (halted)");
+					LOG_TARGET_INFO(target, "became unavailable (halted).");
+				} else if (previous_riscv_state == RISCV_STATE_RUNNING) {
+					LOG_TARGET_DEBUG(target, "  became unavailable (running)");
+					LOG_TARGET_INFO(target, "became unavailable (running).");
+				} else {
+					LOG_TARGET_DEBUG(target, "  became unavailable");
+					LOG_TARGET_INFO(target, "became unavailable.");
+				}
 				target->state = TARGET_UNAVAILABLE;
 				if (r->handle_became_unavailable &&
 						r->handle_became_unavailable(target, previous_riscv_state) != ERROR_OK)

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -246,7 +246,7 @@ struct riscv_info {
 	/* Helper functions that target the various RISC-V debug spec
 	 * implementations. */
 	int (*select_target)(struct target *target);
-	int (*get_hart_state)(struct target *target, enum riscv_hart_state *state);
+	int (*get_hart_state)(struct target *target, enum riscv_hart_state *riscv_state);
 	/* Resume this target, as well as every other prepped target that can be
 	 * resumed near-simultaneously. Clear the prepped flag on any target that
 	 * was resumed. */
@@ -470,7 +470,7 @@ unsigned int riscv_vlenb(const struct target *target);
 
 /* Checks the state of the current hart -- "is_halted" checks the actual
  * on-device register. */
-int riscv_get_hart_state(struct target *target, enum riscv_hart_state *state);
+int riscv_get_hart_state(struct target *target, enum riscv_hart_state *riscv_state);
 
 /* These helper functions let the generic program interface get target-specific
  * information. */

--- a/src/target/startup.tcl
+++ b/src/target/startup.tcl
@@ -28,8 +28,17 @@ proc ocd_process_reset { MODE } {
 	}
 }
 
+proc ocd_get_reset_targets { } {
+	set current [target current]
+	if { $current == "" } {
+		return {}
+	}
+
+	return [$current arp_reset_targets]
+}
+
 proc ocd_process_reset_inner { MODE } {
-	set targets [target names]
+	set targets [ocd_get_reset_targets]
 
 	# If this target must be halted...
 	switch $MODE {
@@ -45,8 +54,11 @@ proc ocd_process_reset_inner { MODE } {
 		}
 	}
 
+	# Reset only the current target's configured reset group.
+	# For SMP systems, this corresponds to the current SMP cluster.
+	#
 	# Target event handlers *might* change which TAPs are enabled
-	# or disabled, so we fire all of them.  But don't issue any
+	# or disabled, so we fire all of them. But don't issue any
 	# target "arp_*" commands, which may issue JTAG transactions,
 	# unless we know the underlying TAP is active.
 	#

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -696,7 +696,7 @@ int target_examine_one(struct target *target)
 	}
 
 	if (target->defer_examine) {
-		LOG_USER("[%s] Target currently unavailable for full examination.", target_name(target));
+		LOG_TARGET_DEBUG(target, "Currently unavailable for full examination");
 		target->defer_examine = defer_state;
 		target_reset_examined(target);
 	} else {

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -685,6 +685,7 @@ int target_examine_one(struct target *target)
 
 	target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_START);
 
+	bool defer_state = target->defer_examine;
 	int retval = target->type->examine(target);
 	if (retval != ERROR_OK) {
 		LOG_TARGET_ERROR(target, "Examination failed");
@@ -694,11 +695,17 @@ int target_examine_one(struct target *target)
 		return retval;
 	}
 
-	LOG_USER("[%s] Target successfully examined.", target_name(target));
-	target_set_examined(target);
+	if (target->defer_examine) {
+		LOG_USER("[%s] Target currently unavailable for full examination.", target_name(target));
+		target->defer_examine = defer_state;
+		target_reset_examined(target);
+	} else {
+		LOG_USER("[%s] Target successfully examined.", target_name(target));
+		target_set_examined(target);
+	}
 	target_call_event_callbacks(target, TARGET_EVENT_EXAMINE_END);
 
-	LOG_TARGET_INFO(target, "Examination succeed");
+	LOG_TARGET_DEBUG(target, "Examination succeeded");
 	return ERROR_OK;
 }
 
@@ -5283,13 +5290,19 @@ COMMAND_HANDLER(handle_target_examine)
 		return ERROR_OK;
 	}
 
+	bool defer_state = target->defer_examine;
 	int retval = target->type->examine(target);
 	if (retval != ERROR_OK) {
 		target_reset_examined(target);
 		return retval;
 	}
 
-	target_set_examined(target);
+	if (target->defer_examine) {
+		LOG_INFO("Unable to do full examination of %s", target_name(target));
+		target->defer_examine = defer_state;
+		target_reset_examined(target);
+	} else
+		target_set_examined(target);
 
 	return ERROR_OK;
 }

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -483,6 +483,21 @@ struct target *get_current_target_or_null(struct command_context *cmd_ctx)
 		: cmd_ctx->current_target;
 }
 
+static bool target_in_reset_group(const struct target *reset_target,
+		const struct target *candidate)
+{
+	if (list_empty(reset_target->smp_targets))
+		return reset_target == candidate;
+
+	struct target_list *group_target;
+	foreach_smp_target(group_target, reset_target->smp_targets) {
+		if (group_target->target == candidate)
+			return true;
+	}
+
+	return false;
+}
+
 int target_poll(struct target *target)
 {
 	int retval;
@@ -611,9 +626,11 @@ static int target_process_reset(struct command_invocation *cmd, enum target_rese
 		return ERROR_FAIL;
 	}
 
+	struct target *reset_target = get_current_target(cmd->ctx);
 	struct target *target;
 	for (target = all_targets; target; target = target->next)
-		target_call_reset_callbacks(target, reset_mode);
+		if (target_in_reset_group(reset_target, target))
+			target_call_reset_callbacks(target, reset_mode);
 
 	/* disable polling during reset to make reset event scripts
 	 * more predictable, i.e. dr/irscan & pathmove in events will
@@ -636,6 +653,9 @@ static int target_process_reset(struct command_invocation *cmd, enum target_rese
 	retval = target_call_timer_callbacks_now();
 
 	for (target = all_targets; target; target = target->next) {
+		if (!target_in_reset_group(reset_target, target))
+			continue;
+
 		target->type->check_reset(target);
 		target->running_alg = false;
 	}
@@ -3304,7 +3324,7 @@ COMMAND_HANDLER(handle_reset_command)
 		reset_mode = n->value;
 	}
 
-	/* reset *all* targets */
+	/* reset the current target's configured reset group */
 	return target_process_reset(CMD, reset_mode);
 }
 
@@ -5444,6 +5464,25 @@ COMMAND_HANDLER(handle_target_wait_state)
 	}
 	return ERROR_OK;
 }
+
+COMMAND_HANDLER(handle_target_reset_targets)
+{
+	if (CMD_ARGC != 0)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+
+	struct target *target = get_current_target(CMD_CTX);
+
+	if (list_empty(target->smp_targets)) {
+		command_print(CMD, "%s", target_name(target));
+		return ERROR_OK;
+	}
+
+	struct target_list *group_target;
+	foreach_smp_target(group_target, target->smp_targets)
+		command_print(CMD, "%s", target_name(group_target->target));
+
+	return ERROR_OK;
+}
 /* List for human, Events defined for this target.
  * scripts/programs should use 'name cget -event NAME'
  */
@@ -5692,6 +5731,13 @@ static const struct command_registration target_instance_command_handlers[] = {
 		.handler = handle_target_wait_state,
 		.help = "used internally for reset processing",
 		.usage = "statename timeoutmsecs",
+	},
+	{
+		.name = "arp_reset_targets",
+		.mode = COMMAND_EXEC,
+		.handler = handle_target_reset_targets,
+		.help = "used internally for reset processing",
+		.usage = "",
 	},
 	{
 		.name = "invoke-event",
@@ -6565,7 +6611,7 @@ static const struct command_registration target_exec_command_handlers[] = {
 		.handler = handle_reset_command,
 		.mode = COMMAND_EXEC,
 		.usage = "[run|halt|init]",
-		.help = "Reset all targets into the specified mode. "
+		.help = "Reset the current target's reset group into the specified mode. "
 			"Default reset mode is run, if not given.",
 	},
 	{


### PR DESCRIPTION
Teach the reset-halt path to tolerate harts that temporarily report
unavailable instead of treating them as hard reset failures. Mark
those harts unavailable, defer examination when they cannot be fully
examined, and make the Tcl reset flow skip unavailable or deferred
targets while it waits for halted state.

Keep unavailable state transitions consistent by invalidating register
state, avoiding register flushes on unexamined targets during deinit,
and preserving enough target state for harts to be examined again when
they return.

Update DCSR setup to use progbuf plus DSCRATCH when the debug module
provides scratch storage and enough program buffer space. This avoids
extra abstract register access while still falling back to the existing
direct register path on smaller implementations.

Co-developed-by: cgsfv <cgsfv@users.noreply.github.com>
Signed-off-by: Jerry Zhang Jian <jerry.zhangjian@sifive.com>